### PR TITLE
fix: Break line in description field if word is too long

### DIFF
--- a/src/vocgui/admins/training_set_admin.py
+++ b/src/vocgui/admins/training_set_admin.py
@@ -20,6 +20,7 @@ class TrainingSetAdmin(OrderedModelAdmin):
     form = TrainingSetForm
     list_display = (
         "title",
+        "style_description_field",
         "released",
         "related_disciplines",
         "creator_group",

--- a/src/vocgui/models/training_set.py
+++ b/src/vocgui/models/training_set.py
@@ -50,7 +50,10 @@ class TrainingSet(OrderedModel):  # pylint: disable=R0903
         verbose_name = _("training set")
         verbose_name_plural = _("training sets")
 
-
     def style_description_field(self):
-        return format_html('<div style="overflow-wrap: break-word; max-width: 150px;" >{}</div>', self.description)
+        return format_html(
+            '<div style="overflow-wrap: break-word; max-width: 150px;" >{}</div>',
+            self.description,
+        )
+
     style_description_field.short_description = "description"

--- a/src/vocgui/models/training_set.py
+++ b/src/vocgui/models/training_set.py
@@ -3,6 +3,7 @@ from ordered_model.models import OrderedModel
 from django.contrib.auth.models import Group
 from django.db.models.deletion import CASCADE
 from django.utils.translation import ugettext_lazy as _
+from django.utils.html import format_html
 
 from .static import convert_umlaute_images
 from .document import Document
@@ -48,3 +49,8 @@ class TrainingSet(OrderedModel):  # pylint: disable=R0903
 
         verbose_name = _("training set")
         verbose_name_plural = _("training sets")
+
+
+    def style_description_field(self):
+        return format_html('<div style="overflow-wrap: break-word; max-width: 150px;" >{}</div>', self.description)
+    style_description_field.short_description = "description"


### PR DESCRIPTION
### Short description
Limit the description field to defined width, so the view does not break if long strings without spaces are entered

### Resolved issues
na
