### PR TITLE
fix permission issue for Lunes objects fixes #252 #253

### DIFF
--- a/src/vocgui/permissions.py
+++ b/src/vocgui/permissions.py
@@ -1,10 +1,6 @@
-from typing import get_args
 from rest_framework_api_key.permissions import BaseHasAPIKey
 from .models import GroupAPIKey
 from rest_framework import permissions
-from rest_framework_api_key.models import APIKey
-from django.contrib.auth.models import Group
-from django.db.models import Q
 from .utils import get_key
 
 
@@ -20,8 +16,8 @@ class VerifyGroupKey(permissions.AllowAny):
 
         :param request: http request
         :type request: HttpRequest
-        :param view: [description]
-        :type view: typing.Any
+        :param view: restframework view
+        :type view: viewsets.ModelViewSet
         :return: False if user doesn't send a API-key
         :rtype: bool
         """

--- a/src/vocgui/views/discipline_filtered_viewset.py
+++ b/src/vocgui/views/discipline_filtered_viewset.py
@@ -38,10 +38,12 @@ class DisciplineFilteredViewSet(viewsets.ModelViewSet):
         if getattr(self, "swagger_fake_view", False):
             return Discipline.objects.none()
         if "discipline_id" in self.kwargs:
-            group_id = Discipline.objects.filter(
+            discipline_infos = Discipline.objects.filter(
                 id=self.kwargs["discipline_id"]
-            ).values_list("created_by_id", flat=True)[0]
-            if group_id:
+            ).values_list("created_by_id", "creator_is_admin")
+            group_id = discipline_infos[0][0]
+            is_admin = discipline_infos[0][1]
+            if group_id and not is_admin:
                 check_group_object_permissions(self.request, group_id)
             queryset = get_filtered_discipline_queryset(self)
         elif "group_id" in self.kwargs:

--- a/src/vocgui/views/document_viewset.py
+++ b/src/vocgui/views/document_viewset.py
@@ -27,10 +27,12 @@ class DocumentViewSet(viewsets.ModelViewSet):
         """
         if getattr(self, "swagger_fake_view", False):
             return Document.objects.none()
-        group_id = TrainingSet.objects.filter(
+        training_set_infos = TrainingSet.objects.filter(
             id=self.kwargs["training_set_id"]
-        ).values_list("created_by_id", flat=True)[0]
-        if group_id:
+        ).values_list("created_by_id", "creator_is_admin")
+        group_id = training_set_infos[0][0]
+        is_admin = training_set_infos[0][1]
+        if group_id and not is_admin:
             check_group_object_permissions(self.request, group_id)
         queryset = (
             Document.objects.filter(

--- a/src/vocgui/views/group_viewset.py
+++ b/src/vocgui/views/group_viewset.py
@@ -5,10 +5,7 @@ from vocgui.serializers import GroupSerializer
 from vocgui.permissions import VerifyGroupKey
 from vocgui.models import GroupAPIKey
 from vocgui.utils import get_key
-from django.db.models import Q
 from django.core.exceptions import PermissionDenied
-from .utils import check_group_object_permissions
-
 
 class GroupViewSet(viewsets.ModelViewSet):
     """

--- a/src/vocgui/views/training_set_viewset.py
+++ b/src/vocgui/views/training_set_viewset.py
@@ -28,10 +28,12 @@ class TrainingSetViewSet(viewsets.ModelViewSet):
         """
         if getattr(self, "swagger_fake_view", False):
             return TrainingSet.objects.none()
-        group_id = Discipline.objects.filter(
+        discipline_infos = Discipline.objects.filter(
             id=self.kwargs["discipline_id"]
-        ).values_list("created_by_id", flat=True)[0]
-        if group_id:
+        ).values_list("created_by_id", "creator_is_admin")
+        group_id = discipline_infos[0][0]
+        is_admin = discipline_infos[0][1]
+        if group_id and not is_admin:
             check_group_object_permissions(self.request, group_id)
         queryset = (
             TrainingSet.objects.filter(

--- a/src/vocgui/views/utils.py
+++ b/src/vocgui/views/utils.py
@@ -7,7 +7,10 @@ from vocgui.models import GroupAPIKey
 
 
 def get_filtered_discipline_queryset(discipline_view_set):
-    """Filters
+    """Returns child disciplines belonging to the discipline id
+    of the passed discipline view set. Only released and non-empty
+    objects are returned. The number of training sets contained by
+    a child is annotated as well.
 
     :param discipline_view_set: A handle to the :class:`DisciplineViewSet`
     :type discipline_view_set: class


### PR DESCRIPTION
### Short description
Removes the typing module since its `get_args` method requires Python 3.8.
Furthermore the `discipline`, `training set` and `document` views were adapted. Previously, accessing data created by superusers that belong to a user group (e.g. "Lunes") threw an error. A valid group API Key was required, even though Lunes objects should be freely accessible. 


### Proposed changes
- check in the above-mentioned views if the requested object was created by a superuser. If so, 'check_group_object_permissions` will not be called. Instead, the corresponding queryset will be returned.
- adapted `permissions.py` to provide Python 3.7 compatibility

### Resolved issues
Fixes: #252 #253
