### PR TITLE
feature/display_trainingset_description fixes #231

### DIFF
--- a/src/vocgui/admins/training_set_admin.py
+++ b/src/vocgui/admins/training_set_admin.py
@@ -20,6 +20,7 @@ class TrainingSetAdmin(OrderedModelAdmin):
     form = TrainingSetForm
     list_display = (
         "title",
+        "description",
         "released",
         "related_disciplines",
         "creator_group",


### PR DESCRIPTION
### Short description
added training set field description to TrainingSetAdmin to display it in training set overview.

Fixes: #231 

Further changes:
in the future we should limit the max. characters of description to prevent it from overloading the overview.
![image](https://user-images.githubusercontent.com/75339002/136839235-a2ccd233-d65a-48c8-a847-3cbe3aeca686.png)
![image](https://user-images.githubusercontent.com/75339002/136839312-19b2e333-579b-47f7-86e2-a92fa40d72b4.png)

