### PR TITLE
Fix validator badge in API docs

### DIFF
--- a/lunes_cms/api/templates/swagger_ui.html
+++ b/lunes_cms/api/templates/swagger_ui.html
@@ -3,7 +3,7 @@
 {% include "drf_spectacular/swagger_ui.html" %}
 
 <style>
-    .swagger-ui img {
+    .swagger-ui .topbar img {
         content: url({% static 'images/logo-lunes-dark.svg' %});
     }
 </style>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In our [new API documentation](https://lunes-test.tuerantuer.org/api/docs/), the validator badge was overwritten with our custom logo:

![Screenshot 2022-07-21 at 15-41-38 Lunes API](https://user-images.githubusercontent.com/16021269/180228089-da534707-e0c1-4846-b2ed-d273d5194e27.png)

### Proposed changes
<!-- Describe this PR in more detail. -->
- Overwrite only logo in top bar, not in footer

Now, it looks like this:

![Screenshot 2022-07-21 at 15-41-59 Lunes API](https://user-images.githubusercontent.com/16021269/180228125-4d94afbf-5a4d-40fe-bcf5-14e0f4b5057a.png)