### PR TITLE
add alt words to str representation of document

### DIFF
--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -19,7 +19,7 @@ from .validators import (
     validate_file_size,
     validate_multiple_extensions,
 )
-from .utils import create_ressource_path
+from .utils import create_ressource_path, document_to_string
 
 
 class Static:
@@ -164,7 +164,7 @@ class Document(models.Model):
         super(Document, self).save(*args, **kwarg)
 
     def __str__(self):
-        return "(" + self.get_article_display() + ") " + self.word
+        return document_to_string(self)
 
     class Meta:
         """

--- a/src/vocgui/utils.py
+++ b/src/vocgui/utils.py
@@ -12,3 +12,15 @@ def create_ressource_path(parent_dir, filename):
     Create a file path with a uuid and given parent directory.
     """
     return os.path.join(parent_dir, str(uuid.uuid1()) + pathlib.Path(filename).suffix)
+
+def document_to_string(doc):
+    """
+    Create string representation of a document object
+    """
+    alt_words = [str(elem) for elem in doc.alternatives.all()]
+    
+    if len(alt_words) > 0:
+        alt_words = "(" + ", ".join(alt_words) + ")"
+        return "(" + doc.get_article_display() + ") " + doc.word + " " + alt_words
+    else:
+        return "(" + doc.get_article_display() + ") " + doc.word


### PR DESCRIPTION
### Short description
Make many to many selector of training set module searchable for alternative words.


### Proposed changes
- implemented custom function in `utils.py` that includes alternative words in string representation of a document

### Resolved issues
Fixes: #111
