### PR TITLE
Bug/training set filter, fixes #290 289 #192

### DIFF
--- a/src/vocgui/admins/document_admin.py
+++ b/src/vocgui/admins/document_admin.py
@@ -13,6 +13,9 @@ from vocgui.list_filter import (
 from vocgui.models import Static, DocumentImage
 
 
+SUPERUSER_ONLY_LIST_FILTERS = [ApprovedImageListFilter]
+
+
 class DocumentAdmin(admin.ModelAdmin):
     """
     Admin Interface to for the Document module.
@@ -178,3 +181,21 @@ class DocumentAdmin(admin.ModelAdmin):
         return obj.get_article_display()
 
     article_display.short_description = _("article")
+
+    def get_list_filter(self, request):
+        """Override djangos get_list_filter function
+        to remove specific list filters that are only relevant
+        for super users.
+
+        :param request: current request
+        :type request: django.http.request
+        :param obj: [description], defaults to None
+        :type obj: django.db.models, optional
+        :return: custom fields list
+        :rtype: list[str]
+        """
+        if request.user.is_superuser:
+            return self.list_filter
+        # remove filters that are only relevant for super users
+        filters = [f for f in self.list_filter if f not in SUPERUSER_ONLY_LIST_FILTERS]
+        return tuple(filters)

--- a/src/vocgui/admins/document_admin.py
+++ b/src/vocgui/admins/document_admin.py
@@ -91,7 +91,7 @@ class DocumentAdmin(admin.ModelAdmin):
         """
         qs = super(DocumentAdmin, self).get_queryset(request)
         if request.user.is_superuser:
-            return qs
+            return qs.filter(creator_is_admin=True)
         return qs.filter(
             created_by__in=request.user.groups.values_list("name", flat=True).distinct()
         )

--- a/src/vocgui/admins/training_set_admin.py
+++ b/src/vocgui/admins/training_set_admin.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
-from django.db.models import Q
+from django.db.models import Q, F
 from django.utils.translation import ugettext_lazy as _
 from mptt.admin import DraggableMPTTAdmin
 
 from vocgui.forms import TrainingSetForm
 from vocgui.models import Static, Document, Discipline
-from vocgui.list_filter import TrainingSetDisciplineListFilter
+from vocgui.list_filter import DisciplineListFilter
 
 
 class TrainingSetAdmin(DraggableMPTTAdmin):
@@ -19,7 +19,7 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
     readonly_fields = ("created_by",)
     search_fields = ["title"]
     form = TrainingSetForm
-    list_filter = (TrainingSetDisciplineListFilter,)
+    list_filter = (DisciplineListFilter,)
     actions = ["make_released", "make_unreleased"]
     list_per_page = 25
 
@@ -93,36 +93,29 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         if not request.user.is_superuser:
             form.base_fields["discipline"].queryset = (
                 Discipline.objects.filter(
-                    created_by__in=request.user.groups.all(),
-                    id__in=[
-                        obj.id
-                        for obj in Discipline.objects.all()
-                        if obj.get_descendant_count() == 0
-                    ],
+                    created_by__in=request.user.groups.all(), lft=F("rght") - 1
                 )
                 .order_by("title")
                 .order_by("level")
             )
-            form.base_fields["documents"].queryset = Document.objects.filter(
-                Q(created_by__in=[group.name for group in request.user.groups.all()])
-                | Q(
-                    id__in=[
-                        obj.id
-                        for obj in Document.objects.filter(creator_is_admin=True)
-                        if obj.is_valid()
-                    ]
+            form.base_fields["documents"].queryset = (
+                Document.objects.filter(
+                    Q(
+                        created_by__in=[
+                            group.name for group in request.user.groups.all()
+                        ]
+                    )
+                    | (
+                        Q(creator_is_admin=True, document_image__confirmed=True)
+                        & ~Q(audio="")
+                    )
                 )
-            ).order_by("word")
+                .distinct()
+                .order_by("word")
+            )
         else:
             form.base_fields["discipline"].queryset = (
-                Discipline.objects.filter(
-                    creator_is_admin=True,
-                    id__in=[
-                        obj.id
-                        for obj in Discipline.objects.all()
-                        if obj.get_descendant_count() == 0
-                    ],
-                )
+                Discipline.objects.filter(creator_is_admin=True, lft=F("rght") - 1)
                 .order_by("title")
                 .order_by("level")
             )

--- a/src/vocgui/admins/training_set_admin.py
+++ b/src/vocgui/admins/training_set_admin.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
-from mptt.admin import DraggableMPTTAdmin, TreeRelatedFieldListFilter
+from mptt.admin import DraggableMPTTAdmin
 from django.utils.translation import ugettext_lazy as _
 
 from vocgui.forms import TrainingSetForm
 from vocgui.models import Static, Document, Discipline
+from vocgui.list_filter import TrainingSetDisciplineListFilter
 
 
 class TrainingSetAdmin(DraggableMPTTAdmin):
@@ -17,7 +18,7 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
     readonly_fields = ("created_by",)
     search_fields = ["title"]
     form = TrainingSetForm
-    list_filter = (("discipline", TreeRelatedFieldListFilter),)
+    list_filter = (TrainingSetDisciplineListFilter, )
     actions = ["make_released", "make_unreleased"]
     list_per_page = 25
 

--- a/src/vocgui/list_filter.py
+++ b/src/vocgui/list_filter.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
+from django.db.models import F
 from django.utils.translation import ugettext_lazy as _
 from .models import Discipline, TrainingSet
 
 
-class DocumentDisciplineListFilter(admin.SimpleListFilter):
+class DisciplineListFilter(admin.SimpleListFilter):
     """
-    Filter for disciplines within document list display.
+    Generic Filter for models that have a direct relationship to disciplines.
     Inherits from `admin.SimpleListFilter`.
     """
 
@@ -30,25 +31,47 @@ class DocumentDisciplineListFilter(admin.SimpleListFilter):
         """
         list_of_disciplines = []
 
+        # Verify that only disciplines are displayed that actually can contain training sets
+        queryset = Discipline.objects.filter(lft=F("rght") - 1)
+
         if request.user.is_superuser:
-            queryset = Discipline.objects.all().filter(creator_is_admin=True)
+            queryset = queryset.filter(creator_is_admin=True)
         else:
-            queryset = Discipline.objects.all().filter(
-                created_by__in=request.user.groups.all()
-            )
+            queryset = queryset.filter(created_by__in=request.user.groups.all())
         for discipline in queryset:
-            if discipline.parent:
-                ancestors = [
-                    node.title
-                    for node in discipline.parent.get_ancestors(include_self=True)
-                ]
-                ancestors.append(discipline.title)
-                list_of_disciplines.append(
-                    (str(discipline.id), " \u2794 ".join(ancestors))
+            list_of_disciplines.append(
+                (
+                    str(discipline.id),
+                    " \u2794 ".join(
+                        map(str, discipline.get_ancestors(include_self=True))
+                    ),
                 )
-            else:
-                list_of_disciplines.append((str(discipline.id), str(discipline)))
+            )
         return sorted(list_of_disciplines, key=lambda tp: tp[1])
+
+    def queryset(self, request, queryset):
+        """
+        Returns the filtered queryset based on the value
+        provided in the query string and retrievable via
+        `self.value()`.
+
+        :param request: current user request
+        :type request: django.http.request
+        :param queryset: current queryset
+        :type queryset: QuerySet
+        :return: filtered queryset based on the value provided in the query string
+        :rtype: QuerySet
+        """
+        if self.value():
+            return queryset.filter(discipline__id=self.value()).distinct()
+        return queryset
+
+
+class DocumentDisciplineListFilter(DisciplineListFilter):
+    """
+    Filter for disciplines within document list display.
+    Inherits from `admin.SimpleListFilter`.
+    """
 
     def queryset(self, request, queryset):
         """
@@ -229,70 +252,4 @@ class AssignedListFilter(admin.SimpleListFilter):
                 return queryset.filter(training_sets__isnull=True).distinct()
             if int(self.value()) == 1:
                 return queryset.filter(training_sets__isnull=False).distinct()
-        return queryset
-
-
-class TrainingSetDisciplineListFilter(admin.SimpleListFilter):
-    """
-    Filter for disciplines within training set list display.
-    Inherits from `admin.SimpleListFilter`.
-    """
-
-    title = _("disciplines")
-
-    # Parameter for the filter that will be used in the URL query.
-    parameter_name = "disciplines"
-
-    def lookups(self, request, model_admin):
-        """
-        Defining look up values that can be seen in the admin
-        interface. Returns tuples: the first element is a coded
-        value, whereas the second one is human-readable.
-
-        :param request: current user request
-        :type request: django.http.request
-        :param model_admin: admin of current model
-        :type model_admin: ModelAdmin
-        :return: list of tuples containing id and title of each discipline
-        :rtype: list
-        """
-        list_of_disciplines = []
-
-        if request.user.is_superuser:
-            queryset = Discipline.objects.all().filter(creator_is_admin=True)
-        else:
-            queryset = Discipline.objects.all().filter(
-                created_by__in=request.user.groups.all()
-            )
-        for discipline in queryset:
-            if discipline.parent:
-                ancestors = [
-                    node.title
-                    for node in discipline.parent.get_ancestors(include_self=True)
-                ]
-                ancestors.append(discipline.title)
-                list_of_disciplines.append(
-                    (str(discipline.id), " \u2794 ".join(ancestors))
-                )
-            else:
-                list_of_disciplines.append((str(discipline.id), str(discipline)))
-        return sorted(list_of_disciplines, key=lambda tp: tp[1])
-
-    def queryset(self, request, queryset):
-        """
-        Returns the filtered queryset based on the value
-        provided in the query string and retrievable via
-        `self.value()`.
-
-        :param request: current user request
-        :type request: django.http.request
-        :param queryset: current queryset
-        :type queryset: QuerySet
-        :return: filtered queryset based on the value provided in the query string
-        :rtype: QuerySet
-        """
-        if self.value():
-            return queryset.filter(
-                training_sets__discipline__id=self.value()
-            ).distinct()
         return queryset

--- a/src/vocgui/list_filter.py
+++ b/src/vocgui/list_filter.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
-from .models import Discipline, DocumentImage, TrainingSet, Document
+from .models import Discipline, TrainingSet
 
 
 class DocumentDisciplineListFilter(admin.SimpleListFilter):
@@ -229,4 +229,70 @@ class AssignedListFilter(admin.SimpleListFilter):
                 return queryset.filter(training_sets__isnull=True).distinct()
             if int(self.value()) == 1:
                 return queryset.filter(training_sets__isnull=False).distinct()
+        return queryset
+
+
+class TrainingSetDisciplineListFilter(admin.SimpleListFilter):
+    """
+    Filter for disciplines within training set list display.
+    Inherits from `admin.SimpleListFilter`.
+    """
+
+    title = _("disciplines")
+
+    # Parameter for the filter that will be used in the URL query.
+    parameter_name = "disciplines"
+
+    def lookups(self, request, model_admin):
+        """
+        Defining look up values that can be seen in the admin
+        interface. Returns tuples: the first element is a coded
+        value, whereas the second one is human-readable.
+
+        :param request: current user request
+        :type request: django.http.request
+        :param model_admin: admin of current model
+        :type model_admin: ModelAdmin
+        :return: list of tuples containing id and title of each discipline
+        :rtype: list
+        """
+        list_of_disciplines = []
+
+        if request.user.is_superuser:
+            queryset = Discipline.objects.all().filter(creator_is_admin=True)
+        else:
+            queryset = Discipline.objects.all().filter(
+                created_by__in=request.user.groups.all()
+            )
+        for discipline in queryset:
+            if discipline.parent:
+                ancestors = [
+                    node.title
+                    for node in discipline.parent.get_ancestors(include_self=True)
+                ]
+                ancestors.append(discipline.title)
+                list_of_disciplines.append(
+                    (str(discipline.id), " \u2794 ".join(ancestors))
+                )
+            else:
+                list_of_disciplines.append((str(discipline.id), str(discipline)))
+        return sorted(list_of_disciplines, key=lambda tp: tp[1])
+
+    def queryset(self, request, queryset):
+        """
+        Returns the filtered queryset based on the value
+        provided in the query string and retrievable via
+        `self.value()`.
+
+        :param request: current user request
+        :type request: django.http.request
+        :param queryset: current queryset
+        :type queryset: QuerySet
+        :return: filtered queryset based on the value provided in the query string
+        :rtype: QuerySet
+        """
+        if self.value():
+            return queryset.filter(
+                training_sets__discipline__id=self.value()
+            ).distinct()
         return queryset

--- a/src/vocgui/models/document.py
+++ b/src/vocgui/models/document.py
@@ -80,6 +80,13 @@ class Document(models.Model):
         os.remove(new_path)
         return converted_audiofile
 
+    def is_valid(self):
+        if self.audio is None:
+            return False
+        if self.document_image.filter(confirmed=True).count() > 0:
+            return True
+        return False
+
     def save(self, *args, **kwargs):
         """Overwrite djangos save function to convert audio files
         to mp3 format (orignal file is saved as backup).

--- a/src/vocgui/models/document.py
+++ b/src/vocgui/models/document.py
@@ -80,13 +80,6 @@ class Document(models.Model):
         os.remove(new_path)
         return converted_audiofile
 
-    def is_valid(self):
-        if self.audio is None:
-            return False
-        if self.document_image.filter(confirmed=True).count() > 0:
-            return True
-        return False
-
     def save(self, *args, **kwargs):
         """Overwrite djangos save function to convert audio files
         to mp3 format (orignal file is saved as backup).

--- a/src/vocgui/views/discipline_viewset.py
+++ b/src/vocgui/views/discipline_viewset.py
@@ -31,7 +31,7 @@ class DisciplineViewSet(viewsets.ModelViewSet):
             return None
         else:
             queryset = Discipline.objects.filter(
-                Q(released=True) & Q(creator_is_admin=True) & Q(lft=F("rght") - 1)
+                released=True, creator_is_admin=True, lft=F("rght") - 1
             ).annotate(
                 total_training_sets=Count(
                     "training_sets", filter=Q(training_sets__released=True)

--- a/src/vocgui/views/discipline_viewset.py
+++ b/src/vocgui/views/discipline_viewset.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from django.db.models import Count, Q
+from django.db.models import F, Q, Count
 from vocgui.models import Discipline
 from vocgui.serializers import DisciplineSerializer
 
@@ -31,15 +31,7 @@ class DisciplineViewSet(viewsets.ModelViewSet):
             return None
         else:
             queryset = Discipline.objects.filter(
-                Q(released=True)
-                & Q(creator_is_admin=True)
-                & Q(
-                    id__in=[
-                        obj.id
-                        for obj in Discipline.objects.all()
-                        if obj.get_descendant_count() == 0
-                    ]
-                )
+                Q(released=True) & Q(creator_is_admin=True) & Q(lft=F("rght") - 1)
             ).annotate(
                 total_training_sets=Count(
                     "training_sets", filter=Q(training_sets__released=True)


### PR DESCRIPTION
### Short description
This PR implements a custom discipline filter for the training set list display. Along the way, I enabled user groups to add Lunes documents to their custom training sets and removed the `ApprovedImageListFilter` for user groups


### Proposed changes
- custom list filter since the `mptt tree filter` displays all disciplines in the database instead of filtering according to the user group
- adapt the `queryset` of the many-to-many selector within the training set admin interface
- overwrite django's `get_list_filter` method to remove `ApprovedImageListFilter` for user groups

### Resolved issues
Fixes: #289
Fixes: #290
Fixes: #192
