### PR TITLE
add nested training sets to discipline serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Content-Type: application/json
         "created_by": Integer           // Creator group id, null if created by admin 
         "total_training_sets": Integer  // # of training sets
         "total_discipline_children": Integer // # of child disciplines
+        "nested_training_sets": List[Integer] // training set ids of discipline and its child elements
     },
     [...]   // repeats for available disciplines
 ]
@@ -99,6 +100,7 @@ If the passed discipline id belongs to a custom user group (not to the Lunes adm
         "created_by": Integer           // Creator group id, null if created by admin 
         "total_training_sets": Integer  // # of training sets
         "total_discipline_children": Integer // # of child disciplines
+        "nested_training_sets": List[Integer] // training set ids of discipline and its child elements
     },
     [...]   // repeats for available disciplines
 ]
@@ -128,6 +130,7 @@ The default endpoint delivers all disciplines created by Lunes administrators.
         "created_by": Integer           // Creator group id, null if created by admin 
         "total_training_sets": Integer  // # of training sets
         "total_discipline_children": Integer // # of child disciplines
+        "nested_training_sets": List[Integer] // training set ids of discipline and its child elements
     },
     [...]   // repeats for available disciplines
 ]
@@ -251,7 +254,8 @@ Here's how to get the site running on your machine.
     - `pip install wheel`
 5. Install system dependencies: `cat requirements.system | xargs sudo apt-get install`
 6. Install project dependencies: `python3 setup.py develop`
-7. Set up Django and run the development server:
+7. Run `lunes-cms` in debug mode by executing `export LUNES_CMS_DEBUG=1` 
+8. Set up Django and run the development server:
     - `vocabulary-trainer migrate`
     - `vocabulary-trainer createsuperuser`
     - `vocabulary-trainer runserver`

--- a/src/vocgui/models/discipline.py
+++ b/src/vocgui/models/discipline.py
@@ -55,6 +55,20 @@ class Discipline(MPTTModel):
             or self.training_sets.filter(released=True).count() > 0
         )
 
+    def get_nested_training_sets(self):
+        """Returns a list of distinct training set ids that are part of this
+        disipline or one of its child elements.
+
+        :return: training set ids
+        :rtype: list(int)
+        """
+        training_sets = []
+        for child in self.get_descendants(include_self=True):
+            training_sets += child.training_sets.filter(released=True).values_list(
+                "id", flat=True
+            )
+        return set(training_sets)
+
     def __str__(self):
         """String representation of Discipline instance
 

--- a/src/vocgui/serializers.py
+++ b/src/vocgui/serializers.py
@@ -2,6 +2,8 @@ from django.contrib.auth.models import Group
 from django.templatetags.static import static
 from rest_framework import serializers
 
+from vocgui.models import training_set
+
 from .models import Discipline, TrainingSet, Document, AlternativeWord, DocumentImage
 from .utils import get_child_count
 
@@ -43,6 +45,9 @@ class DisciplineSerializer(FallbackIconSerializer):
     total_discipline_children = serializers.SerializerMethodField(
         "get_total_discipline_children"
     )
+    nested_training_sets = serializers.ListSerializer(
+        child=serializers.IntegerField(), source="get_nested_training_sets"
+    )
 
     class Meta:
         """
@@ -58,6 +63,7 @@ class DisciplineSerializer(FallbackIconSerializer):
             "created_by",
             "total_training_sets",
             "total_discipline_children",
+            "nested_training_sets",
         )
 
     def get_total_discipline_children(self, obj):


### PR DESCRIPTION
### Short description
This PR adds a `nested_training_set_ids` field to all `discipline` endpoints.


### Proposed changes
- add `get_nested_training_sets` method to ` discipline` model
- include `get_nested_training_sets` to `discipline` serializer

### Resolved issues
Fixes: #322 
