### PR TITLE
Feature/document image preview

### DIFF
--- a/src/vocgui/admin.py
+++ b/src/vocgui/admin.py
@@ -201,6 +201,8 @@ class DocumentImageAdmin(admin.StackedInline):
 
     model = DocumentImage
     search_fields = ["name"]
+    fields = ['name', 'image', 'image_tag']
+    readonly_fields = ['image_tag']
     autocomplete_fields = ["document"]
     insert_after = "autocomplete_fields"
     extra = 0

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -237,7 +237,9 @@ class DocumentImage(models.Model):
     )
 
     def image_tag(self):
-        return mark_safe('<img src="/media/%s" width="330" height="240"/>' % (self.image))
+        if self.image:
+            return mark_safe('<img src="/media/%s" width="330" height="240"/>' % (self.image))
+        return ""
     image_tag.short_description = ''
 
     def save_original_img(self):

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -43,7 +43,6 @@ class Static:
     # maximum (width, height) of images
     img_size = (1024, 768)
 
-
     # letters that should be converted
     replace_dict = {
         "Ä": "Ae",
@@ -145,7 +144,6 @@ class Document(models.Model):
         max_length=255, null=True, blank=True, verbose_name=_("created by")
     )
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
-    plural_article = models.BooleanField(default=False)
 
     @property
     def converted(self, content_type="audio/mpeg"):
@@ -325,7 +323,6 @@ class AlternativeWord(models.Model):
         default="",
         verbose_name=_("article"),
     )
-    plural_article = models.BooleanField(default=False)
     document = models.ForeignKey(
         Document, on_delete=models.CASCADE, related_name="alternatives"
     )

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -13,6 +13,7 @@ from PIL import Image, ImageFilter
 from pydub import AudioSegment
 from django.core.files import File
 from django.utils.translation import ugettext_lazy as _
+from django.utils.html import mark_safe
 from .validators import (
     validate_file_extension,
     validate_file_size,
@@ -41,6 +42,7 @@ class Static:
     blurr_radius = 30
     # maximum (width, height) of images
     img_size = (1024, 768)
+
 
     # letters that should be converted
     replace_dict = {
@@ -143,6 +145,7 @@ class Document(models.Model):
         max_length=255, null=True, blank=True, verbose_name=_("created by")
     )
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
+    plural_article = models.BooleanField(default=False)
 
     @property
     def converted(self, content_type="audio/mpeg"):
@@ -235,6 +238,11 @@ class DocumentImage(models.Model):
         Document, on_delete=models.CASCADE, related_name="document_image"
     )
 
+    def image_tag(self):
+            return mark_safe('<img src="/media/%s" width="330" height="240"/>' % (self.image))
+
+    image_tag.short_description = ''
+
     def save_original_img(self):
         """
         Function to save rough image with '_original' extension
@@ -317,6 +325,7 @@ class AlternativeWord(models.Model):
         default="",
         verbose_name=_("article"),
     )
+    plural_article = models.BooleanField(default=False)
     document = models.ForeignKey(
         Document, on_delete=models.CASCADE, related_name="alternatives"
     )

--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -237,8 +237,7 @@ class DocumentImage(models.Model):
     )
 
     def image_tag(self):
-            return mark_safe('<img src="/media/%s" width="330" height="240"/>' % (self.image))
-
+        return mark_safe('<img src="/media/%s" width="330" height="240"/>' % (self.image))
     image_tag.short_description = ''
 
     def save_original_img(self):


### PR DESCRIPTION
### Problem
- no image preview displayed in admin

### Solution fixes #131 
- implemented a method image_tag in model DocumentImage which returns the current image as html img
- added image_tag to DocumentImageAdmin