### PR TITLE
remove default auth classes from settings

### DIFF
--- a/src/voctrainer/settings.py
+++ b/src/voctrainer/settings.py
@@ -48,10 +48,6 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",
-    "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
-    ],
 }
 
 MIDDLEWARE = [


### PR DESCRIPTION
### Short description
This PR removes default authentication from `settings.py` since our endpoints are generally free to use and don't require login credentials. However, this seems to mess up our api key authentication system.


### Proposed changes
- remove respective variable in `settings.py`
