### PR TITLE
Public upload: skip Allgemeine Grundlagen

### DIFF
--- a/src/vocgui/templates/public_upload.html
+++ b/src/vocgui/templates/public_upload.html
@@ -68,6 +68,7 @@
       $( document ).ready(function() {
 
         lunes_disciplines.forEach(function(element) {
+          if( element[1] === "Allgemeine Grundlagen") { continue; }
           $("#inputDiscipline").append(new Option(element[1], element[0]))
         });
 


### PR DESCRIPTION
### Short description
We do not want "Allgemeine Grundlagen" to show up in the public upload form.


### Proposed changes
Skip the element if the name is matched. This is a pretty dirty hack, but currently I do not see the need for a configurable list that can be changed in the back end.