### PR TITLE
feature/brighten_blur fixes #217

### DIFF
--- a/src/vocgui/models/document_image.py
+++ b/src/vocgui/models/document_image.py
@@ -1,5 +1,5 @@
 from django.db import models
-from PIL import Image, ImageFilter
+from PIL import Image, ImageFilter, ImageEnhance
 from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
@@ -73,6 +73,9 @@ class DocumentImage(models.Model):
 
         img_blurr = img_blurr.resize((Static.img_size[0], Static.img_size[1]))
         img_blurr = img_blurr.filter(ImageFilter.BoxBlur(Static.blurr_radius))
+
+        enhancer = ImageEnhance.Brightness(img_blurr)
+        img_blurr = enhancer.enhance(Static.brightning_factor)
 
         if (
             img_cropped.width > Static.img_size[0]

--- a/src/vocgui/models/static.py
+++ b/src/vocgui/models/static.py
@@ -31,6 +31,9 @@ class Static:
     # maximum (width, height) of images
     img_size = (1024, 768)
 
+    # brightning factor for box blurr (>1 = brighter, <1 = darker)
+    brightning_factor = 1.0
+
     # super admin group name
     admin_group = "Lunes"
 


### PR DESCRIPTION
### Short description
Used ImageEnhance from PIL to brighten the background blur in model document_image. The brightening depends on the variable Static.brightening_factor: 1.0 -> original, <1 -> darken, >1 -> brighten.

Brightening_factor currently set to 1.0 (no brightening).

Fixes: #217 

brightening factor 1.0 (original):
![image](https://user-images.githubusercontent.com/75339002/136950699-ad58c255-896e-4f36-93d0-2190fe2bbfc5.png)

brightening factor 1.5:
![image](https://user-images.githubusercontent.com/75339002/136950766-b8f1c17d-4b6a-41b5-a46f-73a33ad0b4fc.png)

brightening factor 2.0:
![image](https://user-images.githubusercontent.com/75339002/136950824-791b8a52-ab2e-49a4-b3ad-025061d6fe75.png)

