### PR TITLE
Add `libpq-dev` to system prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Following packages are required before installing the project (install them with
 * python3.8 or higher
 * python3-pip
 * python3-venv
+* libpq-dev to compile psycopg2
 * gettext and pcregrep to use the translation features
 * ffmpeg for audio processing
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -15,6 +15,8 @@ Followings are required before installing the project (install them with your ma
 * `git <https://git-scm.com/>`_
 * `python3.8 <https://www.python.org/downloads/release/python-380/>`_ or higher
 * `python3-pip <https://packages.ubuntu.com/search?keywords=python3-pip>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__) / `python-pip <https://www.archlinux.de/packages/extra/x86_64/python-pip>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)
+* `python3-venv <https://docs.python.org/3/library/venv.html>`__
+* `libpq-dev <https://www.postgresql.org/docs/9.5/libpq.html>`__ to compile `psycopg2 <https://www.psycopg.org/docs/install.html#build-prerequisites>`__
 * `gettext <https://www.gnu.org/software/gettext/>`_ and `pcregrep <https://pcre.org/original/doc/html/pcregrep.html>`_ to use the translation features
 * `ffmpeg <https://ffmpeg.org/>`_ for audio processing
 

--- a/docs/src/prod-server.rst
+++ b/docs/src/prod-server.rst
@@ -21,7 +21,7 @@ System requirements
 
     2. Install system requirements::
 
-        sudo apt -y install python3-venv python3-pip ffmpeg
+        sudo apt -y install python3-venv python3-pip libpq-dev ffmpeg
 
 
 Lunes CMS Package

--- a/lunes_cms/README.md
+++ b/lunes_cms/README.md
@@ -19,7 +19,10 @@ Following packages are required before installing the project (install them with
 
 * python3.8 or greater
 * python3-pip
+* python3-venv
 * ffmpeg
+* libpq-dev
+* [PostgreSQL](https://www.postgresql.org/) database server
 * [Apache2](https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/modwsgi/) server with `mod_wsgi`
 
 ### Installation

--- a/requirements.system
+++ b/requirements.system
@@ -1,3 +1,6 @@
+python3-pip
+python3-venv
+libpq-dev
 ffmpeg
 gettext
 pcregrep

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -24,6 +24,11 @@ if [[ ! -x "$(command -v pip3)" ]]; then
     echo "Pip for Python3 is not installed. Please install python3-pip manually and run this script again."  | print_error
     exit 1
 fi
+# Check if prerequisite for psycopg2 is installed
+if [[ ! -x "$(command -v pg_config)" ]]; then
+    echo "The command pg_config is not available. Please install libpq-dev manually and run this script again."  | print_error
+    exit 1
+fi
 # Check if nc (netcat) is installed
 if [[ ! -x "$(command -v nc)" ]]; then
     echo "Netcat is not installed. Please install it manually and run this script again."  | print_error


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
`libpq-dev` is required to compile `psycopg2` which wasn't documented.
