### PR TITLE
Custom icons, tiff support & improved public upload

### DIFF
--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -224,9 +224,10 @@ class DocumentImage(models.Model):
 
     def image_tag(self):
         if self.image and self.image.storage.exists(self.image.name):
-            return mark_safe(
-                '<img src="/media/%s" width="330" height="240"/>' % (self.image)
-            )
+            if ".png" in self.image.name or ".jpg" in self.image.name:
+                return mark_safe(
+                    '<img src="/media/%s" width="330" height="240"/>' % (self.image)
+                )
         return ""
 
     image_tag.short_description = ""

--- a/src/voctrainer/settings.py
+++ b/src/voctrainer/settings.py
@@ -153,6 +153,13 @@ JAZZMIN_SETTINGS = {
     "language_chooser": True,
     "custom_css": "css/main.css",
     "custom_js": "js/scripts.css",
+    "icons": {
+        "auth.user": "fas fa-user-edit",
+        "auth.Group": "fas fa-users",
+        "vocgui.Discipline": "fas fa-book",
+        "vocgui.TrainingSet": "fas fa-stream",
+        "vocgui.Document": "fab fa-amilia",
+    },
 }
 
 JAZZMIN_UI_TWEAKS = {


### PR DESCRIPTION
Solved issues:
- #133: custom icons for disciplines, training sets and documents by adapting the corresponding jazzmin settings
- #171: excluded `.tiff` files from image preview since they can not (easily) be displayed in an `image` node