### PR TITLE
custom key generator fixes  #268

### DIFF
--- a/src/vocgui/admins/group_api_key_admin.py
+++ b/src/vocgui/admins/group_api_key_admin.py
@@ -3,6 +3,7 @@ from rest_framework_api_key.admin import APIKeyModelAdmin
 
 
 class GroupAPIKeyAdmin(APIKeyModelAdmin):
+    exclude = ("objects",)
     list_display = [*APIKeyModelAdmin.list_display, "organization"]
     search_fields = [*APIKeyModelAdmin.search_fields, "organization"]
     list_per_page = 25

--- a/src/vocgui/models/group_api_key.py
+++ b/src/vocgui/models/group_api_key.py
@@ -1,10 +1,71 @@
+import typing
 from django.db import models
+from rest_framework_api_key.crypto import KeyGenerator
 from rest_framework_api_key.models import AbstractAPIKey
+from rest_framework_api_key.models import BaseAPIKeyManager
 from django.contrib.auth.models import Group
 from django.utils.translation import ugettext_lazy as _
+from vocgui.utils import get_random_key
+
+
+class CustomKeyGenerator(KeyGenerator):
+    """
+    Custom KeyGenerator that creates custom api keys, e.g. with a specific length or excluded characters.
+    """
+
+    def __init__(
+        self,
+        prefix_length: int = 3,
+        secret_key_length: int = 7,
+        excluded_chars: list = [],
+    ):
+        """Initialize KeyGenerator
+
+        :param prefix_length: length of prefix, defaults to 3
+        :type prefix_length: int, optional
+        :param secret_key_length: length of secret, defaults to 7
+        :type secret_key_length: int, optional
+        :param excluded_chars: list of characters that should be excluded (mixed dtypes are possible), defaults to []
+        :type excluded_chars: list, optional
+        """
+        super().__init__(
+            prefix_length=prefix_length, secret_key_length=secret_key_length
+        )
+        self.excluded_chars = excluded_chars
+
+    def get_prefix(self) -> str:
+        """Generate prefix
+
+        :return: Key prefix
+        :rtype: str
+        """
+        return get_random_key(self.prefix_length, self.excluded_chars)
+
+    def get_secret_key(self) -> str:
+        """Generate secret
+
+        :return: Key secret
+        :rtype: str
+        """
+        return get_random_key(self.secret_key_length, self.excluded_chars)
+
+
+class GroupAPIKeyManager(BaseAPIKeyManager):
+    """
+    Custom APIKeyManager that creates custom api keys, e.g. with a specific length or excluded characters.
+    """
+
+    key_generator = CustomKeyGenerator(
+        prefix_length=4, secret_key_length=10, excluded_chars=[1, 0, "I", "l", "o", "O"]
+    )
 
 
 class GroupAPIKey(AbstractAPIKey):
+    """
+    Model that handles api keys associated with a user group.
+    """
+
+    objects = GroupAPIKeyManager()
     organization = models.ForeignKey(
         Group,
         on_delete=models.CASCADE,

--- a/src/vocgui/tests/test_utils.py
+++ b/src/vocgui/tests/test_utils.py
@@ -2,11 +2,13 @@
 Tests for vocgui.utils files
 """
 
+import string
 from django.test import TestCase
 from vocgui.models import Document
 from vocgui.models.discipline import Discipline
 from vocgui.models.training_set import TrainingSet
 from vocgui.utils import (
+    get_random_key,
     document_to_string,
     get_child_count,
     create_ressource_path,
@@ -34,6 +36,13 @@ class TestUtils(TestCase):
             title="Werkzeug",
             parent=Discipline.objects.get(title="Handwerker:in"),
         )
+
+    def test_get_random_key(self):
+        excluded_chars = list(string.ascii_uppercase)
+        key = get_random_key(30, excluded_chars)
+        self.assertEqual(30, len(key))
+        for char in excluded_chars:
+            self.assertNotIn(char, key)
 
     def test_document_to_string(self):
         tiger = Document.objects.get(word="Hammer")

--- a/src/vocgui/utils.py
+++ b/src/vocgui/utils.py
@@ -4,7 +4,9 @@ A collection of helper methods and classes
 
 import os
 import uuid
+import string
 import pathlib
+from django.utils.crypto import get_random_string
 
 
 def create_ressource_path(parent_dir, filename):
@@ -18,6 +20,24 @@ def create_ressource_path(parent_dir, filename):
     :rtype: str
     """
     return os.path.join(parent_dir, str(uuid.uuid1()) + pathlib.Path(filename).suffix)
+
+
+def get_random_key(length: int = 10, excluded_chars: list = []) -> str:
+    """Auxiliary function that creates a random key based on latin letters and digits using
+    the passed length. Optionally, it is possible to exclude characters like l and 1.
+
+    :param length: key length, defaults to 10
+    :type length: int, optional
+    :param excluded_chars: list of characters to be excluded (mixed dtypes possible), defaults to []
+    :type excluded_chars: list, optional
+    :return: key
+    :rtype: str
+    """
+    choices = string.ascii_letters + string.digits
+    for char in excluded_chars:
+        choices = choices.replace(str(char), "")
+    key = get_random_string(length, choices)
+    return key
 
 
 def document_to_string(doc):


### PR DESCRIPTION
### Short description
This PR introduces a custom API-Key generator. It limits key length and excludes critical characters like 1, l or I.


### Proposed changes
-  create CustomKeyGenerator and include it in a custom GroupAPIKeyManager
-  helper function get_random_key that creates custom, but random strings 

### Resolved issues
Fixes: #268
