### PR TITLE
Feature/ordered sidebar new fixes #105

### DIFF
--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 10:09+0000\n"
+"POT-Creation-Date: 2021-05-01 09:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,28 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/vocgui/admin.py:64 src/vocgui/list_filter.py:55 src/vocgui/models.py:123
+msgid "training sets"
+msgstr "Module"
+
+#: src/vocgui/admin.py:65 src/vocgui/list_filter.py:16
+#: src/vocgui/list_filter.py:19 src/vocgui/list_filter.py:94
+#: src/vocgui/models.py:47
+msgid "disciplines"
+msgstr "Bereiche"
+
+#: src/vocgui/admin.py:66 src/vocgui/forms.py:20 src/vocgui/forms.py:23
+#: src/vocgui/models.py:96 src/vocgui/models.py:97
+msgid "vocabulary"
+msgstr "Vokabeln"
+
 #: src/vocgui/apps.py:6
 msgid "vocabulary management"
 msgstr "Vokabelverwaltung"
 
 #: src/vocgui/forms.py:16 src/vocgui/list_filter.py:97 src/vocgui/models.py:34
-#: src/vocgui/models.py:46 src/vocgui/models.py:47
+#: src/vocgui/models.py:46
 msgid "discipline"
 msgstr "Bereich"
-
-#: src/vocgui/forms.py:20 src/vocgui/forms.py:23 src/vocgui/models.py:96
-#: src/vocgui/models.py:97
-msgid "vocabulary"
-msgstr "Vokabeln"
-
-#: src/vocgui/list_filter.py:16 src/vocgui/list_filter.py:19
-#: src/vocgui/list_filter.py:94
-msgid "disciplines"
-msgstr "Bereiche"
-
-#: src/vocgui/list_filter.py:55 src/vocgui/models.py:123
-msgid "training sets"
-msgstr "Module"
 
 #: src/vocgui/list_filter.py:58 src/vocgui/models.py:105
 #: src/vocgui/models.py:115 src/vocgui/models.py:122
@@ -109,3 +110,16 @@ msgstr ""
 #: src/voctrainer/settings.py:121
 msgid "French"
 msgstr ""
+
+#, fuzzy
+#~| msgid "training sets"
+#~ msgid "Training sets"
+#~ msgstr "Module"
+
+#~ msgid "Disciplines"
+#~ msgstr "Bereiche"
+
+#, fuzzy
+#~| msgid "vocabulary"
+#~ msgid "Vocabulary"
+#~ msgstr "Vokabeln"

--- a/src/locale/en/LC_MESSAGES/django.po
+++ b/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 10:09+0000\n"
+"POT-Creation-Date: 2021-05-01 09:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,28 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/vocgui/admin.py:64 src/vocgui/list_filter.py:55 src/vocgui/models.py:123
+msgid "training sets"
+msgstr "training sets"
+
+#: src/vocgui/admin.py:65 src/vocgui/list_filter.py:16
+#: src/vocgui/list_filter.py:19 src/vocgui/list_filter.py:94
+#: src/vocgui/models.py:47
+msgid "disciplines"
+msgstr "disciplines"
+
+#: src/vocgui/admin.py:66 src/vocgui/forms.py:20 src/vocgui/forms.py:23
+#: src/vocgui/models.py:96 src/vocgui/models.py:97
+msgid "vocabulary"
+msgstr "vocabulary"
+
 #: src/vocgui/apps.py:6
 msgid "vocabulary management"
 msgstr "vocabulary management"
 
 #: src/vocgui/forms.py:16 src/vocgui/list_filter.py:97 src/vocgui/models.py:34
-#: src/vocgui/models.py:46 src/vocgui/models.py:47
+#: src/vocgui/models.py:46
 msgid "discipline"
 msgstr "discipline"
-
-#: src/vocgui/forms.py:20 src/vocgui/forms.py:23 src/vocgui/models.py:96
-#: src/vocgui/models.py:97
-msgid "vocabulary"
-msgstr "vocabulary"
-
-#: src/vocgui/list_filter.py:16 src/vocgui/list_filter.py:19
-#: src/vocgui/list_filter.py:94
-msgid "disciplines"
-msgstr "disciplines"
-
-#: src/vocgui/list_filter.py:55 src/vocgui/models.py:123
-msgid "training sets"
-msgstr "training sets"
 
 #: src/vocgui/list_filter.py:58 src/vocgui/models.py:105
 #: src/vocgui/models.py:115 src/vocgui/models.py:122
@@ -109,3 +110,18 @@ msgstr "German"
 #: src/voctrainer/settings.py:121
 msgid "French"
 msgstr "French"
+
+#, fuzzy
+#~| msgid "training sets"
+#~ msgid "Training sets"
+#~ msgstr "training sets"
+
+#, fuzzy
+#~| msgid "disciplines"
+#~ msgid "Disciplines"
+#~ msgstr "disciplines"
+
+#, fuzzy
+#~| msgid "vocabulary"
+#~ msgid "Vocabulary"
+#~ msgstr "vocabulary"

--- a/src/locale/fr/LC_MESSAGES/django.po
+++ b/src/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 10:09+0000\n"
+"POT-Creation-Date: 2021-05-01 09:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,28 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: src/vocgui/admin.py:64 src/vocgui/list_filter.py:55 src/vocgui/models.py:123
+msgid "training sets"
+msgstr "modules"
+
+#: src/vocgui/admin.py:65 src/vocgui/list_filter.py:16
+#: src/vocgui/list_filter.py:19 src/vocgui/list_filter.py:94
+#: src/vocgui/models.py:47
+msgid "disciplines"
+msgstr "secteurs"
+
+#: src/vocgui/admin.py:66 src/vocgui/forms.py:20 src/vocgui/forms.py:23
+#: src/vocgui/models.py:96 src/vocgui/models.py:97
+msgid "vocabulary"
+msgstr "vocabulaire"
+
 #: src/vocgui/apps.py:6
 msgid "vocabulary management"
 msgstr "gestion du vocabulaire"
 
 #: src/vocgui/forms.py:16 src/vocgui/list_filter.py:97 src/vocgui/models.py:34
-#: src/vocgui/models.py:46 src/vocgui/models.py:47
+#: src/vocgui/models.py:46
 msgid "discipline"
 msgstr "secteur"
-
-#: src/vocgui/forms.py:20 src/vocgui/forms.py:23 src/vocgui/models.py:96
-#: src/vocgui/models.py:97
-msgid "vocabulary"
-msgstr "vocabulaire"
-
-#: src/vocgui/list_filter.py:16 src/vocgui/list_filter.py:19
-#: src/vocgui/list_filter.py:94
-msgid "disciplines"
-msgstr "secteurs"
-
-#: src/vocgui/list_filter.py:55 src/vocgui/models.py:123
-msgid "training sets"
-msgstr "modules"
 
 #: src/vocgui/list_filter.py:58 src/vocgui/models.py:105
 #: src/vocgui/models.py:115 src/vocgui/models.py:122
@@ -109,3 +110,18 @@ msgstr ""
 #: src/voctrainer/settings.py:121
 msgid "French"
 msgstr ""
+
+#, fuzzy
+#~| msgid "training sets"
+#~ msgid "Training sets"
+#~ msgstr "modules"
+
+#, fuzzy
+#~| msgid "disciplines"
+#~ msgid "Disciplines"
+#~ msgstr "secteurs"
+
+#, fuzzy
+#~| msgid "vocabulary"
+#~ msgid "Vocabulary"
+#~ msgstr "vocabulaire"

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -57,7 +57,6 @@ class DocumentAdmin(nested_admin.NestedModelAdmin):
     list_filter = (DocumentTrainingSetListFilter, DocumentDisciplineListFilter,)
 
 
-#class AdminSite(admin.AdminSite):
 def get_app_list(self, request):
     """
     Return a sorted list of all the installed apps that have been

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin  # pylint: disable=E0401
 from .models import Discipline, TrainingSet, Document, AlternativeWord, DocumentImage  # pylint: disable=E0401
 from image_cropping import ImageCroppingMixin
+from django.utils.translation import ugettext as _
 
 from .list_filter import DisciplineListFilter, DocumentTrainingSetListFilter, DocumentDisciplineListFilter
 import nested_admin
@@ -21,14 +22,14 @@ class DisciplineAdmin(admin.ModelAdmin):
     search_fields = ['title']
     ordering = ['title']
 
-    
+
 class TrainingSetAdmin(admin.ModelAdmin):
     search_fields = ['title']
     autocomplete_fields = ['discipline']
     form = TrainingSetForm
     ordering = ['title', 'discipline__title']
-    list_filter = (DisciplineListFilter, )
-    
+    list_filter = (DisciplineListFilter,)
+
 
 class AlternativeWordAdmin(nested_admin.NestedStackedInline):
     model = AlternativeWord
@@ -50,7 +51,35 @@ class DocumentAdmin(nested_admin.NestedModelAdmin):
     search_fields = ['word']
     inlines = [DocumentImageAdmin, AlternativeWordAdmin]
     ordering = ['word']
-    list_filter = (DocumentTrainingSetListFilter, DocumentDisciplineListFilter, )
+    list_filter = (DocumentTrainingSetListFilter, DocumentDisciplineListFilter,)
+
+
+class AdminSite(admin.AdminSite):
+    def get_app_list(self, request):
+        """
+        Return a sorted list of all the installed apps that have been
+        registered in this site.
+        """
+        ordering = {
+            _("disciplines").capitalize(): 1,
+            _("training sets").capitalize(): 2,
+            _("vocabulary").capitalize(): 3,
+        }
+        app_dict = self._build_app_dict(request)
+        # a.sort(key=lambda x: b.index(x[0]))
+        # Sort the apps alphabetically.
+        app_list = sorted(app_dict.values(), key=lambda x: x['name'].lower())
+
+        # Sort the models alphabetically within each app.
+        for app in app_list:
+            app['models'].sort(key=lambda x: ordering[x['name']])
+
+        return app_list
+
+
+adminsite = AdminSite()
+admin.site = adminsite
+admin.sites.site = adminsite
 
 admin.site.register(Discipline, DisciplineAdmin)
 admin.site.register(TrainingSet, TrainingSetAdmin)

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -7,6 +7,8 @@ from django.contrib import admin  # pylint: disable=E0401
 from .models import Discipline, TrainingSet, Document, AlternativeWord, DocumentImage  # pylint: disable=E0401
 from image_cropping import ImageCroppingMixin
 from django.utils.translation import ugettext as _
+from django.contrib.auth.models import User, Group
+from django.conf import settings
 
 from .list_filter import DisciplineListFilter, DocumentTrainingSetListFilter, DocumentDisciplineListFilter
 import nested_admin
@@ -66,13 +68,16 @@ class AdminSite(admin.AdminSite):
             _("vocabulary").capitalize(): 3,
         }
         app_dict = self._build_app_dict(request)
-        # a.sort(key=lambda x: b.index(x[0]))
+
         # Sort the apps alphabetically.
         app_list = sorted(app_dict.values(), key=lambda x: x['name'].lower())
 
-        # Sort the models alphabetically within each app.
+        # Sort the respective modules according the defined order
         for app in app_list:
-            app['models'].sort(key=lambda x: ordering[x['name']])
+            try:
+                app['models'].sort(key=lambda x: ordering[x['name']])
+            except KeyError:
+                pass
 
         return app_list
 
@@ -81,6 +86,8 @@ adminsite = AdminSite()
 admin.site = adminsite
 admin.sites.site = adminsite
 
+admin.site.register(User)
+admin.site.register(Group)
 admin.site.register(Discipline, DisciplineAdmin)
 admin.site.register(TrainingSet, TrainingSetAdmin)
 admin.site.register(Document, DocumentAdmin)

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -9,6 +9,7 @@ from image_cropping import ImageCroppingMixin
 from django.utils.translation import ugettext as _
 from django.contrib.auth.models import User, Group
 from django.conf import settings
+from django.utils.module_loading import import_module
 
 from .list_filter import DisciplineListFilter, DocumentTrainingSetListFilter, DocumentDisciplineListFilter
 import nested_admin
@@ -56,38 +57,32 @@ class DocumentAdmin(nested_admin.NestedModelAdmin):
     list_filter = (DocumentTrainingSetListFilter, DocumentDisciplineListFilter,)
 
 
-class AdminSite(admin.AdminSite):
-    def get_app_list(self, request):
-        """
-        Return a sorted list of all the installed apps that have been
-        registered in this site.
-        """
-        ordering = {
-            _("disciplines").capitalize(): 1,
-            _("training sets").capitalize(): 2,
-            _("vocabulary").capitalize(): 3,
-        }
-        app_dict = self._build_app_dict(request)
+#class AdminSite(admin.AdminSite):
+def get_app_list(self, request):
+    """
+    Return a sorted list of all the installed apps that have been
+    registered in this site.
+    """
+    ordering = {
+        _("disciplines").capitalize(): 1,
+        _("training sets").capitalize(): 2,
+        _("vocabulary").capitalize(): 3,
+    }
+    app_dict = self._build_app_dict(request)
 
-        # Sort the apps alphabetically.
-        app_list = sorted(app_dict.values(), key=lambda x: x['name'].lower())
+    # Sort the apps alphabetically.
+    app_list = sorted(app_dict.values(), key=lambda x: x['name'].lower())
 
-        # Sort the respective modules according the defined order
-        for app in app_list:
-            try:
-                app['models'].sort(key=lambda x: ordering[x['name']])
-            except KeyError:
-                pass
+    # Sort the respective modules according the defined order
+    for app in app_list:
+        try:
+            app['models'].sort(key=lambda x: ordering[x['name']])
+        except KeyError:
+            pass
+    return app_list
 
-        return app_list
 
-
-adminsite = AdminSite()
-admin.site = adminsite
-admin.sites.site = adminsite
-
-admin.site.register(User)
-admin.site.register(Group)
+admin.AdminSite.get_app_list = get_app_list 
 admin.site.register(Discipline, DisciplineAdmin)
 admin.site.register(TrainingSet, TrainingSetAdmin)
 admin.site.register(Document, DocumentAdmin)

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -44,7 +44,7 @@ class Discipline(models.Model):  # pylint: disable=R0903
         Define user readable name of Field
         """
         verbose_name = _('discipline')
-        verbose_name_plural = _('discipline')
+        verbose_name_plural = _('disciplines')
 
 
 class Document(models.Model):  # pylint: disable=R0903

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -112,7 +112,7 @@ class TrainingSet(models.Model):  # pylint: disable=R0903
                                        related_name='training_sets')
 
     def __str__(self):
-        return self.title + " (" + _('training set') + ": " + self.discipline.title + ")"
+        return self.title + " (" + _('discipline').capitalize() + ": " + self.discipline.title + ")"
 
     # pylint: disable=R0903
     class Meta:


### PR DESCRIPTION
### Problem
- models in django admin sidebar aren't in fixed order but sorted alphabetically

### Solution fixes #105 
- overrode get_app_list function of AdminSite with custom ordering (1. discipline 2. training set 3. document)
- added try catch to prevent key error when trying to sort different app (e.g. Authentication and authorization) using custom ordering


### bugfixes:
- fixed displayed name of trainingset 
- fixed discipline verbose_name_plural