### PR TITLE
Ignore dependabot updates for Django >=4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "django"
+        versions: [">=4.0"]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Ignore dependabot updates for Django >=4.0 to prevent PRs like #382 in the future