### PR TITLE
Upscale images that are smaller than final resolution

### DIFF
--- a/src/vocgui/models.py
+++ b/src/vocgui/models.py
@@ -264,8 +264,11 @@ class DocumentImage(models.Model):
             img_cropped.width > Static.img_size[0]
             or img_cropped.height > Static.img_size[1]
         ):
-            max_size = (Static.img_size[0], Static.img_size[1])
-            img_cropped.thumbnail(max_size)
+            img_cropped.thumbnail(Static.img_size)
+        elif (img_cropped.width / img_cropped.height) > (Static.img_size[0] / Static.img_size[1]):
+            img_cropped = img_cropped.resize((Static.img_size[0], round((Static.img_size[0] / img_cropped.width) * img_cropped.height)))
+        else:
+            img_cropped = img_cropped.resize((round(Static.img_size[1] / img_cropped.height) * img_cropped.width, Static.img_size[1]))
 
         offset = (
             ((img_blurr.width - img_cropped.width) // 2),


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
added resizing for images that are smaller than the final resolution

### Proposed changes
<!-- Describe this PR in more detail. -->

- resize the image to either width or height of final resolution (keep the ratio) depending on the width/height ratio of the image 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #168 
