### PR TITLE
Feature/countmodules, fixes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Content-Type: application/json
 ```javascript
 [
     {
-        "id": Integer,        // ID of discipline
-        "title": String,      // title of discipline
-        "description": String // description of discipline 
-        "icon": String        // URL to image
+        "id": Integer,                  // ID of discipline
+        "title": String,                // title of discipline
+        "description": String           // description of discipline 
+        "icon": String                  // URL to image
+        "total_training_sets": Integer  // # of training sets
     },
     [...]                     // repeats for available disciplines
 ]
@@ -39,10 +40,11 @@ Content-Type: application/json
 ```javascript
 [
     {
-        "id": Integer,    // ID of training set
-        "title": String,  // title of discipline
-        "details": String // details about training set 
-        "icon": String    // URL to image
+        "id": Integer,             // ID of training set
+        "title": String,           // title of discipline
+        "details": String          // details about training set 
+        "icon": String             // URL to image
+        "total_documents": Integer // # of documents
     }
     [...]                 // repeats for available training sets
 ]

--- a/src/vocgui/serializers.py
+++ b/src/vocgui/serializers.py
@@ -3,14 +3,16 @@ from rest_framework import serializers
 from .models import Discipline, TrainingSet, Document, AlternativeWord
 
 class DisciplineSerializer(serializers.ModelSerializer):
+    total_training_sets = serializers.IntegerField()
     class Meta:
         model = Discipline
-        fields = ('id', 'title', 'description', 'icon')
+        fields = ('id', 'title', 'description', 'icon', 'total_training_sets')
 
 class TrainingSetSerializer(serializers.ModelSerializer):
+    total_documents = serializers.IntegerField()
     class Meta:
         model = TrainingSet
-        fields = ('id', 'title', 'description', 'icon')
+        fields = ('id', 'title', 'description', 'icon', 'total_documents')
 
 class AlternativeWordSerializer(serializers.ModelSerializer):
     class Meta:

--- a/src/vocgui/views.py
+++ b/src/vocgui/views.py
@@ -6,6 +6,7 @@ from django.core import serializers  # pylint: disable=E0401
 from django.shortcuts import render  # pylint: disable=E0401
 from rest_framework import viewsets
 from django.shortcuts import redirect
+from django.db.models import Count
 
 from .models import TrainingSet, Document, AlternativeWord, Discipline
 from .serializers import DisciplineSerializer, DocumentSerializer, TrainingSetSerializer, AlternativeWordSerializer
@@ -13,6 +14,11 @@ from .serializers import DisciplineSerializer, DocumentSerializer, TrainingSetSe
 class DisciplineViewSet(viewsets.ModelViewSet):
     queryset = Discipline.objects.all()
     serializer_class = DisciplineSerializer
+
+    def get_queryset(self):
+        return Discipline.objects.annotate(
+            total_training_sets=Count('training_sets')
+        )
 
 class DocumentViewSet(viewsets.ModelViewSet):
     serializer_class = DocumentSerializer
@@ -26,6 +32,7 @@ class TrainingSetViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         queryset = TrainingSet.objects.filter(discipline_id=self.kwargs['discipline_id'])
+        queryset = queryset.annotate(total_documents=Count('documents'))
         return queryset
 
 def redirect_view(request):


### PR DESCRIPTION
**Issue:** 

- the frontend needs the number of training sets when calling `/api/disciplines/` for each discipline object
-  the frontend needs the number of documents when calling `api/training_set/[DISCIPLINE_ID]` for each training set_object

**Solution:**

- added `Count` annotation to the respective classes in `views.py`
- added the respective attribute to the corresponding serializers
