### PR TITLE
Add API endpoint for all default words

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,17 @@ Content-Type: application/json
 
 ## List of documents
 List of available documents. A document is an item to be learned and consists of an image, multiple correct answers, and other details. If training set ID is provided as a parameter, the list will return only documents belonging to the training set. A valid API-Key may be required.
-### Request
+
+### List of documents by training set
+Get all documents that belong to a given training set
+
+#### Request
 ```http
 GET /api/documents/[TRAINING_SET_ID] HTTP/1.1
 Host: lunes.tuerantuer.org
 Content-Type: application/json
 ```
-### Response
+#### Response
 ```javascript
 [
     {
@@ -174,7 +178,44 @@ Content-Type: application/json
         "alternatives": [
             {
                 "alt_word": String,         // Alternative word
-                "article": Integer,         // ID of article (german grammer) belonging to the item (1:Der, 2:Die, 3:Das, 4:Die (Plural))
+                "article": Integer,         // ID of article (german grammar) belonging to the item (1:Der, 2:Die, 3:Das, 4:Die (Plural))
+            },
+            [...]   // repeats for available alternatives
+        ],
+        "document_image": [
+            {
+                "id": Integer,  //image id
+                "image": String //URL to image
+            },
+            [...]   // repeats for available images
+        ]
+    },
+    [...]   // repeats for available documents
+]
+```
+
+### All documents
+Get the list of all documents or retrieve a single record by appending the id of the word.
+
+#### Request
+```http
+GET /api/words/HTTP/1.1
+Host: lunes.tuerantuer.org
+Content-Type: application/json
+```
+#### Response
+```javascript
+[
+    {
+        "id": Integer,              // ID of training set
+        "word": String,             // primary correct answer
+        "article": Integer,         // ID of article (german grammar) belonging to the item (1:Der, 2:Die, 3:Das, 4:Die (Plural))
+        "audio": String,            // URL to (converted) audio file
+        "word_type": String,        // Word type of document: Nomen, Verb, Adjektiv
+        "alternatives": [
+            {
+                "alt_word": String,         // Alternative word
+                "article": Integer,         // ID of article (german grammar) belonging to the item (1:Der, 2:Die, 3:Das, 4:Die (Plural))
             },
             [...]   // repeats for available alternatives
         ],

--- a/src/vocgui/urls.py
+++ b/src/vocgui/urls.py
@@ -63,6 +63,7 @@ router.register(
 router.register(
     r"document_by_id/(?P<document_id>[0-9]+)", views.DocumentByIdViewSet, "documents"
 )
+router.register(r"words", views.WordViewSet, "words")
 router.register(
     r"group_info",
     views.GroupViewSet,

--- a/src/vocgui/views/__init__.py
+++ b/src/vocgui/views/__init__.py
@@ -5,6 +5,7 @@ from .document_viewset import DocumentViewSet
 from .group_viewset import GroupViewSet
 from .training_set_viewset import TrainingSetViewSet
 from .other_viewset import public_upload, redirect_view
+from .word_viewset import WordViewSet
 
 __all__ = [
     "DisciplineFilteredViewSet",

--- a/src/vocgui/views/word_viewset.py
+++ b/src/vocgui/views/word_viewset.py
@@ -1,0 +1,34 @@
+from rest_framework import viewsets
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from vocgui.models import Document
+from vocgui.serializers import DocumentSerializer
+
+
+class WordViewSet(viewsets.ModelViewSet):
+    """
+    Retrieve the list of all default words/documents or get a single record by appending the id of the requested word.
+    """
+
+    serializer_class = DocumentSerializer
+    http_method_names = ["get"]
+    authentication_classes = [SessionAuthentication, BasicAuthentication]
+
+    def get_queryset(self):
+        """
+        Get the queryset of words/documents
+
+        :return: The queryset of words
+        :rtype: ~django.db.models.query.QuerySet
+        """
+        if getattr(self, "swagger_fake_view", False):
+            return Document.objects.none()
+        return (
+            Document.objects.filter(
+                creator_is_admin=True,
+                document_image__confirmed=True,
+                training_sets__released=True,
+                training_sets__discipline__released=True,
+            )
+            .select_related()
+            .distinct()
+        )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add API endpoint for all default words

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add endpoint `api/words/` to get all default words (created by admins)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #304
