### PR TITLE
Improve filter on public upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ UNRELEASED
 * [ [#269](https://github.com/digitalfabrik/lunes-cms/issues/269) ] Allow to set custom API key
 * [ [#285](https://github.com/digitalfabrik/lunes-cms/issues/285) ] Generate API key with correct requirements
 * [ [#271](https://github.com/digitalfabrik/lunes-cms/issues/271) ] Generate QR codes for API keys
+* [ [#369](https://github.com/digitalfabrik/lunes-cms/issues/369) ] Improve list view of missing images
+* [ [#372](https://github.com/digitalfabrik/lunes-cms/issues/372) ] Extend the public upload form with a show-all-list
 
 
 2022.6.2

--- a/lunes_cms/help/templates/public_upload.html
+++ b/lunes_cms/help/templates/public_upload.html
@@ -65,28 +65,43 @@
         3: "das",
         4: "die (Plural)"
       }
+      let buffer_array = []
+
+      function Comparator(a, b) {
+        if (a[1] < b[1]) return -1;
+        if (a[1] > b[1]) return 1;
+        return 0;
+      }
 
       $( document ).ready(function() {
-
         lunes_disciplines.forEach(function(element) {
           if( element[1] !== "Allgemeine Grundlagen") {
             $("#inputDiscipline").append(new Option(element[1], element[0]))
           }
         });
-
         $("#inputDiscipline").change(function() {
-          var discipline_id = $("#inputDiscipline").val();
+          buffer_array = [];
+          let discipline_id = $("#inputDiscipline").val();
+          if (discipline_id == "all") {
+            buffer_array = lunes_documents;
+          } else if (discipline_id != "none") {
+            lunes_training_sets.forEach(function(element) {
+              if(lunes_disc_sets_map[discipline_id].includes(element[0])) {
+                let training_set_id = element[0];
+                lunes_documents = lunes_documents.sort(Comparator)
+                lunes_documents.forEach(function(element) {
+                  if(element[3] == training_set_id) {
+                    buffer_array.push(element)
+                  }
+                });
+              }
+            });
+          }
           $("#inputDocument").find('option').remove();
-          lunes_training_sets.forEach(function(element) {
-            if(lunes_disc_sets_map[discipline_id].includes(element[0])) {
-              var training_set_id = element[0];
-              lunes_documents.forEach(function(element) {
-                if(element[3] == training_set_id) {
-                  $("#inputDocument").append(new Option( article_map[element[2]] + " " + element[1], element[0]));
-                }
-              });
-            }
-          });
+          buffer_array = buffer_array.sort(Comparator);
+          buffer_array.forEach(element =>
+            $("#inputDocument").append(new Option(article_map[element[2]] + " " + element[1], element[0]))
+          );
         });
       });
     </script>
@@ -105,11 +120,14 @@
       </h3>
       {% if upload_success %}<div class="alert alert-success" role="alert">Vielen Dank für dein Bild. Das Lunes Team wird es prüfen und freigeben.</div>{% endif %}
       <label for="inputDiscipline" class="sr-only">Beruf auswählen</label>
-      <select id="inputDiscipline" class="form-control" required autofocus><option>Bitte Beruf wählen</option></select>
+      <select id="inputDiscipline" class="form-control" required autofocus>
+          <option value="none">Bitte Beruf wählen</option>
+          <option value="all">Alle Berufe</option>
+      </select>
       <label for="inputDocument" class="sr-only">Wort auswählen</label>
       <select id="inputDocument" name="inputDocument" class="form-control" required></select>
       <label for="inputFile" class="sr-only">Bild</label>
-      <input type="file" id="inputFile" name="inputFile" accept="image/*" id="inputFile" class="form-control" required>
+      <input type="file" id="inputFile" name="inputFile" accept="image/*" id="inputFile" class="form-control" capture="environment" required>
       <div class="col-xs-12" style="height:10px;"></div>
       <div class="checkbox mb-3">
         <label>

--- a/lunes_cms/help/views/public_upload.py
+++ b/lunes_cms/help/views/public_upload.py
@@ -36,6 +36,7 @@ def public_upload(request):
     )
     disciplines = (
         Discipline.objects.values_list("id", "title")
+        .order_by("title")
         .filter(training_sets__isnull=False)
         .filter(training_sets__documents__document_image__isnull=True)
         .distinct()


### PR DESCRIPTION
### Short description
This PR tries to improve the filter on our public upload site


### Proposed changes

- I added a function to sort first the disciplines, this works as expected
- I used this function also to sort the documents, and this doesn't work as expected. I think l.92 is responsible for this. When I console.log the elements before l. 92 the documents are sorted as expected, when I check after l. 92 it doesn't work, and it shows the vocubularies in a semi sorted way. Do you have an idea how what the issue is here?
- I added the option to see all missing words
- I added an option to immediately access your camera on your mobile phone. However, this needs to be tested a lot, because I had different results on different devices.

### Resolved issues
Fixes: #369 
Fixes: #372 
