### PR TITLE
fix word count, fixes #224

### DIFF
--- a/src/vocgui/views.py
+++ b/src/vocgui/views.py
@@ -250,7 +250,9 @@ class TrainingSetViewSet(viewsets.ModelViewSet):
             .order_by("order")
             .annotate(
                 total_documents=Count(
-                    "documents", filter=Q(documents__document_image__confirmed=True)
+                    "documents",
+                    filter=Q(documents__document_image__confirmed=True),
+                    distinct=True,
                 )
             )
         )


### PR DESCRIPTION
### Short description
When adding multiple images to a document, the word count will be displayed incorrectly. For Example, a training set containg 10 documents, 9 of them with only one image, but another one with two, will then result in the incorrect word count of 11.

### Proposed changes
- Adapt views.py so that only distinct documents are counted

### Resolved issues
Fixes: #224
