### PR TITLE
adapt search for alternative words fixes #215

### DIFF
--- a/src/vocgui/admins/document_admin.py
+++ b/src/vocgui/admins/document_admin.py
@@ -15,7 +15,7 @@ class DocumentAdmin(admin.ModelAdmin):
 
     exclude = ("article_plural", "creator_is_admin")  # hide article_plural in admin
     readonly_fields = ("created_by",)
-    search_fields = ["word"]
+    search_fields = ["word", "alternatives__alt_word"]
     inlines = [DocumentImageAdmin, AlternativeWordAdmin]
     ordering = ["word", "creation_date"]
     list_display = (


### PR DESCRIPTION
### Short description
When searching for an alternative word in the document list display, the user now can see corresponding documents that are linked to the respective alternative word.

### Proposed changes
- adapted search fields of `documents` admin file

### Resolved issues
Fixes: #215
