### PR TITLE
Feature/audio fixes #76

### DIFF
--- a/src/vocgui/forms.py
+++ b/src/vocgui/forms.py
@@ -4,18 +4,19 @@ from django.db import models
 
 from .models import Document, TrainingSet, Discipline
 
-class TrainingSetForm(forms.ModelForm):    
+
+class TrainingSetForm(forms.ModelForm):
     class Meta:
         model = TrainingSet
         fields = ['title', 'description', 'icon', 'discipline', 'documents']
-    
+
     title = models.CharField(max_length=255)
     description = models.CharField(max_length=255, blank=True)
     discipline = forms.ModelChoiceField(queryset=Discipline.objects.all())
     documents = forms.ModelMultipleChoiceField(
-            queryset=Document.objects.all(),
-            widget=FilteredSelectMultiple(
-                verbose_name=('Wörter'),
-                is_stacked=False
-            )
+        queryset=Document.objects.all(),
+        widget=FilteredSelectMultiple(
+            verbose_name=('Wörter'),
+            is_stacked=False
+        )
     )

--- a/src/vocgui/list_filter.py
+++ b/src/vocgui/list_filter.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 
 from .models import Discipline, TrainingSet, Document
 
+
 class DocumentDisciplineListFilter(admin.SimpleListFilter):
     """
     This filter will always return a subset of the instances in a Model, either filtering by the
@@ -11,7 +12,6 @@ class DocumentDisciplineListFilter(admin.SimpleListFilter):
     """
 
     title = 'Bereichen'
-
 
     # Parameter for the filter that will be used in the URL query.
     parameter_name = 'Bereiche'
@@ -43,6 +43,7 @@ class DocumentDisciplineListFilter(admin.SimpleListFilter):
             return queryset.filter(training_sets__discipline_id=self.value())
         return queryset
 
+
 class DocumentTraininSetListFilter(admin.SimpleListFilter):
     """
     This filter will always return a subset of the instances in a Model, either filtering by the
@@ -50,7 +51,6 @@ class DocumentTraininSetListFilter(admin.SimpleListFilter):
     """
 
     title = 'Modulen'
-
 
     # Parameter for the filter that will be used in the URL query.
     parameter_name = 'Modul'

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -3,7 +3,7 @@ Models for the UI
 """
 import os
 from pathlib import Path
-
+from .validators import validate_file_extension
 from django.db import models  # pylint: disable=E0401
 from pydub import AudioSegment
 from django.core.files import File
@@ -50,11 +50,12 @@ class Document(models.Model):  # pylint: disable=R0903
     word_type = models.CharField(max_length=255, choices=Static.word_type_choices, default='')
     word = models.CharField(max_length=255)
     article = models.CharField(max_length=255, choices=Static.article_choices, default='')
-    audio = models.FileField(upload_to='audio/', blank=True)
+    audio = models.FileField(upload_to='audio/', validators=[validate_file_extension])
     creation_date = models.DateTimeField(auto_now_add=True)
 
+
     @property
-    def converted(self,  content_type='audio/mpeg', bitrate="192k"):
+    def converted(self,  content_type='audio/mpeg'):
         super(Document, self).save()
         file_path = self.audio.path
         original_extension = file_path.split('.')[-1]

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -53,23 +53,23 @@ class Document(models.Model):  # pylint: disable=R0903
     audio = models.FileField(upload_to='audio/', validators=[validate_file_extension, validate_file_size])
     creation_date = models.DateTimeField(auto_now_add=True)
 
-
     @property
     def converted(self,  content_type='audio/mpeg'):
         super(Document, self).save()
         file_path = self.audio.path
         original_extension = file_path.split('.')[-1]
         mp3_converted_file = AudioSegment.from_file(file_path, original_extension)
-        new_path = file_path[:-3] + 'mp3'
+        new_path = file_path[:-4] + '-conv.mp3'
         mp3_converted_file.export(new_path, format='mp3', bitrate="44.1k")
 
         converted_audiofile = File(
             file=open(new_path, 'rb'),
             name=Path(new_path)
         )
-        converted_audiofile.name = self.word + '.mp3'
+        converted_audiofile.name = Path(new_path).name
         converted_audiofile.content_type = content_type
         converted_audiofile.size = os.path.getsize(new_path)
+        os.remove(new_path)
         return converted_audiofile
 
     def save(self, *args, **kwarg):

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -3,7 +3,7 @@ Models for the UI
 """
 import os
 from pathlib import Path
-from .validators import validate_file_extension
+from .validators import validate_file_extension, validate_file_size
 from django.db import models  # pylint: disable=E0401
 from pydub import AudioSegment
 from django.core.files import File
@@ -50,7 +50,7 @@ class Document(models.Model):  # pylint: disable=R0903
     word_type = models.CharField(max_length=255, choices=Static.word_type_choices, default='')
     word = models.CharField(max_length=255)
     article = models.CharField(max_length=255, choices=Static.article_choices, default='')
-    audio = models.FileField(upload_to='audio/', validators=[validate_file_extension])
+    audio = models.FileField(upload_to='audio/', validators=[validate_file_extension, validate_file_size])
     creation_date = models.DateTimeField(auto_now_add=True)
 
 

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -67,7 +67,7 @@ class Document(models.Model):  # pylint: disable=R0903
             file=open(new_path, 'rb'),
             name=Path(new_path)
         )
-        converted_audiofile.name = Path(new_path).name
+        converted_audiofile.name = self.word + '.mp3'
         converted_audiofile.content_type = content_type
         converted_audiofile.size = os.path.getsize(new_path)
         return converted_audiofile

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -55,6 +55,7 @@ class Document(models.Model):  # pylint: disable=R0903
 
     @property
     def converted(self,  content_type='audio/mpeg', bitrate="192k"):
+        super(Document, self).save()
         file_path = self.audio.path
         original_extension = file_path.split('.')[-1]
         mp3_converted_file = AudioSegment.from_file(file_path, original_extension)

--- a/src/vocgui/validators.py
+++ b/src/vocgui/validators.py
@@ -4,4 +4,10 @@ def validate_file_extension(value):
     ext = os.path.splitext(value.name)[1]  # [0] returns path+filename
     valid_extensions = ['.mp3', '.aac', '.wav', '.m4a', '.wma', '.ogg']
     if not ext.lower() in valid_extensions:
-        raise ValidationError('Unerlaubtes Dateiformat')
+        raise ValidationError('Unerlaubtes Dateiformat! Erlaubt: .mp3 .aac .wav .m4a .wma .ogg')
+
+
+def validate_file_size(value):
+    from django.core.exceptions import ValidationError
+    if value.size > (5 * 1024 * 1024):
+        raise ValidationError('Datei zu groß! Maximal 5 MB')

--- a/src/vocgui/validators.py
+++ b/src/vocgui/validators.py
@@ -1,0 +1,7 @@
+def validate_file_extension(value):
+    import os
+    from django.core.exceptions import ValidationError
+    ext = os.path.splitext(value.name)[1]  # [0] returns path+filename
+    valid_extensions = ['.mp3', '.aac', '.wav', '.m4a', '.wma', '.ogg']
+    if not ext.lower() in valid_extensions:
+        raise ValidationError('Unerlaubtes Dateiformat')

--- a/src/voctrainer/settings.py
+++ b/src/voctrainer/settings.py
@@ -43,6 +43,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'drf_yasg',
     'nested_admin',
+    'pydub',
+    'ffmpeg',
 ]
 
 REST_FRAMEWORK = { 'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema' }


### PR DESCRIPTION
### Problem 
- upload of different audio formats should be possible
- audio files saved should be standardized 44.1khz mp3

### Solution fixes #76 
- implemented automatic conversion to .mp3 44.1khz using pydub (partially used https://hvitis.dev/how-to-convert-audio-files-with-python-and-django)
- added validation for file size (max 5MB) and file format (.mp3 .aac .wav .m4a .wma .ogg)

### Issue
- currently 3 files are saved per upload (original, converted, document audio (copy of converted))

