### PR TITLE
allow confirmed dummy only for superusers fixes #245

### DIFF
--- a/src/vocgui/admins/document_image_admin.py
+++ b/src/vocgui/admins/document_image_admin.py
@@ -11,26 +11,26 @@ class DocumentImageAdmin(admin.StackedInline):
 
     model = DocumentImage
     search_fields = ["name"]
-    fields = ["name", "image", "image_tag", "confirmed"]
+    fields = ["name", "image", "image_tag"]
+    superuser_fields = ["confirmed"]
     readonly_fields = ["image_tag"]
     autocomplete_fields = ["document"]
     insert_after = "autocomplete_fields"
     extra = 0
 
-    def get_form(self, request, obj=None, **kwargs):
-        """
-        Modify user form since normal users shouldn't
-        see a confirmed button. This is only neccessary
-        for superusers.
+    def get_fields(self, request, obj = None):
+        """Override djangos get_fields function
+        to add custom superuser fields to the
+        admin interface if the user has the corresponding
+        access rights.
 
-        :param request: current user request
+        :param request: current request
         :type request: django.http.request
-        :param obj: django model object, defaults to None
+        :param obj: [description], defaults to None
         :type obj: django.db.models, optional
-        :return: model form with adjustet fields
-        :rtype: ModelForm
+        :return: custom fields list
+        :rtype: list[str]
         """
-        self.exclude = []
-        if not request.user.is_superuser:
-            self.exclude.append("confirmed")
-        return super(DocumentImageAdmin, self.get_form(request, obj, **kwargs))
+        if request.user.is_superuser and self.superuser_fields:
+            return (self.fields or tuple()) + self.superuser_fields
+        return super(DocumentImageAdmin, self).get_fields(request, obj)


### PR DESCRIPTION
### Short description
Restrict the document admin view to only display the confirmed dummy if the user is super admin


### Proposed changes
- add a superuser_fields attribute to DocumentImageAdmin
- overwrite djangos get_fields function of DocumentImageAdmin to add superuser_fields to the fields attribute if the user has the respective access rights
-

### Resolved issues
Fixes: #245 
