### PR TITLE
Add dark mode theme

### DIFF
--- a/src/vocgui/static/css/corporate_identity.css
+++ b/src/vocgui/static/css/corporate_identity.css
@@ -164,3 +164,38 @@
 .card-primary.card-outline {
     border-top: 3px solid #425bee;
 }
+
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+    :root {
+        /* Selected table row */
+        --selected-row: #2d2d4a;
+    }
+    body {
+        background-color: #282838;
+    }
+    .card {
+        background-color: #2d2d4a;
+    }
+    .table-striped thead tr,
+    .table-striped tbody tr:nth-of-type(even) {
+        background-color: #000e38;
+    }
+    .main-header,
+    .card-header,
+    .table-striped tbody tr:nth-of-type(odd) {
+        background-color: #47476e;
+    }
+    /* These classes might have to be changed if the accent color is changed to a different value than "navy" */
+    .accent-navy .btn-link,
+    .accent-navy .nav-tabs .nav-link,
+    .accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn) {
+        color: #8ba6fa;
+    }
+    .main-footer,
+    .accent-navy .btn-link:hover,
+    .accent-navy .nav-tabs .nav-link:hover,
+    .accent-navy a:not(.dropdown-item):not(.btn-app):not(.nav-link):not(.brand-link):not(.page-link):not(.btn):hover {
+        color: #c4e3ff;
+    }
+}

--- a/src/vocgui/static/css/overlay.css
+++ b/src/vocgui/static/css/overlay.css
@@ -81,3 +81,9 @@
     opacity: 0;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .overlay .overlay_content {
+    background-color: #282838;
+  }
+}

--- a/src/voctrainer/settings.py
+++ b/src/voctrainer/settings.py
@@ -171,6 +171,7 @@ JAZZMIN_UI_TWEAKS = {
     "brand_small_text": False,
     "brand_colour": "navbar-dark",
     "accent": "accent-navy",
+    "dark_mode_theme": "darkly",
     "navbar": "navbar-primary navbar-dark",
     "no_navbar_border": True,
     "navbar_fixed": False,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
When the user's browser is in dark mode, the "darkly" scheme will be used with a few custom modifications to keep the corporate identity design.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add "darkly" theme when browser is in dark mode
- Add a few custom background colors to match the general color scheme

![Screenshot 2022-03-13 at 17-06-23 Modulgruppe zur Änderung auswählen Lunes CMS](https://user-images.githubusercontent.com/16021269/158068574-731a5a79-66fe-45bc-90ec-95d70cc1165e.png)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #298
