### PR TITLE
Feature/has_audio has_image list display

### DIFF
--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -266,7 +266,8 @@ class DocumentAdmin(admin.ModelAdmin):
             return obj.created_by
         else:
             return None
-
+    creator_group.short_description = _("creator group")
+    creator_group.admin_order_field = 'created_by'
 
     # function to display if the document has an audio 
     def has_audio(self, obj):
@@ -276,6 +277,7 @@ class DocumentAdmin(admin.ModelAdmin):
             return False
     has_audio.boolean = True
     has_audio.short_description = _("audio")
+    has_audio.admin_order_field = 'audio' 
 
     # function to display if the document has atleast one image
     def has_image(self, obj):
@@ -285,8 +287,9 @@ class DocumentAdmin(admin.ModelAdmin):
             return False
     has_image.boolean = True
     has_image.short_description = _("image")
+    has_image.admin_order_field = 'document_image__document'
 
-    creator_group.short_description = _("creator group")
+   
 
     # only display models of the corresponding user group
     def get_queryset(self, request):

--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -5,6 +5,7 @@ specify autocomplete_fields, search_fields and nested modules
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
+from django.forms.fields import NullBooleanField
 from django.http.request import RAISE_ERROR
 
 from image_cropping import ImageCroppingMixin
@@ -224,6 +225,8 @@ class DocumentAdmin(admin.ModelAdmin):
         "word_type",
         "article",
         "related_training_set",
+        "has_audio",
+        "has_image",
         "creator_group",
         "creation_date",
     )
@@ -263,6 +266,25 @@ class DocumentAdmin(admin.ModelAdmin):
             return obj.created_by
         else:
             return None
+
+
+    # function to display if the document has an audio 
+    def has_audio(self, obj):
+        if obj.audio:
+            return True
+        else:
+            return False
+    has_audio.boolean = True
+    has_audio.short_description = _("audio")
+
+    # function to display if the document has atleast one image
+    def has_image(self, obj):
+        if DocumentImage.objects.all().filter(document = obj):
+            return True
+        else:
+            return False
+    has_image.boolean = True
+    has_image.short_description = _("image")
 
     creator_group.short_description = _("creator group")
 


### PR DESCRIPTION
### Problem: 
- There is no overview for vocabulary with missing files (audio/image)

### Solution: partly solves #158 
- Added has_image and has_audio to document list display 
- Implemented ordering when clicking on audio/image/creatorgroup in vocabulary overview