### PR TITLE
Remove tests from documentation

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -44,14 +44,11 @@ Reference
     :hidden:
 
     ref/lunes_cms
-    ref/tests
 
 * :doc:`ref/lunes_cms`: The main of the lunes-cms with the following sub-packages:
 
   - :doc:`ref/lunes_cms.cms`: This is the content management system for backend users which contains all database models, views, forms and templates.
   - :doc:`ref/lunes_cms.core`: This is the project's main app which contains all configuration files.
-
-* :doc:`ref/tests`: The tests for lunes-cms
 
 
 Indices and tables

--- a/tools/build_documentation.sh
+++ b/tools/build_documentation.sh
@@ -32,9 +32,6 @@ fi
 echo -e "Scanning Python source code and generating reStructuredText files from it..." | print_info
 sphinx-apidoc --no-toc --module-first -o "${DOC_SRC_REF_DIR}" "${PACKAGE_DIR}" "${PACKAGE_DIR}/cms/migrations"
 
-# Generate .rst files for tests module
-sphinx-apidoc --no-toc --module-first -o "${DOC_SRC_REF_DIR}" "tests"
-
 # Modify .rst files to remove unnecessary submodule- & subpackage-titles
 # At first, the 'find'-command returns all .rst files in the sphinx directory
 # The sed pattern replacement is divided into five stages explained below:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Apparently, readthedocs does not find the tests module and I can't find a way around it... let's remove it for now to fix the documentation build.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove tests from documentation
