### PR TITLE
image preview supports .png and .jpg regardless of extension case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#338](https://github.com/digitalfabrik/lunes-cms/issues/338) ] Support image preview regardless of extension case
+
 
 2022.5.0
 --------

--- a/lunes_cms/cms/models/document_image.py
+++ b/lunes_cms/cms/models/document_image.py
@@ -32,7 +32,7 @@ class DocumentImage(models.Model):
         :rtype: str
         """
         if self.image and self.image.storage.exists(self.image.name):
-            if ".png" in self.image.name or ".jpg" in self.image.name:
+            if any(self.image.name.lower().endswith(ext) for ext in [".jpg", ".png"]):
                 # The normal image tag for jpg and png previews
                 return mark_safe(
                     f'<img src="/media/{self.image}" width="330" height="240" />'


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
makes image preview work regardless of whether the file extension is upper or lower case

### Proposed changes
<!-- Describe this PR in more detail. -->
- Checks the file extension against a lower case version of the file name so that the case of the file extension doesn't matter.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #338
