### PR TITLE
Feature/basic authentication fixes #140 #136 #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ GET /api/disciplines/ HTTP/1.1
 Host: lunes.tuerantuer.org
 Content-Type: application/json
 ```
+The default endpoint delivers all disciplines created by Lunes administrators. Optionally, group ids can be passed as well (multiple ids devided by `&`):
+```http
+GET /api/disciplines/[[GROUP_ID]&[GROUP_ID]&[...]] HTTP/1.1
+Host: lunes.tuerantuer.org
+Content-Type: application/json
+```
+The request will return all disciplines either created by Lunes administrators or by one of the passed user groups.
+
 ### Response
 ```javascript
 [
@@ -22,6 +30,7 @@ Content-Type: application/json
         "title": String,                // title of discipline
         "description": String,          // description of discipline 
         "icon": String,                 // URL to image
+        "created_by": Integer           // Creator group id, null if created by admin 
         "total_training_sets": Integer  // # of training sets
     },
     [...]   // repeats for available disciplines

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -35,6 +35,8 @@ class DisciplineAdmin(OrderedModelAdmin):
     )
     search_fields = ["title"]
     actions = ['delete_selected', 'make_released', 'make_unreleased']
+    list_display = ("title", "released", "creator_group", "move_up_down_links")
+    list_per_page = 25
 
     def save_model(self, request, obj, form, change):
         if not change:
@@ -57,9 +59,15 @@ class DisciplineAdmin(OrderedModelAdmin):
         choices = super(DisciplineAdmin, self).get_action_choices(request)
         choices.pop(0)
         return choices
-    
-    list_display = ("title", "released", "move_up_down_links")
-    list_per_page = 25
+
+    def creator_group(self, obj):
+        if obj.creator_is_admin:
+            return Static.admin_group
+        elif obj.created_by:
+            return obj.created_by
+        else:
+            return None
+    creator_group.short_description = _('creator group')
 
 
 class TrainingSetAdmin(OrderedModelAdmin):
@@ -155,7 +163,7 @@ class DocumentAdmin(admin.ModelAdmin):
     search_fields = ["word"]
     inlines = [DocumentImageAdmin, AlternativeWordAdmin]
     ordering = ["word", "creation_date"]
-    list_display = ("word", "word_type", "article", "related_training_set", "creation_date")
+    list_display = ("word", "word_type", "article", "related_training_set", "creator_group", "creation_date")
     list_filter = (
         DocumentTrainingSetListFilter,
         DocumentDisciplineListFilter,
@@ -181,6 +189,15 @@ class DocumentAdmin(admin.ModelAdmin):
             child.title for child in obj.training_sets.all()
         ])
     related_training_set.short_description = _('training set')
+
+    def creator_group(self, obj):
+        if obj.creator_is_admin:
+            return Static.admin_group
+        elif obj.created_by:
+            return obj.created_by
+        else:
+            return None
+    creator_group.short_description = _('creator group')
 
 
 def get_app_list(self, request):

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -14,7 +14,14 @@ from django.conf import settings
 from django.utils.module_loading import import_module
 from ordered_model.admin import OrderedModelAdmin
 
-from .models import Discipline, TrainingSet, Document, AlternativeWord, DocumentImage, Static
+from .models import (
+    Discipline,
+    TrainingSet,
+    Document,
+    AlternativeWord,
+    DocumentImage,
+    Static,
+)
 from .list_filter import (
     DisciplineListFilter,
     DocumentTrainingSetListFilter,
@@ -30,11 +37,11 @@ class DisciplineAdmin(OrderedModelAdmin):
     """
 
     readonly_fields = (
-        'created_by',
-        'creator_is_admin',
+        "created_by",
+        "creator_is_admin",
     )
     search_fields = ["title"]
-    actions = ['delete_selected', 'make_released', 'make_unreleased']
+    actions = ["delete_selected", "make_released", "make_unreleased"]
     list_display = ("title", "released", "creator_group", "move_up_down_links")
     list_per_page = 25
 
@@ -43,19 +50,19 @@ class DisciplineAdmin(OrderedModelAdmin):
         if not change:
             if len(request.user.groups.all()) >= 1:
                 obj.created_by = request.user.groups.all()[0]
-            else: 
-                raise IndexError ("No group assigned. Please add the user to a group")
+            else:
+                raise IndexError("No group assigned. Please add the user to a group")
             obj.creator_is_admin = request.user.is_superuser
         obj.save()
 
     # django actions to release/unrelease model
     @admin.action(description=_("Release selected disciplines"))
     def make_released(self, request, queryset):
-        queryset.update(released = True)
+        queryset.update(released=True)
 
     @admin.action(description=_("Unrelease selected disciplines"))
     def make_unreleased(self, request, queryset):
-        queryset.update(released = False)
+        queryset.update(released=False)
 
     def get_action_choices(self, request):
         choices = super(DisciplineAdmin, self).get_action_choices(request)
@@ -70,7 +77,8 @@ class DisciplineAdmin(OrderedModelAdmin):
             return obj.created_by
         else:
             return None
-    creator_group.short_description = _('creator group')
+
+    creator_group.short_description = _("creator group")
 
     # only display models of the corresponding user group
     def get_queryset(self, request):
@@ -85,15 +93,22 @@ class TrainingSetAdmin(OrderedModelAdmin):
     Admin Interface to for the TrainigSet module.
     Inheriting from `admin.ModelAdmin`.
     """
+
     readonly_fields = (
-        'created_by',
-        'creator_is_admin',
+        "created_by",
+        "creator_is_admin",
     )
     search_fields = ["title"]
     form = TrainingSetForm
-    list_display = ("title", "released", "related_disciplines", "creator_group", "move_up_down_links")
+    list_display = (
+        "title",
+        "released",
+        "related_disciplines",
+        "creator_group",
+        "move_up_down_links",
+    )
     list_filter = (DisciplineListFilter,)
-    actions = ['make_released', 'make_unreleased']
+    actions = ["make_released", "make_unreleased"]
     list_per_page = 25
 
     # Save user group and admin satus of model
@@ -101,19 +116,19 @@ class TrainingSetAdmin(OrderedModelAdmin):
         if not change:
             if len(request.user.groups.all()) >= 1:
                 obj.created_by = request.user.groups.all()[0]
-            else: 
-                raise IndexError ("No group assigned. Please add the user to a group")
+            else:
+                raise IndexError("No group assigned. Please add the user to a group")
             obj.creator_is_admin = request.user.is_superuser
         obj.save()
 
     # django actions to release/unrelease model
     @admin.action(description=_("Release selected training sets"))
     def make_released(self, request, queryset):
-        queryset.update(released = True)     
+        queryset.update(released=True)
 
     @admin.action(description=_("Unrelease selected training sets"))
     def make_unreleased(self, request, queryset):
-        queryset.update(released = False)
+        queryset.update(released=False)
 
     def get_action_choices(self, request):
         choices = super(TrainingSetAdmin, self).get_action_choices(request)
@@ -122,10 +137,9 @@ class TrainingSetAdmin(OrderedModelAdmin):
 
     # fucntion to display related disciplines
     def related_disciplines(self, obj):
-        return ", ".join([
-            child.title for child in obj.discipline.all()
-        ])
-    related_disciplines.short_description = _('disciplines')
+        return ", ".join([child.title for child in obj.discipline.all()])
+
+    related_disciplines.short_description = _("disciplines")
 
     # function to display creator group in list display
     def creator_group(self, obj):
@@ -135,7 +149,8 @@ class TrainingSetAdmin(OrderedModelAdmin):
             return obj.created_by
         else:
             return None
-    creator_group.short_description = _('creator group')
+
+    creator_group.short_description = _("creator group")
 
     # only display models of the corresponding user group
     def get_queryset(self, request):
@@ -144,7 +159,6 @@ class TrainingSetAdmin(OrderedModelAdmin):
             return qs
         return qs.filter(created_by__in=request.user.groups.all())
 
-    
 
 class AlternativeWordAdmin(admin.StackedInline):
     """
@@ -177,14 +191,22 @@ class DocumentAdmin(admin.ModelAdmin):
     Admin Interface to for the Document module.
     Inheriting from `admin.ModelAdmin`.
     """
+
     readonly_fields = (
-        'created_by',
-        'creator_is_admin',
+        "created_by",
+        "creator_is_admin",
     )
     search_fields = ["word"]
     inlines = [DocumentImageAdmin, AlternativeWordAdmin]
     ordering = ["word", "creation_date"]
-    list_display = ("word", "word_type", "article", "related_training_set", "creator_group", "creation_date")
+    list_display = (
+        "word",
+        "word_type",
+        "article",
+        "related_training_set",
+        "creator_group",
+        "creation_date",
+    )
     list_filter = (
         DocumentTrainingSetListFilter,
         DocumentDisciplineListFilter,
@@ -196,8 +218,8 @@ class DocumentAdmin(admin.ModelAdmin):
         if not change:
             if len(request.user.groups.all()) >= 1:
                 obj.created_by = request.user.groups.all()[0].name
-            else: 
-                raise IndexError ("No group assigned. Please add the user to a group")
+            else:
+                raise IndexError("No group assigned. Please add the user to a group")
             obj.creator_is_admin = request.user.is_superuser
         obj.save()
 
@@ -205,14 +227,13 @@ class DocumentAdmin(admin.ModelAdmin):
     def get_action_choices(self, request):
         choices = super(DocumentAdmin, self).get_action_choices(request)
         choices.pop(0)
-        return choices#
-    
+        return choices  #
+
     # fucntion to display related training sets
     def related_training_set(self, obj):
-        return ", ".join([
-            child.title for child in obj.training_sets.all()
-        ])
-    related_training_set.short_description = _('training set')
+        return ", ".join([child.title for child in obj.training_sets.all()])
+
+    related_training_set.short_description = _("training set")
 
     # function to display creator group in list display
     def creator_group(self, obj):
@@ -222,7 +243,8 @@ class DocumentAdmin(admin.ModelAdmin):
             return obj.created_by
         else:
             return None
-    creator_group.short_description = _('creator group')
+
+    creator_group.short_description = _("creator group")
 
     # only display models of the corresponding user group
     def get_queryset(self, request):
@@ -262,8 +284,6 @@ def get_app_list(self, request):
         except KeyError:
             pass
     return app_list
-
-
 
 
 admin.AdminSite.get_app_list = get_app_list

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.utils.module_loading import import_module
 from ordered_model.admin import OrderedModelAdmin
 
-from .models import Discipline, TrainingSet, Document, AlternativeWord, DocumentImage
+from .models import Discipline, TrainingSet, Document, AlternativeWord, DocumentImage, Static
 from .list_filter import (
     DisciplineListFilter,
     DocumentTrainingSetListFilter,
@@ -73,7 +73,7 @@ class TrainingSetAdmin(OrderedModelAdmin):
     )
     search_fields = ["title"]
     form = TrainingSetForm
-    list_display = ("title", "released", "related_disciplines", "move_up_down_links")
+    list_display = ("title", "released", "related_disciplines", "creator_group", "move_up_down_links")
     list_filter = (DisciplineListFilter,)
     actions = ['make_released', 'make_unreleased']
     list_per_page = 25
@@ -105,6 +105,17 @@ class TrainingSetAdmin(OrderedModelAdmin):
             child.title for child in obj.discipline.all()
         ])
     related_disciplines.short_description = _('disciplines')
+
+    def creator_group(self, obj):
+        if obj.creator_is_admin:
+            return Static.admin_group
+        elif obj.created_by:
+            return obj.created_by
+        else:
+            return None
+    creator_group.short_description = _('creator group')
+
+    
 
 class AlternativeWordAdmin(admin.StackedInline):
     """

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -38,6 +38,7 @@ class DisciplineAdmin(OrderedModelAdmin):
     list_display = ("title", "released", "creator_group", "move_up_down_links")
     list_per_page = 25
 
+    # Save user group and admin satus of model
     def save_model(self, request, obj, form, change):
         if not change:
             if len(request.user.groups.all()) >= 1:
@@ -47,6 +48,7 @@ class DisciplineAdmin(OrderedModelAdmin):
             obj.creator_is_admin = request.user.is_superuser
         obj.save()
 
+    # django actions to release/unrelease model
     @admin.action(description=_("Release selected disciplines"))
     def make_released(self, request, queryset):
         queryset.update(released = True)
@@ -60,6 +62,7 @@ class DisciplineAdmin(OrderedModelAdmin):
         choices.pop(0)
         return choices
 
+    # function to display creator group in list display
     def creator_group(self, obj):
         if obj.creator_is_admin:
             return Static.admin_group
@@ -68,6 +71,13 @@ class DisciplineAdmin(OrderedModelAdmin):
         else:
             return None
     creator_group.short_description = _('creator group')
+
+    # only display models of the corresponding user group
+    def get_queryset(self, request):
+        qs = super(DisciplineAdmin, self).get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(created_by__in=request.user.groups.all())
 
 
 class TrainingSetAdmin(OrderedModelAdmin):
@@ -86,6 +96,7 @@ class TrainingSetAdmin(OrderedModelAdmin):
     actions = ['make_released', 'make_unreleased']
     list_per_page = 25
 
+    # Save user group and admin satus of model
     def save_model(self, request, obj, form, change):
         if not change:
             if len(request.user.groups.all()) >= 1:
@@ -95,6 +106,7 @@ class TrainingSetAdmin(OrderedModelAdmin):
             obj.creator_is_admin = request.user.is_superuser
         obj.save()
 
+    # django actions to release/unrelease model
     @admin.action(description=_("Release selected training sets"))
     def make_released(self, request, queryset):
         queryset.update(released = True)     
@@ -108,12 +120,14 @@ class TrainingSetAdmin(OrderedModelAdmin):
         choices.pop(0)
         return choices
 
+    # fucntion to display related disciplines
     def related_disciplines(self, obj):
         return ", ".join([
             child.title for child in obj.discipline.all()
         ])
     related_disciplines.short_description = _('disciplines')
 
+    # function to display creator group in list display
     def creator_group(self, obj):
         if obj.creator_is_admin:
             return Static.admin_group
@@ -122,6 +136,13 @@ class TrainingSetAdmin(OrderedModelAdmin):
         else:
             return None
     creator_group.short_description = _('creator group')
+
+    # only display models of the corresponding user group
+    def get_queryset(self, request):
+        qs = super(TrainingSetAdmin, self).get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(created_by__in=request.user.groups.all())
 
     
 
@@ -170,6 +191,7 @@ class DocumentAdmin(admin.ModelAdmin):
     )
     list_per_page = 25
 
+    # Save user group and admin satus of model
     def save_model(self, request, obj, form, change):
         if not change:
             if len(request.user.groups.all()) >= 1:
@@ -179,17 +201,20 @@ class DocumentAdmin(admin.ModelAdmin):
             obj.creator_is_admin = request.user.is_superuser
         obj.save()
 
+    # function to display available action choices
     def get_action_choices(self, request):
         choices = super(DocumentAdmin, self).get_action_choices(request)
         choices.pop(0)
         return choices#
     
+    # fucntion to display related training sets
     def related_training_set(self, obj):
         return ", ".join([
             child.title for child in obj.training_sets.all()
         ])
     related_training_set.short_description = _('training set')
 
+    # function to display creator group in list display
     def creator_group(self, obj):
         if obj.creator_is_admin:
             return Static.admin_group
@@ -198,6 +223,13 @@ class DocumentAdmin(admin.ModelAdmin):
         else:
             return None
     creator_group.short_description = _('creator group')
+
+    # only display models of the corresponding user group
+    def get_queryset(self, request):
+        qs = super(DocumentAdmin, self).get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(created_by__in=request.user.groups.all())
 
 
 def get_app_list(self, request):

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -247,7 +247,7 @@ class DocumentAdmin(admin.ModelAdmin):
     def get_action_choices(self, request):
         choices = super(DocumentAdmin, self).get_action_choices(request)
         choices.pop(0)
-        return choices  #
+        return choices
 
     # fucntion to display related training sets
     def related_training_set(self, obj):

--- a/src/vocgui/apps.py
+++ b/src/vocgui/apps.py
@@ -7,5 +7,6 @@ class VocguiConfig(AppConfig):
     Application settings for the `vocgui` app, which
     is our main cms app. Inherits from `AppConfig`.
     """
+
     name = "vocgui"
     verbose_name = _("vocabulary management")

--- a/src/vocgui/forms.py
+++ b/src/vocgui/forms.py
@@ -11,22 +11,26 @@ class TrainingSetForm(forms.ModelForm):
     Defining custom form for the training set admin interface.
     Inherits from `forms.ModelForm`.
     """
+
     class Meta:
         """
         Defining Meta description of `TrainingSetForm`.
         """
+
         model = TrainingSet
         fields = ["released", "title", "description", "icon", "documents"]
 
     title = models.CharField(max_length=255)
     description = models.CharField(max_length=255, blank=True)
     discipline = forms.ModelMultipleChoiceField(
-        queryset=Discipline.objects.all().order_by('title'),
-        widget=FilteredSelectMultiple(verbose_name=(_("disciplines")), is_stacked=False),
+        queryset=Discipline.objects.all().filter().order_by("title"),
+        widget=FilteredSelectMultiple(
+            verbose_name=(_("disciplines")), is_stacked=False
+        ),
         label=_("disciplines"),
     )
     documents = forms.ModelMultipleChoiceField(
-        queryset=Document.objects.all().order_by('word'),
+        queryset=Document.objects.all().order_by("word"),
         widget=FilteredSelectMultiple(verbose_name=(_("vocabulary")), is_stacked=False),
         label=_("vocabulary"),
     )

--- a/src/vocgui/list_filter.py
+++ b/src/vocgui/list_filter.py
@@ -13,7 +13,7 @@ class DocumentDisciplineListFilter(admin.SimpleListFilter):
     title = _("disciplines")
 
     # Parameter for the filter that will be used in the URL query.
-    parameter_name = ("disciplines")
+    parameter_name = "disciplines"
 
     def lookups(self, request, model_admin):
         """
@@ -57,7 +57,9 @@ class DocumentDisciplineListFilter(admin.SimpleListFilter):
         """
         # Compare the requested value to decide how to filter the queryset.
         if self.value():
-            return queryset.filter(training_sets__discipline__id=self.value()).distinct()
+            return queryset.filter(
+                training_sets__discipline__id=self.value()
+            ).distinct()
         return queryset
 
 
@@ -70,7 +72,7 @@ class DocumentTrainingSetListFilter(admin.SimpleListFilter):
     title = _("training sets")
 
     # Parameter for the filter that will be used in the URL query.
-    parameter_name = ("training set")
+    parameter_name = "training set"
 
     def lookups(self, request, model_admin):
         """
@@ -126,7 +128,7 @@ class DisciplineListFilter(admin.SimpleListFilter):
     title = _("disciplines")
 
     # Parameter for the filter that will be used in the URL query.
-    parameter_name = ("discipline")
+    parameter_name = "discipline"
 
     default_value = None
 

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -4,7 +4,7 @@ Models for the UI
 import os
 from pathlib import Path
 from django.db import models
-from django.contrib.auth.models import User, Group 
+from django.contrib.auth.models import User, Group
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.db.models.deletion import CASCADE
@@ -57,7 +57,7 @@ class Static:
     admin_group = "Lunes"
 
     # default group name
-    default_group_name = "Lunes Admin"
+    default_group_name = None
 
 
 def convert_umlaute_images(instance, filename):
@@ -333,11 +333,9 @@ class AlternativeWord(models.Model):
         verbose_name = _("alternative word")
         verbose_name_plural = _("alternative words")
 
-# automatically adds a group when creating a new user
+
+# automatically adds a group when creating a new user if group name given in Static module
 @receiver(post_save, sender=User)
 def create_user_profile(sender, instance, created, **kwargs):
-    if created:
+    if Static.default_group_name and created:
         instance.groups.add(Group.objects.get(name=Static.default_group_name))
-
-        
-

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -51,6 +51,9 @@ class Static:
         "ß":"ss",
     }
 
+    # super admin group name
+    admin_group = "Lunes"
+
 def convert_umlaute_images(instance, filename):
     for i,j in Static.replace_dict.items():
         filename = filename.replace(i,j)

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -42,27 +42,30 @@ class Static:
 
     # letters that should be converted
     replace_dict = {
-        "Ä":"Ae",
-        "Ö":"Oe",
-        "Ü":"Ue",
-        "ä":"ae",
-        "ö":"oe",
-        "ü":"ue",
-        "ß":"ss",
+        "Ä": "Ae",
+        "Ö": "Oe",
+        "Ü": "Ue",
+        "ä": "ae",
+        "ö": "oe",
+        "ü": "ue",
+        "ß": "ss",
     }
 
     # super admin group name
     admin_group = "Lunes"
 
+
 def convert_umlaute_images(instance, filename):
-    for i,j in Static.replace_dict.items():
-        filename = filename.replace(i,j)
-    return os.path.join('images/', filename)
+    for i, j in Static.replace_dict.items():
+        filename = filename.replace(i, j)
+    return os.path.join("images/", filename)
+
 
 def convert_umlaute_audio(instance, filename):
-    for i,j in Static.replace_dict.items():
-        filename = filename.replace(i,j)
-    return os.path.join('audio/', filename)
+    for i, j in Static.replace_dict.items():
+        filename = filename.replace(i, j)
+    return os.path.join("audio/", filename)
+
 
 class Discipline(OrderedModel):
     """
@@ -77,8 +80,12 @@ class Discipline(OrderedModel):
     description = models.CharField(
         max_length=255, blank=True, verbose_name=_("description")
     )
-    icon = models.ImageField(upload_to=convert_umlaute_images, blank=True, verbose_name=_("icon"))
-    created_by = models.ForeignKey(Group, on_delete=CASCADE, null=True, blank=True, verbose_name=_("created by"))
+    icon = models.ImageField(
+        upload_to=convert_umlaute_images, blank=True, verbose_name=_("icon")
+    )
+    created_by = models.ForeignKey(
+        Group, on_delete=CASCADE, null=True, blank=True, verbose_name=_("created by")
+    )
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
 
     def __str__(self):
@@ -124,8 +131,12 @@ class Document(models.Model):
         null=True,
         verbose_name=_("audio"),
     )
-    creation_date = models.DateTimeField(auto_now_add=True, verbose_name=_("creation date"))
-    created_by = models.CharField(max_length=255, null=True, blank=True, verbose_name=_("created by"))
+    creation_date = models.DateTimeField(
+        auto_now_add=True, verbose_name=_("creation date")
+    )
+    created_by = models.CharField(
+        max_length=255, null=True, blank=True, verbose_name=_("created by")
+    )
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
 
     @property
@@ -186,12 +197,16 @@ class TrainingSet(OrderedModel):  # pylint: disable=R0903
     description = models.CharField(
         max_length=255, blank=True, verbose_name=_("description")
     )
-    icon = models.ImageField(upload_to=convert_umlaute_images, blank=True, verbose_name=_("icon"))
+    icon = models.ImageField(
+        upload_to=convert_umlaute_images, blank=True, verbose_name=_("icon")
+    )
     documents = models.ManyToManyField(Document, related_name="training_sets")
     discipline = models.ManyToManyField(Discipline, related_name="training_sets")
-    created_by = models.ForeignKey(Group, on_delete=CASCADE, null=True, blank=True, verbose_name=_("created by"))
+    created_by = models.ForeignKey(
+        Group, on_delete=CASCADE, null=True, blank=True, verbose_name=_("created by")
+    )
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
-    
+
     def __str__(self):
         return self.title
 

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -4,7 +4,9 @@ Models for the UI
 import os
 from pathlib import Path
 from django.db import models
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import User, Group 
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.db.models.deletion import CASCADE
 from ordered_model.models import OrderedModel
 from PIL import Image, ImageFilter
@@ -53,6 +55,9 @@ class Static:
 
     # super admin group name
     admin_group = "Lunes"
+
+    # default group name
+    default_group_name = "Lunes Admin"
 
 
 def convert_umlaute_images(instance, filename):
@@ -327,3 +332,12 @@ class AlternativeWord(models.Model):
 
         verbose_name = _("alternative word")
         verbose_name_plural = _("alternative words")
+
+# automatically adds a group when creating a new user
+@receiver(post_save, sender=User)
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        instance.groups.add(Group.objects.get(name=Static.default_group_name))
+
+        
+

--- a/src/vocgui/serializers.py
+++ b/src/vocgui/serializers.py
@@ -17,7 +17,14 @@ class DisciplineSerializer(serializers.ModelSerializer):
         """
 
         model = Discipline
-        fields = ("id", "title", "description", "icon", "total_training_sets")
+        fields = (
+            "id",
+            "title",
+            "description",
+            "icon",
+            "created_by",
+            "total_training_sets",
+        )
 
 
 class TrainingSetSerializer(serializers.ModelSerializer):

--- a/src/vocgui/serializers.py
+++ b/src/vocgui/serializers.py
@@ -8,12 +8,14 @@ class DisciplineSerializer(serializers.ModelSerializer):
     Serializer for the Discipline module. Inherits from
     `serializers.ModelSerializer`.
     """
+
     total_training_sets = serializers.IntegerField()
 
     class Meta:
         """
         Define model and the corresponding fields
         """
+
         model = Discipline
         fields = ("id", "title", "description", "icon", "total_training_sets")
 
@@ -23,12 +25,14 @@ class TrainingSetSerializer(serializers.ModelSerializer):
     Serializer for the TrainingSet module. Inherits from
     `serializers.ModelSerializer`.
     """
+
     total_documents = serializers.IntegerField()
 
     class Meta:
         """
         Define model and the corresponding fields
         """
+
         model = TrainingSet
         fields = ("id", "title", "description", "icon", "total_documents")
 
@@ -38,10 +42,12 @@ class AlternativeWordSerializer(serializers.ModelSerializer):
     Serializer for the AlternativeWord module. Inherits from
     `serializers.ModelSerializer`.
     """
+
     class Meta:
         """
         Define model and the corresponding fields
         """
+
         model = AlternativeWord
         fields = ("alt_word", "article")
 
@@ -51,10 +57,12 @@ class DocumentImageSerializer(serializers.ModelSerializer):
     Serializer for the DocumentImage module. Inherits from
     `serializers.ModelSerializer`.
     """
+
     class Meta:
         """
         Define model and the corresponding fields
         """
+
         model = DocumentImage
         fields = ("id", "image")
 
@@ -64,6 +72,7 @@ class DocumentSerializer(serializers.ModelSerializer):
     Serializer for the Document module. Inherits from
     `serializers.ModelSerializer`.
     """
+
     alternatives = AlternativeWordSerializer(many=True, read_only=True)
     document_image = DocumentImageSerializer(many=True, read_only=True)
 
@@ -71,6 +80,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         """
         Define model and the corresponding fields
         """
+
         model = Document
         fields = (
             "id",

--- a/src/vocgui/urls.py
+++ b/src/vocgui/urls.py
@@ -28,11 +28,9 @@ schema_view = get_schema_view(
 )
 # router for dynmaic url patterns
 router = routers.DefaultRouter()
-router.register(r"disciplines", views.DisciplineViewSet, "disciplines")
+#router.register(r"disciplines/$", views.DisciplineViewSet, "disciplines")
 router.register(
-    r"disciplines_groups/(?P<group_id>[\d+&]+)",
-    views.DisciplineGroupViewSet,
-    "disciplines",
+    r"disciplines(?:/(?P<group_id>[\d+&]+))?", views.DisciplineViewSet, "disciplines", #(?:/(?P<username>[-\w]+))?
 )
 router.register(
     r"training_set/(?P<discipline_id>[0-9]+)", views.TrainingSetViewSet, "training_set"

--- a/src/vocgui/urls.py
+++ b/src/vocgui/urls.py
@@ -30,6 +30,11 @@ schema_view = get_schema_view(
 router = routers.DefaultRouter()
 router.register(r"disciplines", views.DisciplineViewSet, "disciplines")
 router.register(
+    r"disciplines_groups/(?P<group_id>[\d+&]+)",
+    views.DisciplineGroupViewSet,
+    "disciplines",
+)
+router.register(
     r"training_set/(?P<discipline_id>[0-9]+)", views.TrainingSetViewSet, "training_set"
 )
 router.register(

--- a/src/vocgui/views.py
+++ b/src/vocgui/views.py
@@ -20,7 +20,7 @@ from .serializers import (
 
 class DisciplineViewSet(viewsets.ModelViewSet):
     """
-    Defines a view set for the Discipline module.
+    Defines a view set for the Discipline module, optionally filtered by user groups.
     Inherits from `viewsets.ModelViewSet` and defines queryset
     and serializers.
     """
@@ -41,53 +41,31 @@ class DisciplineViewSet(viewsets.ModelViewSet):
         """
         if getattr(self, "swagger_fake_view", False):
             return Discipline.objects.none()
-        queryset = (
-            Discipline.objects.filter(Q(released=True) & Q(creator_is_admin=True))
-            .order_by("order")
-            .annotate(
-                total_training_sets=Count(
-                    "training_sets", filter=Q(training_sets__released=True)
+        if 'group_id' in self.kwargs:
+            groups = self.kwargs["group_id"].split("&")
+            queryset = (
+                Discipline.objects.filter(
+                    Q(released=True) & (Q(creator_is_admin=True) | Q(created_by__in=groups))
+                )
+                .order_by("order")
+                .annotate(
+                    total_training_sets=Count(
+                        "training_sets", filter=Q(training_sets__released=True)
+                    )
                 )
             )
-        )
-        return queryset
-
-
-class DisciplineGroupViewSet(viewsets.ModelViewSet):
-    """
-    Defines a view set for the Discipline module filtered by user groups.
-    Inherits from `viewsets.ModelViewSet` and defines queryset
-    and serializers.
-    """
-
-    queryset = Discipline.objects.all()
-    serializer_class = DisciplineSerializer
-    http_method_names = ["get"]
-
-    def get_queryset(self):
-        """
-        Defining custom queryset
-
-        :param self: A handle to the :class:`DisciplineGroupViewSet`
-        :type self: class
-
-        :return: (filtered) queryset
-        :rtype: QuerySet
-        """
-        if getattr(self, "swagger_fake_view", False):
-            return Discipline.objects.none()
-        groups = self.kwargs["group_id"].split("&")
-        queryset = (
-            Discipline.objects.filter(
-                Q(released=True) & (Q(creator_is_admin=True) | Q(created_by__in=groups))
-            )
-            .order_by("order")
-            .annotate(
-                total_training_sets=Count(
-                    "training_sets", filter=Q(training_sets__released=True)
+        else:
+                queryset = (
+                    Discipline.objects.filter(
+                        Q(released=True) & Q(creator_is_admin=True)
+                    )
+                    .order_by("order")
+                    .annotate(
+                        total_training_sets=Count(
+                            "training_sets", filter=Q(training_sets__released=True)
+                        )
+                    )
                 )
-            )
-        )
         return queryset
 
 

--- a/src/vocgui/views.py
+++ b/src/vocgui/views.py
@@ -27,7 +27,7 @@ class DisciplineViewSet(viewsets.ModelViewSet):
 
     queryset = Discipline.objects.all()
     serializer_class = DisciplineSerializer
-    http_method_names = ['get']
+    http_method_names = ["get"]
 
     def get_queryset(self):
         """
@@ -61,7 +61,7 @@ class DocumentViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = DocumentSerializer
-    http_method_names = ['get']
+    http_method_names = ["get"]
 
     def get_queryset(self):
         """
@@ -90,7 +90,7 @@ class TrainingSetViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = TrainingSetSerializer
-    http_method_names = ['get']
+    http_method_names = ["get"]
 
     def get_queryset(self):
         """

--- a/src/vocgui/views.py
+++ b/src/vocgui/views.py
@@ -55,17 +55,17 @@ class DisciplineViewSet(viewsets.ModelViewSet):
                 )
             )
         else:
-                queryset = (
-                    Discipline.objects.filter(
-                        Q(released=True) & Q(creator_is_admin=True)
-                    )
-                    .order_by("order")
-                    .annotate(
-                        total_training_sets=Count(
-                            "training_sets", filter=Q(training_sets__released=True)
-                        )
+            queryset = (
+                Discipline.objects.filter(
+                    Q(released=True) & Q(creator_is_admin=True)
+                )
+                .order_by("order")
+                .annotate(
+                    total_training_sets=Count(
+                        "training_sets", filter=Q(training_sets__released=True)
                     )
                 )
+            )
         return queryset
 
 


### PR DESCRIPTION
**Problems:**
It was not possible to manage different disciplines, training sets and documents according to multiple user groups.

**Proposed Changes:**
- Users only see the modules that belong to their group in django admin. If the user is superadmin, all elements will be displayed.
- added a group list_display element
- filtered the many to many selectors accordingly
- implemented a optional endpoint in order to fetch all disciplines of a specific group
- optional setting to provide a default user group
- adapted read me
- black formatting