### PR TITLE
Enable optional trailing slash without redirect

### DIFF
--- a/src/vocgui/urls.py
+++ b/src/vocgui/urls.py
@@ -13,6 +13,15 @@ from drf_yasg import openapi
 from . import views
 
 
+class OptionalSlashRouter(routers.DefaultRouter):
+    """
+    Custom router to allow routes with and without trailing slash to work without redirects
+    """
+    def __init__(self):
+        super().__init__()
+        self.trailing_slash = "/?"
+
+
 # Schema view for swagger documentation
 schema_view = get_schema_view(
     openapi.Info(
@@ -26,8 +35,8 @@ schema_view = get_schema_view(
     public=True,
     permission_classes=(permissions.AllowAny,),
 )
-# Router for dynmaic url patterns
-router = routers.DefaultRouter()
+# Router for dynamic url patterns
+router = OptionalSlashRouter()
 router.register(
     r"disciplines(?:/(?P<group_id>[\d+&]+))?",
     views.DisciplineViewSet,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This might or might not fix some problems for the iOS app which can't handle redirects correctly.

### Proposed changes
<!-- Describe this PR in more detail. -->
Add an `OptionalSlashRouter` with an optional trailing slash
(Taken from https://stackoverflow.com/a/46163870)

