### PR TITLE
Change dependabot frequency from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "django"
         versions: [">=4.0"]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since we're not releasing new lunes cms versions that frequently, I guess it makes sense to also bump the dependency versions less frequently.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Change dependabot frequency from weekly to monthly
