### PR TITLE
Add icon preview for disciplines and training sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#337](https://github.com/digitalfabrik/lunes-cms/issues/337) ] Remove image names
 * [ [#211](https://github.com/digitalfabrik/lunes-cms/issues/211) ] Add feedback endpoint to API
 * [ [#346](https://github.com/digitalfabrik/lunes-cms/issues/346) ] Add bulk action to mark feedback as read
+* [ [#317](https://github.com/digitalfabrik/lunes-cms/issues/317) ] Add icon preview for disciplines and training sets
 
 
 2022.6.0

--- a/lunes_cms/cms/admins/discipline_admin.py
+++ b/lunes_cms/cms/admins/discipline_admin.py
@@ -14,8 +14,16 @@ class DisciplineAdmin(DraggableMPTTAdmin):
     Inheriting from `mptt.admin.DraggableMPTTAdmin`.
     """
 
-    exclude = ("creator_is_admin",)
-    readonly_fields = ("created_by",)
+    fields = [
+        "released",
+        "title",
+        "description",
+        "icon",
+        "image_tag",
+        "parent",
+        "created_by",
+    ]
+    readonly_fields = ["created_by", "image_tag"]
     search_fields = ["title"]
     actions = ["delete_selected", "make_released", "make_unreleased"]
     list_per_page = 25
@@ -151,3 +159,6 @@ class DisciplineAdmin(DraggableMPTTAdmin):
             return None
 
     creator_group.short_description = _("creator group")
+
+    class Media:
+        js = ("js/image_preview.js",)

--- a/lunes_cms/cms/admins/training_set_admin.py
+++ b/lunes_cms/cms/admins/training_set_admin.py
@@ -20,7 +20,17 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
     """
 
     exclude = ("creator_is_admin",)
-    readonly_fields = ("created_by",)
+    fields = [
+        "released",
+        "title",
+        "description",
+        "icon",
+        "image_tag",
+        "documents",
+        "discipline",
+        "created_by",
+    ]
+    readonly_fields = ["created_by", "image_tag"]
     search_fields = ["title"]
     form = TrainingSetForm
     list_filter = (DisciplineListFilter,)
@@ -267,3 +277,6 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
             return None
 
     creator_group.short_description = _("creator group")
+
+    class Media:
+        js = ("js/image_preview.js",)

--- a/lunes_cms/cms/models/discipline.py
+++ b/lunes_cms/cms/models/discipline.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from mptt.models import MPTTModel, TreeForeignKey
 
-from ..utils import get_child_count
+from ..utils import get_child_count, get_image_tag
 from .feedback import Feedback
 from .static import convert_umlaute_images
 
@@ -71,6 +71,17 @@ class Discipline(MPTTModel):
                 "id", flat=True
             )
         return set(training_sets)
+
+    def image_tag(self):
+        """
+        Image thumbnail to display a preview of the icon
+
+        :return: img HTML tag to display an image thumbnail
+        :rtype: str
+        """
+        return get_image_tag(self.icon)
+
+    image_tag.short_description = ""
 
     def __str__(self):
         """String representation of Discipline instance

--- a/lunes_cms/cms/models/document_image.py
+++ b/lunes_cms/cms/models/document_image.py
@@ -1,9 +1,9 @@
 from django.db import models
-from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from PIL import Image, ImageFilter
 
+from ..utils import get_image_tag
 from ..validators import validate_multiple_extensions
 from .static import Static, convert_umlaute_images
 from .document import Document
@@ -24,23 +24,14 @@ class DocumentImage(models.Model):
     confirmed = models.BooleanField(default=True, verbose_name="confirmed")
 
     def image_tag(self):
-        """Image thumbnail to display a preview of a image in the editing section
+        """
+        Image thumbnail to display a preview of a image in the editing section
         of the DocumentImage admin.
 
         :return: img HTML tag to display an image thumbnail
         :rtype: str
         """
-        if self.image and self.image.storage.exists(self.image.name):
-            if any(self.image.name.lower().endswith(ext) for ext in [".jpg", ".png"]):
-                # The normal image tag for jpg and png previews
-                return mark_safe(
-                    f'<img src="/media/{self.image}" width="330" height="240" />'
-                )
-        else:
-            # The dummy image tag for new files which are to be uploaded
-            return mark_safe('<img src="" width="330" height="auto" class="hidden" />')
-        # Empty tag for image types that cannot be previewed
-        return ""
+        return get_image_tag(self.image)
 
     image_tag.short_description = ""
 

--- a/lunes_cms/cms/models/training_set.py
+++ b/lunes_cms/cms/models/training_set.py
@@ -7,6 +7,7 @@ from django.db.models.deletion import CASCADE
 from django.utils.translation import ugettext_lazy as _
 from django.utils.html import format_html
 
+from ..utils import get_image_tag
 from .feedback import Feedback
 from .static import convert_umlaute_images
 from .document import Document
@@ -48,6 +49,17 @@ class TrainingSet(MPTTModel):  # pylint: disable=R0903
         verbose_name=_("parent"),
     )
     feedback = GenericRelation(Feedback)
+
+    def image_tag(self):
+        """
+        Image thumbnail to display a preview of the icon
+
+        :return: img HTML tag to display an image thumbnail
+        :rtype: str
+        """
+        return get_image_tag(self.icon)
+
+    image_tag.short_description = ""
 
     def __str__(self):
         """String representation of TrainingSet instance

--- a/lunes_cms/cms/static/js/image_preview.js
+++ b/lunes_cms/cms/static/js/image_preview.js
@@ -2,37 +2,46 @@
  * Function to preview a document image before it's uploaded
 */
 function previewImage(event){
-  if (event.target.name.endsWith("-image")) {
-    // Get file which is to be uploaded
-    let file = event.target.files[0];
-    // Get image tag
-    let img = $(event.target).closest(".card-body").find(".field-image_tag").find("img")[0];
-    // If the file is set and is either a jpg or png, update the preview
-    if (file && ["image/jpg", "image/jpeg", "image/png"].includes(file.type)){
-      let reader = new FileReader();
-      reader.onload = function(){
-        $(img).attr("src", reader.result);
-        $(img).attr("height", "auto");
-        $(img).removeClass("hidden");
-      }
-      reader.readAsDataURL(file);
-    } else {
-      // Otherwise, clear the preview and hide the image
-      $(img).attr("src", "");
-      $(img).addClass("hidden");
+  // Get file which is to be uploaded
+  let file;
+  if (event.target.files) {
+    file = event.target.files[0];
+  }
+  // Get image tag
+  let img = $(event.target).closest(".card-body").find(".field-image_tag").find("img")[0];
+  // If the file is set and is either a jpg or png, update the preview
+  if (file && ["image/jpg", "image/jpeg", "image/png"].includes(file.type)) {
+    let reader = new FileReader();
+    reader.onload = function(){
+      $(img).attr("src", reader.result);
+      $(img).attr("height", "auto");
+      $(img).removeClass("hidden");
     }
-  } else if (event.target.name.endsWith("DELETE")) {
-    // If the deletion checkbox is activated, clear the file field and the preview
-    if (event.target.checked) {
-      let fileInput = $(event.target).closest(".card").find("input[name^='document_image-'][name$='-image']")[0];
-      fileInput.value = "";
-      $(fileInput).trigger("change");
-    }
+    reader.readAsDataURL(file);
+  } else {
+    // Otherwise, clear the preview and hide the image
+    $(img).attr("src", "");
+    $(img).addClass("hidden");
+  }
+}
+
+/*
+ * Function to hide the preview when the image should be deleted
+*/
+function resetPreview(event){
+  // If the deletion checkbox is activated, clear the file field and the preview
+  if (event.target.checked) {
+    let fileInput = $(event.target).closest(".card").find("input[type='file']")[0];
+    fileInput.value = "";
+    $(fileInput).trigger("change");
   }
 }
 
 $(document).ready(() => {
-  $("input[name^='document_image-'][name$='-image']").each(() => {
+  $("input[type='file']").each(() => {
     $(this).change(previewImage);
+  });
+  $("input[name^='document_image-'][name$='-DELETE'],input[name='icon-clear']").each(() => {
+    $(this).change(resetPreview);
   });
 });

--- a/lunes_cms/cms/utils.py
+++ b/lunes_cms/cms/utils.py
@@ -6,7 +6,11 @@ import os
 import uuid
 import string
 import pathlib
+
+from html import escape
+
 from django.utils.crypto import get_random_string
+from django.utils.html import mark_safe
 from django.utils.translation import ugettext as _
 
 
@@ -111,6 +115,30 @@ def get_key(request, keyword="Api-Key"):
     except ValueError:
         key = None
     return key
+
+
+def get_image_tag(image):
+    """
+    Image thumbnail to display a preview of a image
+
+    :param image: The image file
+    :type image: ~django.db.models.fields.files.ImageFieldFile
+
+    :return: HTML tag to display an image thumbnail
+    :rtype: str
+    """
+    src = ""
+    if (
+        image
+        and image.storage.exists(image.name)
+        and any(image.name.lower().endswith(ext) for ext in [".jpg", ".png"])
+    ):
+        # The normal src attribute for jpg and png previews
+        src = escape(f"/media/{image}")
+    # Hide preview if image is empty or has invalid type
+    html_cls = "" if src else 'class="hidden"'
+    # HTML image tag for previews
+    return mark_safe(f'<img src="{src}" width="330" height="auto" {html_cls} />')
 
 
 def iter_to_string(iter):

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-20 13:12+0000\n"
+"POT-Creation-Date: 2022-06-20 13:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,12 +17,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: cms/admin.py:33 cms/admins/training_set_admin.py:251 cms/forms.py:48
-#: cms/forms.py:50 cms/list_filter.py:14 cms/models/discipline.py:89
+#: cms/admin.py:33 cms/admins/training_set_admin.py:261 cms/forms.py:48
+#: cms/forms.py:50 cms/list_filter.py:14 cms/models/discipline.py:100
 msgid "disciplines"
 msgstr "Modulgruppen"
 
-#: cms/admin.py:34 cms/list_filter.py:102 cms/models/training_set.py:80
+#: cms/admin.py:34 cms/list_filter.py:102 cms/models/training_set.py:92
 msgid "training sets"
 msgstr "Module"
 
@@ -39,21 +39,21 @@ msgstr "API Keys"
 msgid "feedback"
 msgstr "Feedback"
 
-#: cms/admins/discipline_admin.py:111
+#: cms/admins/discipline_admin.py:119
 msgid "Release selected disciplines"
 msgstr "Ausgewählte Modulgruppen veröffentlichen"
 
-#: cms/admins/discipline_admin.py:124
+#: cms/admins/discipline_admin.py:132
 msgid "Unrelease selected disciplines"
 msgstr "Ausgewählte Modulgruppen zurückhalten"
 
-#: cms/admins/discipline_admin.py:153 cms/admins/document_admin.py:150
-#: cms/admins/training_set_admin.py:269
+#: cms/admins/discipline_admin.py:161 cms/admins/document_admin.py:150
+#: cms/admins/training_set_admin.py:279
 msgid "creator group"
 msgstr "Besitzergruppe"
 
-#: cms/admins/document_admin.py:132 cms/models/training_set.py:25
-#: cms/models/training_set.py:79
+#: cms/admins/document_admin.py:132 cms/models/training_set.py:26
+#: cms/models/training_set.py:91
 msgid "training set"
 msgstr "Modul"
 
@@ -61,7 +61,7 @@ msgstr "Modul"
 msgid "audio"
 msgstr "Audio"
 
-#: cms/admins/document_admin.py:188 cms/models/document_image.py:134
+#: cms/admins/document_admin.py:188 cms/models/document_image.py:125
 msgid "image"
 msgstr "Bild"
 
@@ -88,11 +88,11 @@ msgid "The selected feedback entries were successfully marked as unread."
 msgstr ""
 "Die ausgewählten Feedback-Eitnräge wurden erfolgreich als ungelesen markiert."
 
-#: cms/admins/training_set_admin.py:131
+#: cms/admins/training_set_admin.py:141
 msgid "Release selected training sets"
 msgstr "Ausgewählte Module veröffentlichen"
 
-#: cms/admins/training_set_admin.py:166
+#: cms/admins/training_set_admin.py:176
 msgid ""
 "The training set {} could not be released because it contains less than {} "
 "vocabulary words with confirmed images."
@@ -106,29 +106,29 @@ msgstr[1] ""
 "Die Module {} konnten nicht veröffentlicht werden, da sie weniger als {} "
 "Vokabeln mit bestätigten Bildern enthalten."
 
-#: cms/admins/training_set_admin.py:179
+#: cms/admins/training_set_admin.py:189
 msgid "The training set {} is already released."
 msgid_plural "The training sets {} are already released."
 msgstr[0] "Das Modul {} ist bereits veröffentlicht."
 msgstr[1] "Die Module {} sind bereits veröffentlicht."
 
-#: cms/admins/training_set_admin.py:193
+#: cms/admins/training_set_admin.py:203
 msgid "The training set {} was successfully released."
 msgid_plural "The training sets {} were successfully released."
 msgstr[0] "Das Modul {} wurde erfolgreich veröffentlicht."
 msgstr[1] "Die Module {} wurden erfolgreich veröffentlicht."
 
-#: cms/admins/training_set_admin.py:199
+#: cms/admins/training_set_admin.py:209
 msgid "Unrelease selected training sets"
 msgstr "Ausgewählte Module zurückhalten"
 
-#: cms/admins/training_set_admin.py:223
+#: cms/admins/training_set_admin.py:233
 msgid "The training set {} is already unreleased."
 msgid_plural "The training sets {} are already unreleased."
 msgstr[0] "Das Modul {} ist bereits zurückgehalten."
 msgstr[1] "Die Module {} sind bereits zurückgehalten."
 
-#: cms/admins/training_set_admin.py:234
+#: cms/admins/training_set_admin.py:244
 msgid "The training set {} was successfully unreleased."
 msgid_plural "The training sets {} were successfully unreleased."
 msgstr[0] "Das Modul {} wurde erfolgreich zurückgehalten."
@@ -191,35 +191,35 @@ msgstr "Alternatives Wort"
 msgid "alternative words"
 msgstr "Alternative Wörter"
 
-#: cms/models/discipline.py:22 cms/models/training_set.py:24
+#: cms/models/discipline.py:22 cms/models/training_set.py:25
 msgid "released"
 msgstr "veröffentlicht"
 
-#: cms/models/discipline.py:23 cms/models/discipline.py:88
-#: cms/models/training_set.py:36
+#: cms/models/discipline.py:23 cms/models/discipline.py:99
+#: cms/models/training_set.py:37
 msgid "discipline"
 msgstr "Modulgruppe"
 
-#: cms/models/discipline.py:25 cms/models/training_set.py:27
+#: cms/models/discipline.py:25 cms/models/training_set.py:28
 msgid "description"
 msgstr "Beschreibung"
 
 #: cms/models/discipline.py:28 cms/models/group.py:10
-#: cms/models/training_set.py:30
+#: cms/models/training_set.py:31
 msgid "icon"
 msgstr "Icon"
 
 #: cms/models/discipline.py:35 cms/models/document.py:55
-#: cms/models/training_set.py:39
+#: cms/models/training_set.py:40
 msgid "created by"
 msgstr "Erstellt von"
 
 #: cms/models/discipline.py:38 cms/models/document.py:57
-#: cms/models/training_set.py:41
+#: cms/models/training_set.py:42
 msgid "admin"
 msgstr "Admin"
 
-#: cms/models/discipline.py:45 cms/models/training_set.py:48
+#: cms/models/discipline.py:45 cms/models/training_set.py:49
 msgid "parent"
 msgstr "Übergeordnete Modulgruppe"
 
@@ -235,7 +235,7 @@ msgstr "Wort"
 msgid "creation date"
 msgstr "Erstellt am"
 
-#: cms/models/document_image.py:135
+#: cms/models/document_image.py:126
 msgid "images"
 msgstr "Bilder"
 
@@ -295,11 +295,11 @@ msgstr "API-Key"
 msgid "API Keys"
 msgstr "API-Keys"
 
-#: cms/models/training_set.py:33
+#: cms/models/training_set.py:34
 msgid "document"
 msgstr "Dokument"
 
-#: cms/models/training_set.py:68
+#: cms/models/training_set.py:80
 msgid ""
 "It is not possible to create child elements for training sets (unlike "
 "disciplines)."
@@ -318,7 +318,7 @@ msgstr ""
 msgid "{} with id {} does not exist."
 msgstr "{} mit der ID {} existiert nicht."
 
-#: cms/utils.py:135
+#: cms/utils.py:163
 msgid "and"
 msgstr "und"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add icon preview for disciplines and training sets

### Proposed changes
<!-- Describe this PR in more detail. -->
- Generalize the existing preview script to make it work for both the document images and the discipline/trainingset icons
- Add image tag to discipline and training set admins

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #317
