### PR TITLE
Deliver protected vocabulary at `/words` API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#404](https://github.com/digitalfabrik/lunes-cms/issues/404) ] Deliver protected vocabulary words in API
+
 
 2022.8.0
 --------

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -243,12 +243,13 @@ VOCABULARY_ENDPOINTS = [
     {
         "endpoint": "/api/words/",
         "api_key": "VALIDTOKEN",
-        "expected_result": "tests/api/expected-results/words.json",
+        "expected_result": "tests/api/expected-results/words_by_key.json",
     },
     {
         "endpoint": "/api/words/",
         "api_key": "INVALIDTOKEN",
-        "expected_result": "tests/api/expected-results/words.json",
+        "expected_result": "tests/api/expected-results/permission_denied.json",
+        "expected_status_code": 403,
     },
     {
         "endpoint": "/api/words/2/",
@@ -262,7 +263,24 @@ VOCABULARY_ENDPOINTS = [
     {
         "endpoint": "/api/words/2/",
         "api_key": "INVALIDTOKEN",
-        "expected_result": "tests/api/expected-results/words_2.json",
+        "expected_result": "tests/api/expected-results/permission_denied.json",
+        "expected_status_code": 403,
+    },
+    {
+        "endpoint": "/api/words/170/",
+        "expected_result": "tests/api/expected-results/not_found.json",
+        "expected_status_code": 404,
+    },
+    {
+        "endpoint": "/api/words/170/",
+        "api_key": "VALIDTOKEN",
+        "expected_result": "tests/api/expected-results/words_170.json",
+    },
+    {
+        "endpoint": "/api/words/170/",
+        "api_key": "INVALIDTOKEN",
+        "expected_result": "tests/api/expected-results/permission_denied.json",
+        "expected_status_code": 403,
     },
 ]
 

--- a/tests/api/expected-results/words_170.json
+++ b/tests/api/expected-results/words_170.json
@@ -1,0 +1,14 @@
+{
+  "id": 170,
+  "word": "Auto",
+  "article": 3,
+  "audio": "http://testserver/media/audio/auto.mp3",
+  "word_type": "Nomen",
+  "alternatives": [],
+  "document_image": [
+      {
+          "id": 178,
+          "image": "http://testserver/media/images/auto.jpg"
+      }
+  ]
+}

--- a/tests/api/expected-results/words_by_key.json
+++ b/tests/api/expected-results/words_by_key.json
@@ -1,0 +1,10305 @@
+[
+  {
+      "id": 2,
+      "word": "Schere",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schere.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 2,
+              "image": "http://testserver/media/images/schere.jpg"
+          }
+      ]
+  },
+  {
+      "id": 3,
+      "word": "Schlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 3,
+              "image": "http://testserver/media/images/schlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 4,
+      "word": "Buch",
+      "article": 3,
+      "audio": "http://testserver/media/audio/buch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 4,
+              "image": "http://testserver/media/images/buch.png"
+          }
+      ]
+  },
+  {
+      "id": 6,
+      "word": "Akkuschrauber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/akkuschrauber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 6,
+              "image": "http://testserver/media/images/akkuschrauber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 7,
+      "word": "Bohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Metallbohrer",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 7,
+              "image": "http://testserver/media/images/bohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 8,
+      "word": "Bohrmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bohrmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Handbohrmaschine",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 746,
+              "image": "http://testserver/media/images/bohrmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 9,
+      "word": "Dübel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/dubel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 9,
+              "image": "http://testserver/media/images/dubel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 10,
+      "word": "Feile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/feile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 10,
+              "image": "http://testserver/media/images/feile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 11,
+      "word": "Gerüst",
+      "article": 3,
+      "audio": "http://testserver/media/audio/gerust.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 11,
+              "image": "http://testserver/media/images/gerust.jpg"
+          }
+      ]
+  },
+  {
+      "id": 12,
+      "word": "Leiter",
+      "article": 2,
+      "audio": "http://testserver/media/audio/leiter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1274,
+              "image": "http://testserver/media/images/leiter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 13,
+      "word": "Maßband",
+      "article": 3,
+      "audio": "http://testserver/media/audio/maband.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 290,
+              "image": "http://testserver/media/images/maband.jpg"
+          }
+      ]
+  },
+  {
+      "id": 14,
+      "word": "Meißel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/meiel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 291,
+              "image": "http://testserver/media/images/meiel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 15,
+      "word": "Messer",
+      "article": 3,
+      "audio": "http://testserver/media/audio/messer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 513,
+              "image": "http://testserver/media/images/messer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 16,
+      "word": "Schubkarre",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schubkarre.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Schubkarren",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 16,
+              "image": "http://testserver/media/images/schubkarre.jpg"
+          }
+      ]
+  },
+  {
+      "id": 17,
+      "word": "Zollstock",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zollstock.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Meterstab",
+              "article": 1
+          },
+          {
+              "alt_word": "Gliedermaßstab",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 828,
+              "image": "http://testserver/media/images/zollstock.jpg"
+          }
+      ]
+  },
+  {
+      "id": 18,
+      "word": "Arbeitshandschuh",
+      "article": 1,
+      "audio": "http://testserver/media/audio/arbeitshandschuh.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Handschuh",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 317,
+              "image": "http://testserver/media/images/arbeitshandschuh.jpg"
+          }
+      ]
+  },
+  {
+      "id": 20,
+      "word": "Besen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/besen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 20,
+              "image": "http://testserver/media/images/besen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 21,
+      "word": "Eimer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/eimer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 21,
+              "image": "http://testserver/media/images/eimer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 22,
+      "word": "Gehörschutz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gehorschutz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1272,
+              "image": "http://testserver/media/images/gehorschutz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 23,
+      "word": "Hammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/hammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 23,
+              "image": "http://testserver/media/images/hammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 24,
+      "word": "Kabeltrommel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kabeltrommel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 237,
+              "image": "http://testserver/media/images/kabeltrommel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 25,
+      "word": "Klebeband",
+      "article": 3,
+      "audio": "http://testserver/media/audio/klebeband.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 287,
+              "image": "http://testserver/media/images/klebeband.jpg"
+          }
+      ]
+  },
+  {
+      "id": 26,
+      "word": "Schraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 299,
+              "image": "http://testserver/media/images/schraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 27,
+      "word": "Schraubenzieher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schraubenzieher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Schraubendreher",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 27,
+              "image": "http://testserver/media/images/schraubenzieher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 28,
+      "word": "Schraubenschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schraubenschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Ring-Maulschlüssel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1423,
+              "image": "http://testserver/media/images/schraubenschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 29,
+      "word": "Schutzbrille",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schutzbrille.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Sicherheitsbrille",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 29,
+              "image": "http://testserver/media/images/schutzbrille.jpg"
+          }
+      ]
+  },
+  {
+      "id": 30,
+      "word": "Schutzhelm",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schutzhelm.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 30,
+              "image": "http://testserver/media/images/schutzhelm.jpg"
+          }
+      ]
+  },
+  {
+      "id": 31,
+      "word": "Staubsauger",
+      "article": 1,
+      "audio": "http://testserver/media/audio/staubsauger.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 31,
+              "image": "http://testserver/media/images/staubsauger.jpg"
+          }
+      ]
+  },
+  {
+      "id": 32,
+      "word": "Wasserwaage",
+      "article": 2,
+      "audio": "http://testserver/media/audio/wasserwaage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 32,
+              "image": "http://testserver/media/images/wasserwaage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 33,
+      "word": "Abisolierzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/abisolierzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 807,
+              "image": "http://testserver/media/images/abisolierzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 34,
+      "word": "Bohrkrone",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bohrkrone.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 34,
+              "image": "http://testserver/media/images/bohrkrone.jpg"
+          }
+      ]
+  },
+  {
+      "id": 35,
+      "word": "Crimpzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/crimpzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Aderendhülsenzange",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 446,
+              "image": "http://testserver/media/images/crimpzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 49,
+      "word": "Gipsbecher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gipsbecher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Gipsbecher",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1612,
+              "image": "http://testserver/media/images/gipsbecher.png"
+          }
+      ]
+  },
+  {
+      "id": 66,
+      "word": "Schleifpapier",
+      "article": 3,
+      "audio": "http://testserver/media/audio/schleifpapier.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 70,
+              "image": "http://testserver/media/images/schleifpapier.jpg"
+          }
+      ]
+  },
+  {
+      "id": 116,
+      "word": "Seitenschneider",
+      "article": 1,
+      "audio": "http://testserver/media/audio/seitenschneider.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 121,
+              "image": "http://testserver/media/images/seitenschneider.jpg"
+          }
+      ]
+  },
+  {
+      "id": 117,
+      "word": "Spannungsprüfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/spannungsprufer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Duspol",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 122,
+              "image": "http://testserver/media/images/spannungsprufer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 118,
+      "word": "Steckdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/steckdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 123,
+              "image": "http://testserver/media/images/steckdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 119,
+      "word": "Badewanne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/badewanne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 124,
+              "image": "http://testserver/media/images/badewanne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 120,
+      "word": "Doppelmaulschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/doppelmaulschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Maulschlüssel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 125,
+              "image": "http://testserver/media/images/doppelmaulschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 123,
+      "word": "Toilette",
+      "article": 2,
+      "audio": "http://testserver/media/audio/toilette.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "WC",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 128,
+              "image": "http://testserver/media/images/toilette.jpg"
+          }
+      ]
+  },
+  {
+      "id": 124,
+      "word": "Waschbecken",
+      "article": 3,
+      "audio": "http://testserver/media/audio/waschbecken.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 607,
+              "image": "http://testserver/media/images/waschbecken.jpg"
+          }
+      ]
+  },
+  {
+      "id": 125,
+      "word": "Wasserhahn",
+      "article": 1,
+      "audio": "http://testserver/media/audio/wasserhahn.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Waschbeckenarmatur",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 130,
+              "image": "http://testserver/media/images/wasserhahn.jpg"
+          }
+      ]
+  },
+  {
+      "id": 126,
+      "word": "Wasserpumpenzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/wasserpumpenzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 131,
+              "image": "http://testserver/media/images/wasserpumpenzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 132,
+      "word": "Elektrohammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/elektrohammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 137,
+              "image": "http://testserver/media/images/elektrohammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 133,
+      "word": "Spachtel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/spachtel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Spachtel",
+              "article": 2
+          },
+          {
+              "alt_word": "Spachtel",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 138,
+              "image": "http://testserver/media/images/spachtel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 135,
+      "word": "Antennendose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/antennendose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 140,
+              "image": "http://testserver/media/images/antennendose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 136,
+      "word": "Kreuzerder",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kreuzerder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 141,
+              "image": "http://testserver/media/images/kreuzerder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 139,
+      "word": "Leuchtmittel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/leuchtmittel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Glühbirne",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 144,
+              "image": "http://testserver/media/images/leuchtmittel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 140,
+      "word": "Arbeitskleidung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/arbeitskleidung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 145,
+              "image": "http://testserver/media/images/arbeitskleidung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 141,
+      "word": "Putzlappen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/putzlappen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Lappen",
+              "article": 1
+          },
+          {
+              "alt_word": "Reinigungstuch",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 288,
+              "image": "http://testserver/media/images/putzlappen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 142,
+      "word": "Mülleimer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/mulleimer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Papierkorb",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 255,
+              "image": "http://testserver/media/images/mulleimer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 143,
+      "word": "Bleistift",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bleistift.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 149,
+              "image": "http://testserver/media/images/bleistift.jpg"
+          }
+      ]
+  },
+  {
+      "id": 144,
+      "word": "Zimmermannsbleistift",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zimmermannsbleistift.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Bleistift",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 150,
+              "image": "http://testserver/media/images/zimmermannsbleistift.jpg"
+          }
+      ]
+  },
+  {
+      "id": 145,
+      "word": "Werkzeugkiste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/werkzeugkiste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Werkzeugkasten",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1515,
+              "image": "http://testserver/media/images/werkzeugkiste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 146,
+      "word": "Abdeckfolie",
+      "article": 2,
+      "audio": "http://testserver/media/audio/abdeckfolie.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 449,
+              "image": "http://testserver/media/images/abdeckfolie.png"
+          }
+      ]
+  },
+  {
+      "id": 151,
+      "word": "Föhn",
+      "article": 1,
+      "audio": "http://testserver/media/audio/fohn.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Haartrockner",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 655,
+              "image": "http://testserver/media/images/fohn.jpg"
+          }
+      ]
+  },
+  {
+      "id": 156,
+      "word": "Kamm",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kamm.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 625,
+              "image": "http://testserver/media/images/kamm.jpg"
+          }
+      ]
+  },
+  {
+      "id": 157,
+      "word": "Spiegel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/spiegel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 164,
+              "image": "http://testserver/media/images/spiegel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 160,
+      "word": "Handbügelsäge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/handbugelsage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Säge",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 167,
+              "image": "http://testserver/media/images/handbugelsage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 161,
+      "word": "Nageleisen",
+      "article": 3,
+      "audio": "http://testserver/media/audio/nageleisen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Brechstange",
+              "article": 2
+          },
+          {
+              "alt_word": "Kuhfuß",
+              "article": 1
+          },
+          {
+              "alt_word": "Brecheisen",
+              "article": 3
+          },
+          {
+              "alt_word": "Hebeleisen",
+              "article": 3
+          },
+          {
+              "alt_word": "Ziegenfuß",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 168,
+              "image": "http://testserver/media/images/nageleisen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 167,
+      "word": "Winkel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/winkel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Schreinerwinkel",
+              "article": 1
+          },
+          {
+              "alt_word": "Tischlerwinkel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 175,
+              "image": "http://testserver/media/images/winkel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 170,
+      "word": "Auto",
+      "article": 3,
+      "audio": "http://testserver/media/audio/auto.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 178,
+              "image": "http://testserver/media/images/auto.jpg"
+          }
+      ]
+  },
+  {
+      "id": 171,
+      "word": "Autobatterie",
+      "article": 2,
+      "audio": "http://testserver/media/audio/autobatterie.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Autobatterie",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 180,
+              "image": "http://testserver/media/images/autobatterie.jpg"
+          }
+      ]
+  },
+  {
+      "id": 173,
+      "word": "Hebebühne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/hebebuhne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 182,
+              "image": "http://testserver/media/images/hebebuhne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 175,
+      "word": "Drehmomentschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/drehmomentschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Newtonmeterschlüssel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 184,
+              "image": "http://testserver/media/images/drehmomentschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 177,
+      "word": "Motorbremse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/motorbremse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 186,
+              "image": "http://testserver/media/images/motorbremse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 178,
+      "word": "Ölkanister",
+      "article": 1,
+      "audio": "http://testserver/media/audio/olkanister.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 187,
+              "image": "http://testserver/media/images/olkanister.jpg"
+          }
+      ]
+  },
+  {
+      "id": 181,
+      "word": "Ratsche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/ratsche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Knarre",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 190,
+              "image": "http://testserver/media/images/ratsche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 182,
+      "word": "Scheibenwischer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/scheibenwischer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Scheibenwischer",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 191,
+              "image": "http://testserver/media/images/scheibenwischer.png"
+          }
+      ]
+  },
+  {
+      "id": 183,
+      "word": "Schweißgerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/schweigerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 192,
+              "image": "http://testserver/media/images/schweigerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 186,
+      "word": "Schürze",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schurze.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 195,
+              "image": "http://testserver/media/images/schurze.jpg"
+          }
+      ]
+  },
+  {
+      "id": 187,
+      "word": "Ofenhandschuh",
+      "article": 1,
+      "audio": "http://testserver/media/audio/ofenhandschuh.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 196,
+              "image": "http://testserver/media/images/ofenhandschuh.jpg"
+          }
+      ]
+  },
+  {
+      "id": 188,
+      "word": "Kittel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kittel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 197,
+              "image": "http://testserver/media/images/kittel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 189,
+      "word": "Backofen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/backofen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 198,
+              "image": "http://testserver/media/images/backofen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 201,
+      "word": "Cutter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/cutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Cuttermesser",
+              "article": 3
+          },
+          {
+              "alt_word": "Japanmesser",
+              "article": 3
+          },
+          {
+              "alt_word": "Teppichmesser",
+              "article": 0
+          },
+          {
+              "alt_word": "Tapetenmesser",
+              "article": 3
+          },
+          {
+              "alt_word": "Stanley-Messer",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 877,
+              "image": "http://testserver/media/images/cutter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 202,
+      "word": "Betonmischer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/betonmischer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 211,
+              "image": "http://testserver/media/images/betonmischer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 204,
+      "word": "Maurerhammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/maurerhammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 213,
+              "image": "http://testserver/media/images/maurerhammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 208,
+      "word": "Schaufel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schaufel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 217,
+              "image": "http://testserver/media/images/schaufel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 211,
+      "word": "Sackkarre",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sackkarre.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Sackkarren",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1118,
+              "image": "http://testserver/media/images/sackkarre.jpg"
+          }
+      ]
+  },
+  {
+      "id": 214,
+      "word": "Bügelmessschraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bugelmessschraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 223,
+              "image": "http://testserver/media/images/bugelmessschraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 215,
+      "word": "Drehwerkzeug",
+      "article": 3,
+      "audio": "http://testserver/media/audio/drehwerkzeug.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 224,
+              "image": "http://testserver/media/images/drehwerkzeug.jpg"
+          }
+      ]
+  },
+  {
+      "id": 216,
+      "word": "universelle Fräsmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/universelle-frasmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "universelle Fräse",
+              "article": 2
+          },
+          {
+              "alt_word": "Universalfräsmaschine",
+              "article": 2
+          },
+          {
+              "alt_word": "Universalfräse",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1093,
+              "image": "http://testserver/media/images/universelle-frasmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 217,
+      "word": "Grenzlehrdorn",
+      "article": 1,
+      "audio": "http://testserver/media/audio/grenzlehrdorn.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 226,
+              "image": "http://testserver/media/images/grenzlehrdorn.jpg"
+          }
+      ]
+  },
+  {
+      "id": 218,
+      "word": "Körner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/korner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Körner",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 227,
+              "image": "http://testserver/media/images/korner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 219,
+      "word": "Messschieber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/messschieber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 228,
+              "image": "http://testserver/media/images/messschieber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 220,
+      "word": "Schweißgeschirr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/schweigeschirr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 229,
+              "image": "http://testserver/media/images/schweigeschirr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 221,
+      "word": "Dusche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/dusche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 230,
+              "image": "http://testserver/media/images/dusche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 223,
+      "word": "Kreissäge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kreissage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 232,
+              "image": "http://testserver/media/images/kreissage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 224,
+      "word": "Nagel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/nagel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Nägel",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 233,
+              "image": "http://testserver/media/images/nagel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 225,
+      "word": "Pumpenzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/pumpenzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 234,
+              "image": "http://testserver/media/images/pumpenzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 226,
+      "word": "Stichsäge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/stichsage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 235,
+              "image": "http://testserver/media/images/stichsage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 227,
+      "word": "Zange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/zange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kneifzange",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 236,
+              "image": "http://testserver/media/images/zange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 228,
+      "word": "Akku-Winkelschleifer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/akku-winkelschleifer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Akkuflex",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 238,
+              "image": "http://testserver/media/images/akku-winkelschleifer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 231,
+      "word": "Filzstift",
+      "article": 1,
+      "audio": "http://testserver/media/audio/filzstift.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Edding",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1558,
+              "image": "http://testserver/media/images/filzstift.jpg"
+          }
+      ]
+  },
+  {
+      "id": 232,
+      "word": "Fäustel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/faustel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Fausthammer",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 242,
+              "image": "http://testserver/media/images/faustel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 237,
+      "word": "Handfeger",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handfeger.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Handbesen",
+              "article": 1
+          },
+          {
+              "alt_word": "Kehrbesen",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 247,
+              "image": "http://testserver/media/images/handfeger.jpg"
+          }
+      ]
+  },
+  {
+      "id": 238,
+      "word": "Isolierband",
+      "article": 3,
+      "audio": "http://testserver/media/audio/isolierband.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Isolierbänder",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 248,
+              "image": "http://testserver/media/images/isolierband.jpg"
+          }
+      ]
+  },
+  {
+      "id": 260,
+      "word": "Warnweste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/warnweste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Sicherheitsweste",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 274,
+              "image": "http://testserver/media/images/warnweste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 261,
+      "word": "Arbeitshose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/arbeitshose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 275,
+              "image": "http://testserver/media/images/arbeitshose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 262,
+      "word": "Arbeitsjacke",
+      "article": 2,
+      "audio": "http://testserver/media/audio/arbeitsjacke.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 276,
+              "image": "http://testserver/media/images/arbeitsjacke.jpg"
+          }
+      ]
+  },
+  {
+      "id": 263,
+      "word": "Bohrstange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bohrstange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 278,
+              "image": "http://testserver/media/images/bohrstange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 265,
+      "word": "Flachsenker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/flachsenker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 281,
+              "image": "http://testserver/media/images/flachsenker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 266,
+      "word": "Gewindefräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gewindefraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 282,
+              "image": "http://testserver/media/images/gewindefraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 267,
+      "word": "Gewindeschneider",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gewindeschneider.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 283,
+              "image": "http://testserver/media/images/gewindeschneider.jpg"
+          }
+      ]
+  },
+  {
+      "id": 268,
+      "word": "Handreibahle",
+      "article": 2,
+      "audio": "http://testserver/media/audio/handreibahle.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Reibahle",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 284,
+              "image": "http://testserver/media/images/handreibahle.jpg"
+          }
+      ]
+  },
+  {
+      "id": 269,
+      "word": "Industriestaubsauger",
+      "article": 1,
+      "audio": "http://testserver/media/audio/industriestaubsauger.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Nass-Trockensauger",
+              "article": 0
+          }
+      ],
+      "document_image": [
+          {
+              "id": 285,
+              "image": "http://testserver/media/images/industriestaubsauger.jpg"
+          }
+      ]
+  },
+  {
+      "id": 270,
+      "word": "Kegelsenker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kegelsenker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 286,
+              "image": "http://testserver/media/images/kegelsenker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 271,
+      "word": "Mülltonne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/mulltonne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 292,
+              "image": "http://testserver/media/images/mulltonne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 272,
+      "word": "Nutenfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/nutenfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1001,
+              "image": "http://testserver/media/images/nutenfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 274,
+      "word": "Rändel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/randel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 295,
+              "image": "http://testserver/media/images/randel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 275,
+      "word": "Rohrzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/rohrzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 296,
+              "image": "http://testserver/media/images/rohrzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 276,
+      "word": "Schaftfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schaftfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 297,
+              "image": "http://testserver/media/images/schaftfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 277,
+      "word": "Scheibenfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/scheibenfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 298,
+              "image": "http://testserver/media/images/scheibenfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 280,
+      "word": "Wendeschneidplatte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/wendeschneidplatte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 303,
+              "image": "http://testserver/media/images/wendeschneidplatte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 281,
+      "word": "Winkelfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/winkelfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1011,
+              "image": "http://testserver/media/images/winkelfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 282,
+      "word": "Zentrierbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zentrierbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 306,
+              "image": "http://testserver/media/images/zentrierbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 284,
+      "word": "zweipolige Phasenprüfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zweipolige-phasenprufer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Phasenprüfer",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 308,
+              "image": "http://testserver/media/images/zweipolige-phasenprufer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 285,
+      "word": "LAN-Tester",
+      "article": 1,
+      "audio": "http://testserver/media/audio/lan-tester.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "LAN Tester",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 309,
+              "image": "http://testserver/media/images/lan-tester.jpg"
+          }
+      ]
+  },
+  {
+      "id": 286,
+      "word": "digitale Messschieber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/digitale-messschieber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Messschieber",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 310,
+              "image": "http://testserver/media/images/digitale-messschieber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 287,
+      "word": "Gummihammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gummihammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Simplex-Gummihammer",
+              "article": 1
+          },
+          {
+              "alt_word": "Plattenlegehammer",
+              "article": 1
+          },
+          {
+              "alt_word": "Pflasterhammer",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 311,
+              "image": "http://testserver/media/images/gummihammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 290,
+      "word": "NC-Anbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/nc-anbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "NC Anbohrer",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 314,
+              "image": "http://testserver/media/images/nc-anbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 292,
+      "word": "Schlagbohrmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schlagbohrmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 318,
+              "image": "http://testserver/media/images/schlagbohrmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 300,
+      "word": "Kreissägeblatt",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kreissageblatt.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 328,
+              "image": "http://testserver/media/images/kreissageblatt.jpg"
+          }
+      ]
+  },
+  {
+      "id": 301,
+      "word": "Schlangenbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schlangenbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 329,
+              "image": "http://testserver/media/images/schlangenbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 302,
+      "word": "Langbandschleifmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/langbandschleifmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 330,
+              "image": "http://testserver/media/images/langbandschleifmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 303,
+      "word": "Schleifigel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schleifigel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 331,
+              "image": "http://testserver/media/images/schleifigel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 304,
+      "word": "Schraubstock",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schraubstock.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 332,
+              "image": "http://testserver/media/images/schraubstock.jpg"
+          }
+      ]
+  },
+  {
+      "id": 309,
+      "word": "Kehrblech",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kehrblech.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kehrschaufel",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 337,
+              "image": "http://testserver/media/images/kehrblech.jpg"
+          }
+      ]
+  },
+  {
+      "id": 311,
+      "word": "Säbelsägeblatt",
+      "article": 3,
+      "audio": "http://testserver/media/audio/sabelsageblatt.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 339,
+              "image": "http://testserver/media/images/sabelsageblatt.jpg"
+          }
+      ]
+  },
+  {
+      "id": 315,
+      "word": "Ständerbohrmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/standerbohrmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1571,
+              "image": "http://testserver/media/images/standerbohrmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 320,
+      "word": "Breitbandschleifmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/breitbandschleifmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 348,
+              "image": "http://testserver/media/images/breitbandschleifmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 322,
+      "word": "Winkelschleifer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/winkelschleifer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Flex",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1446,
+              "image": "http://testserver/media/images/winkelschleifer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 323,
+      "word": "Bithalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bithalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Bitaufnahme",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 351,
+              "image": "http://testserver/media/images/bithalter.png"
+          }
+      ]
+  },
+  {
+      "id": 324,
+      "word": "Bit",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bit.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Bit",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 352,
+              "image": "http://testserver/media/images/bit.jpg"
+          }
+      ]
+  },
+  {
+      "id": 335,
+      "word": "Exzenterschleifer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/exzenterschleifer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1444,
+              "image": "http://testserver/media/images/exzenterschleifer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 337,
+      "word": "Inbus",
+      "article": 1,
+      "audio": "http://testserver/media/audio/inbus.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Inbusschlüssel",
+              "article": 1
+          },
+          {
+              "alt_word": "Innensechskantschlüssel",
+              "article": 1
+          },
+          {
+              "alt_word": "Stiftschlüssel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1482,
+              "image": "http://testserver/media/images/inbus.jpg"
+          }
+      ]
+  },
+  {
+      "id": 343,
+      "word": "Locher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/locher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 385,
+              "image": "http://testserver/media/images/locher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 350,
+      "word": "Desinfektionsmittel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/desinfektionsmittel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Hand-Desinfektionsmittel",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1027,
+              "image": "http://testserver/media/images/desinfektionsmittel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 360,
+      "word": "Einweghandschuh",
+      "article": 1,
+      "audio": "http://testserver/media/audio/einweghandschuh.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Einmalhandschuh",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1213,
+              "image": "http://testserver/media/images/einweghandschuh.jpg"
+          }
+      ]
+  },
+  {
+      "id": 361,
+      "word": "Mund-Nase-Schutz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/mund-nase-schutz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Mund-Nase-Bedeckung",
+              "article": 2
+          },
+          {
+              "alt_word": "Mundschutz",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1164,
+              "image": "http://testserver/media/images/mund-nase-schutz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 401,
+      "word": "Kabelentmantler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kabelentmantler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Abmantelwerkzeug",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 723,
+              "image": "http://testserver/media/images/kabelentmantler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 402,
+      "word": "Kabelmesser",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kabelmesser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 782,
+              "image": "http://testserver/media/images/kabelmesser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 403,
+      "word": "Kabelschere",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kabelschere.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 783,
+              "image": "http://testserver/media/images/kabelschere.jpg"
+          }
+      ]
+  },
+  {
+      "id": 409,
+      "word": "Gabelstapler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gabelstapler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1108,
+              "image": "http://testserver/media/images/gabelstapler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 415,
+      "word": "Ordner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/ordner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 384,
+              "image": "http://testserver/media/images/ordner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 418,
+      "word": "Tacker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/tacker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 386,
+              "image": "http://testserver/media/images/tacker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 419,
+      "word": "Telefon",
+      "article": 3,
+      "audio": "http://testserver/media/audio/telefon.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 383,
+              "image": "http://testserver/media/images/telefon.jpg"
+          }
+      ]
+  },
+  {
+      "id": 425,
+      "word": "Kugelschreiber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kugelschreiber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 379,
+              "image": "http://testserver/media/images/kugelschreiber.png"
+          }
+      ]
+  },
+  {
+      "id": 436,
+      "word": "Halbrundfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/halbrundfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1076,
+              "image": "http://testserver/media/images/halbrundfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 438,
+      "word": "Metall-Bügelsäge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/metall-bugelsage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "PUK-Säge",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 812,
+              "image": "http://testserver/media/images/metall-bugelsage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 441,
+      "word": "Rundfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/rundfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1077,
+              "image": "http://testserver/media/images/rundfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 473,
+      "word": "Dreikantfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/dreikantfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1072,
+              "image": "http://testserver/media/images/dreikantfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 474,
+      "word": "Flachstumpffeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/flachstumpffeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1586,
+              "image": "http://testserver/media/images/flachstumpffeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 476,
+      "word": "Kombinationszange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kombinationszange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kombizange",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 441,
+              "image": "http://testserver/media/images/kombinationszange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 477,
+      "word": "Kraft-Seitenschneider",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kraft-seitenschneider.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 785,
+              "image": "http://testserver/media/images/kraft-seitenschneider.jpg"
+          }
+      ]
+  },
+  {
+      "id": 484,
+      "word": "Schlosserhammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schlosserhammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 814,
+              "image": "http://testserver/media/images/schlosserhammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 495,
+      "word": "Handhubwagen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handhubwagen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Hubwagen",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1111,
+              "image": "http://testserver/media/images/handhubwagen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 499,
+      "word": "Hochregallager",
+      "article": 3,
+      "audio": "http://testserver/media/audio/hochregallager.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1124,
+              "image": "http://testserver/media/images/hochregallager.jpg"
+          }
+      ]
+  },
+  {
+      "id": 500,
+      "word": "Verladerampe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/verladerampe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1130,
+              "image": "http://testserver/media/images/verladerampe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 502,
+      "word": "Kleinteilelager",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kleinteilelager.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1125,
+              "image": "http://testserver/media/images/kleinteilelager.jpg"
+          }
+      ]
+  },
+  {
+      "id": 508,
+      "word": "Schwamm",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schwamm.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 800,
+              "image": "http://testserver/media/images/schwamm.jpg"
+          }
+      ]
+  },
+  {
+      "id": 509,
+      "word": "Spülmittel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/spulmittel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1209,
+              "image": "http://testserver/media/images/spulmittel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 510,
+      "word": "Küchentuch",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kuchentuch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1224,
+              "image": "http://testserver/media/images/kuchentuch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 511,
+      "word": "Geschirrtuch",
+      "article": 3,
+      "audio": "http://testserver/media/audio/geschirrtuch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Geschirrtücher",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 529,
+              "image": "http://testserver/media/images/geschirrtuch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 512,
+      "word": "Spülbürste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spulburste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1211,
+              "image": "http://testserver/media/images/spulburste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 513,
+      "word": "Spülbecken",
+      "article": 3,
+      "audio": "http://testserver/media/audio/spulbecken.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1212,
+              "image": "http://testserver/media/images/spulbecken.jpg"
+          }
+      ]
+  },
+  {
+      "id": 514,
+      "word": "Elektroherd",
+      "article": 1,
+      "audio": "http://testserver/media/audio/elektroherd.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Herd",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1287,
+              "image": "http://testserver/media/images/elektroherd.jpg"
+          }
+      ]
+  },
+  {
+      "id": 515,
+      "word": "Herdplatte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/herdplatte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1288,
+              "image": "http://testserver/media/images/herdplatte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 516,
+      "word": "Suppe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/suppe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 668,
+              "image": "http://testserver/media/images/suppe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 518,
+      "word": "Butter",
+      "article": 2,
+      "audio": "http://testserver/media/audio/butter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 678,
+              "image": "http://testserver/media/images/butter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 522,
+      "word": "Schüssel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 510,
+              "image": "http://testserver/media/images/schussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 523,
+      "word": "Sieb",
+      "article": 3,
+      "audio": "http://testserver/media/audio/sieb.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 526,
+              "image": "http://testserver/media/images/sieb.jpg"
+          }
+      ]
+  },
+  {
+      "id": 524,
+      "word": "Topf",
+      "article": 1,
+      "audio": "http://testserver/media/audio/topf.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 797,
+              "image": "http://testserver/media/images/topf.jpg"
+          }
+      ]
+  },
+  {
+      "id": 525,
+      "word": "Pfanne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/pfanne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 537,
+              "image": "http://testserver/media/images/pfanne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 528,
+      "word": "Platte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/platte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1308,
+              "image": "http://testserver/media/images/platte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 529,
+      "word": "Salatbesteck",
+      "article": 3,
+      "audio": "http://testserver/media/audio/salatbesteck.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1281,
+              "image": "http://testserver/media/images/salatbesteck.jpg"
+          }
+      ]
+  },
+  {
+      "id": 530,
+      "word": "Schale",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schale.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1289,
+              "image": "http://testserver/media/images/schale.jpg"
+          }
+      ]
+  },
+  {
+      "id": 531,
+      "word": "Flaschenöffner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/flaschenoffner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1282,
+              "image": "http://testserver/media/images/flaschenoffner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 532,
+      "word": "Besteck",
+      "article": 3,
+      "audio": "http://testserver/media/audio/besteck.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 402,
+              "image": "http://testserver/media/images/besteck.jpg"
+          }
+      ]
+  },
+  {
+      "id": 533,
+      "word": "Löffel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/loffel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 403,
+              "image": "http://testserver/media/images/loffel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 534,
+      "word": "Gabel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/gabel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 404,
+              "image": "http://testserver/media/images/gabel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 535,
+      "word": "Geschirr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/geschirr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 405,
+              "image": "http://testserver/media/images/geschirr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 536,
+      "word": "Tasse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/tasse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 471,
+              "image": "http://testserver/media/images/tasse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 537,
+      "word": "Teller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/teller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 407,
+              "image": "http://testserver/media/images/teller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 538,
+      "word": "Gedeck",
+      "article": 3,
+      "audio": "http://testserver/media/audio/gedeck.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1611,
+              "image": "http://testserver/media/images/gedeck.png"
+          }
+      ]
+  },
+  {
+      "id": 539,
+      "word": "Unterteller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/unterteller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Untertasse",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 520,
+              "image": "http://testserver/media/images/unterteller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 540,
+      "word": "Flasche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/flasche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 685,
+              "image": "http://testserver/media/images/flasche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 541,
+      "word": "Glas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/glas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 485,
+              "image": "http://testserver/media/images/glas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 542,
+      "word": "Bierglas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bierglas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1596,
+              "image": "http://testserver/media/images/bierglas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 543,
+      "word": "Weinglas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/weinglas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 521,
+              "image": "http://testserver/media/images/weinglas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 544,
+      "word": "Sektglas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/sektglas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 516,
+              "image": "http://testserver/media/images/sektglas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 545,
+      "word": "Schnapsglas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/schnapsglas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 713,
+              "image": "http://testserver/media/images/schnapsglas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 546,
+      "word": "Eierbecher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/eierbecher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 875,
+              "image": "http://testserver/media/images/eierbecher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 547,
+      "word": "Kanne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kanne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1310,
+              "image": "http://testserver/media/images/kanne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 548,
+      "word": "Krug",
+      "article": 1,
+      "audio": "http://testserver/media/audio/krug.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Karaffe",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 509,
+              "image": "http://testserver/media/images/krug.jpg"
+          }
+      ]
+  },
+  {
+      "id": 549,
+      "word": "Serviette",
+      "article": 2,
+      "audio": "http://testserver/media/audio/serviette.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 514,
+              "image": "http://testserver/media/images/serviette.jpg"
+          }
+      ]
+  },
+  {
+      "id": 553,
+      "word": "Gewindebohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gewindebohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 978,
+              "image": "http://testserver/media/images/gewindebohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 559,
+      "word": "Kreisschneider",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kreisschneider.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1039,
+              "image": "http://testserver/media/images/kreisschneider.jpg"
+          }
+      ]
+  },
+  {
+      "id": 567,
+      "word": "Spiralbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/spiralbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1587,
+              "image": "http://testserver/media/images/spiralbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 568,
+      "word": "Walzenstirnfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/walzenstirnfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1010,
+              "image": "http://testserver/media/images/walzenstirnfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 589,
+      "word": "Auflaufform",
+      "article": 2,
+      "audio": "http://testserver/media/audio/auflaufform.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 494,
+              "image": "http://testserver/media/images/auflaufform.jpg"
+          }
+      ]
+  },
+  {
+      "id": 595,
+      "word": "Tischdecke",
+      "article": 2,
+      "audio": "http://testserver/media/audio/tischdecke.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1295,
+              "image": "http://testserver/media/images/tischdecke.jpg"
+          }
+      ]
+  },
+  {
+      "id": 596,
+      "word": "Vase",
+      "article": 2,
+      "audio": "http://testserver/media/audio/vase.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1249,
+              "image": "http://testserver/media/images/vase.jpg"
+          }
+      ]
+  },
+  {
+      "id": 599,
+      "word": "Backblech",
+      "article": 3,
+      "audio": "http://testserver/media/audio/backblech.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 496,
+              "image": "http://testserver/media/images/backblech.jpg"
+          }
+      ]
+  },
+  {
+      "id": 613,
+      "word": "Schneebesen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schneebesen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Schaumschläger",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 463,
+              "image": "http://testserver/media/images/schneebesen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 617,
+      "word": "Teigschaber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/teigschaber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 454,
+              "image": "http://testserver/media/images/teigschaber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 636,
+      "word": "Butterdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/butterdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1290,
+              "image": "http://testserver/media/images/butterdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 638,
+      "word": "Zuckerspender",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zuckerspender.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 522,
+              "image": "http://testserver/media/images/zuckerspender.jpg"
+          }
+      ]
+  },
+  {
+      "id": 641,
+      "word": "GN-Behälter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gn-behalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 410,
+              "image": "http://testserver/media/images/gn-behalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 646,
+      "word": "Teeglas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/teeglas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 414,
+              "image": "http://testserver/media/images/teeglas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 649,
+      "word": "Dosenöffner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/dosenoffner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 457,
+              "image": "http://testserver/media/images/dosenoffner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 651,
+      "word": "Pinsel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/pinsel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 719,
+              "image": "http://testserver/media/images/pinsel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 654,
+      "word": "Backpapier",
+      "article": 3,
+      "audio": "http://testserver/media/audio/backpapier.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 466,
+              "image": "http://testserver/media/images/backpapier.jpg"
+          }
+      ]
+  },
+  {
+      "id": 656,
+      "word": "Dunstabzugshaube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/dunstabzugshaube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Abzugshaube",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 493,
+              "image": "http://testserver/media/images/dunstabzugshaube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 667,
+      "word": "Kaffeemaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kaffeemaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kaffeebereiter",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 503,
+              "image": "http://testserver/media/images/kaffeemaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 668,
+      "word": "Kühlschrank",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kuhlschrank.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 535,
+              "image": "http://testserver/media/images/kuhlschrank.jpg"
+          }
+      ]
+  },
+  {
+      "id": 670,
+      "word": "Thermoskanne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/thermoskanne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 544,
+              "image": "http://testserver/media/images/thermoskanne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 671,
+      "word": "Omelett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/omelett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 666,
+              "image": "http://testserver/media/images/omelett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 673,
+      "word": "Spiegelei",
+      "article": 3,
+      "audio": "http://testserver/media/audio/spiegelei.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 667,
+              "image": "http://testserver/media/images/spiegelei.jpg"
+          }
+      ]
+  },
+  {
+      "id": 674,
+      "word": "Haferflocken",
+      "article": 4,
+      "audio": "http://testserver/media/audio/haferflocken.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 664,
+              "image": "http://testserver/media/images/haferflocken.jpg"
+          }
+      ]
+  },
+  {
+      "id": 675,
+      "word": "Rotwein",
+      "article": 1,
+      "audio": "http://testserver/media/audio/rotwein.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 675,
+              "image": "http://testserver/media/images/rotwein.jpg"
+          }
+      ]
+  },
+  {
+      "id": 676,
+      "word": "Weißwein",
+      "article": 1,
+      "audio": "http://testserver/media/audio/weiwein.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 677,
+              "image": "http://testserver/media/images/weiwein.jpg"
+          }
+      ]
+  },
+  {
+      "id": 678,
+      "word": "Bier",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bier.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 670,
+              "image": "http://testserver/media/images/bier.jpg"
+          }
+      ]
+  },
+  {
+      "id": 679,
+      "word": "Eistee",
+      "article": 1,
+      "audio": "http://testserver/media/audio/eistee.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 671,
+              "image": "http://testserver/media/images/eistee.jpg"
+          }
+      ]
+  },
+  {
+      "id": 680,
+      "word": "Saft",
+      "article": 1,
+      "audio": "http://testserver/media/audio/saft.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 676,
+              "image": "http://testserver/media/images/saft.jpg"
+          }
+      ]
+  },
+  {
+      "id": 681,
+      "word": "Eiswürfel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/eiswurfel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 672,
+              "image": "http://testserver/media/images/eiswurfel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 682,
+      "word": "Honig",
+      "article": 1,
+      "audio": "http://testserver/media/audio/honig.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 679,
+              "image": "http://testserver/media/images/honig.jpg"
+          }
+      ]
+  },
+  {
+      "id": 683,
+      "word": "Marmelade",
+      "article": 2,
+      "audio": "http://testserver/media/audio/marmelade.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 681,
+              "image": "http://testserver/media/images/marmelade.jpg"
+          }
+      ]
+  },
+  {
+      "id": 685,
+      "word": "Tee",
+      "article": 1,
+      "audio": "http://testserver/media/audio/tee.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 682,
+              "image": "http://testserver/media/images/tee.jpg"
+          }
+      ]
+  },
+  {
+      "id": 686,
+      "word": "Teebeutel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/teebeutel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 683,
+              "image": "http://testserver/media/images/teebeutel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 687,
+      "word": "Kaffee",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kaffee.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 680,
+              "image": "http://testserver/media/images/kaffee.jpg"
+          }
+      ]
+  },
+  {
+      "id": 688,
+      "word": "Kaffeefilter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kaffeefilter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 504,
+              "image": "http://testserver/media/images/kaffeefilter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 689,
+      "word": "Milch",
+      "article": 2,
+      "audio": "http://testserver/media/audio/milch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 674,
+              "image": "http://testserver/media/images/milch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 691,
+      "word": "Öl",
+      "article": 3,
+      "audio": "http://testserver/media/audio/ol.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 673,
+              "image": "http://testserver/media/images/ol.jpg"
+          }
+      ]
+  },
+  {
+      "id": 692,
+      "word": "Müsli",
+      "article": 3,
+      "audio": "http://testserver/media/audio/musli.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 665,
+              "image": "http://testserver/media/images/musli.jpg"
+          }
+      ]
+  },
+  {
+      "id": 693,
+      "word": "Zahnstocher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zahnstocher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1390,
+              "image": "http://testserver/media/images/zahnstocher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 698,
+      "word": "Korkenzieher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/korkenzieher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 798,
+              "image": "http://testserver/media/images/korkenzieher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 700,
+      "word": "Chafing-Dish",
+      "article": 1,
+      "audio": "http://testserver/media/audio/chafing-dish.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 499,
+              "image": "http://testserver/media/images/chafing-dish.jpg"
+          }
+      ]
+  },
+  {
+      "id": 701,
+      "word": "Cocktailglas",
+      "article": 3,
+      "audio": "http://testserver/media/audio/cocktailglas.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 500,
+              "image": "http://testserver/media/images/cocktailglas.jpg"
+          }
+      ]
+  },
+  {
+      "id": 702,
+      "word": "Espressotasse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/espressotasse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 501,
+              "image": "http://testserver/media/images/espressotasse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 703,
+      "word": "Kaffeelöffel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kaffeeloffel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 505,
+              "image": "http://testserver/media/images/kaffeeloffel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 704,
+      "word": "Kuchengabel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kuchengabel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 511,
+              "image": "http://testserver/media/images/kuchengabel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 705,
+      "word": "Kaffeeportionierer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kaffeeportionierer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 506,
+              "image": "http://testserver/media/images/kaffeeportionierer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 706,
+      "word": "Kuchenteller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kuchenteller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 832,
+              "image": "http://testserver/media/images/kuchenteller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 707,
+      "word": "Schieferplatte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schieferplatte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Schieferplatten",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 515,
+              "image": "http://testserver/media/images/schieferplatte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 709,
+      "word": "Suppenteller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/suppenteller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 518,
+              "image": "http://testserver/media/images/suppenteller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 710,
+      "word": "Kaffeetasse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kaffeetasse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 507,
+              "image": "http://testserver/media/images/kaffeetasse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 713,
+      "word": "Bodenwischgerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bodenwischgerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1854,
+              "image": "http://testserver/media/images/bodenwischgerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 714,
+      "word": "Papierhandtuch",
+      "article": 3,
+      "audio": "http://testserver/media/audio/papierhandtuch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 583,
+              "image": "http://testserver/media/images/papierhandtuch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 715,
+      "word": "Papierhandtuchspender",
+      "article": 1,
+      "audio": "http://testserver/media/audio/papierhandtuchspender.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 584,
+              "image": "http://testserver/media/images/papierhandtuchspender.jpg"
+          }
+      ]
+  },
+  {
+      "id": 716,
+      "word": "Reinigungsbürste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/reinigungsburste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 801,
+              "image": "http://testserver/media/images/reinigungsburste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 717,
+      "word": "Reinigungshandschuh",
+      "article": 1,
+      "audio": "http://testserver/media/audio/reinigungshandschuh.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Spülhandschuh",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1240,
+              "image": "http://testserver/media/images/reinigungshandschuh.jpg"
+          }
+      ]
+  },
+  {
+      "id": 718,
+      "word": "Reinigungsmittel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/reinigungsmittel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1214,
+              "image": "http://testserver/media/images/reinigungsmittel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 719,
+      "word": "Reinigungswagen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/reinigungswagen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1263,
+              "image": "http://testserver/media/images/reinigungswagen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 720,
+      "word": "Seifenspender",
+      "article": 1,
+      "audio": "http://testserver/media/audio/seifenspender.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 587,
+              "image": "http://testserver/media/images/seifenspender.jpg"
+          }
+      ]
+  },
+  {
+      "id": 721,
+      "word": "Sprühflasche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spruhflasche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 650,
+              "image": "http://testserver/media/images/spruhflasche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 723,
+      "word": "Staubsaugerbeutel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/staubsaugerbeutel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1219,
+              "image": "http://testserver/media/images/staubsaugerbeutel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 724,
+      "word": "Wischbezug",
+      "article": 1,
+      "audio": "http://testserver/media/audio/wischbezug.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1220,
+              "image": "http://testserver/media/images/wischbezug.jpg"
+          }
+      ]
+  },
+  {
+      "id": 726,
+      "word": "Bademantel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bademantel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1279,
+              "image": "http://testserver/media/images/bademantel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 727,
+      "word": "Badezimmer",
+      "article": 3,
+      "audio": "http://testserver/media/audio/badezimmer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 569,
+              "image": "http://testserver/media/images/badezimmer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 728,
+      "word": "Balkon",
+      "article": 1,
+      "audio": "http://testserver/media/audio/balkon.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1237,
+              "image": "http://testserver/media/images/balkon.jpg"
+          }
+      ]
+  },
+  {
+      "id": 729,
+      "word": "Bettdecke",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bettdecke.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 565,
+              "image": "http://testserver/media/images/bettdecke.jpg"
+          }
+      ]
+  },
+  {
+      "id": 730,
+      "word": "Bettwäsche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bettwasche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 714,
+              "image": "http://testserver/media/images/bettwasche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 731,
+      "word": "Doppelbett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/doppelbett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 566,
+              "image": "http://testserver/media/images/doppelbett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 732,
+      "word": "Duschkopf",
+      "article": 1,
+      "audio": "http://testserver/media/audio/duschkopf.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 567,
+              "image": "http://testserver/media/images/duschkopf.jpg"
+          }
+      ]
+  },
+  {
+      "id": 733,
+      "word": "Einzelbett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/einzelbett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 568,
+              "image": "http://testserver/media/images/einzelbett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 734,
+      "word": "Fenster",
+      "article": 3,
+      "audio": "http://testserver/media/audio/fenster.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 434,
+              "image": "http://testserver/media/images/fenster.jpg"
+          }
+      ]
+  },
+  {
+      "id": 735,
+      "word": "Fernbedienung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/fernbedienung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 715,
+              "image": "http://testserver/media/images/fernbedienung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 736,
+      "word": "Fernseher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/fernseher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 580,
+              "image": "http://testserver/media/images/fernseher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 738,
+      "word": "Garderobe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/garderobe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 572,
+              "image": "http://testserver/media/images/garderobe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 739,
+      "word": "Gardine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/gardine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1254,
+              "image": "http://testserver/media/images/gardine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 740,
+      "word": "Handtuch",
+      "article": 3,
+      "audio": "http://testserver/media/audio/handtuch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 796,
+              "image": "http://testserver/media/images/handtuch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 741,
+      "word": "Handtuchhalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handtuchhalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 574,
+              "image": "http://testserver/media/images/handtuchhalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 742,
+      "word": "Handtuchstange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/handtuchstange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 575,
+              "image": "http://testserver/media/images/handtuchstange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 743,
+      "word": "Hoteltresor",
+      "article": 1,
+      "audio": "http://testserver/media/audio/hoteltresor.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Hotelsafe",
+              "article": 1
+          },
+          {
+              "alt_word": "Zimmersafe",
+              "article": 1
+          },
+          {
+              "alt_word": "Zimmertresor",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 592,
+              "image": "http://testserver/media/images/hoteltresor.jpg"
+          }
+      ]
+  },
+  {
+      "id": 745,
+      "word": "Kleiderbügel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kleiderbugel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1216,
+              "image": "http://testserver/media/images/kleiderbugel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 746,
+      "word": "Kleiderschrank",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kleiderschrank.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 576,
+              "image": "http://testserver/media/images/kleiderschrank.jpg"
+          }
+      ]
+  },
+  {
+      "id": 747,
+      "word": "Klimaanlagenregler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/klimaanlagenregler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 577,
+              "image": "http://testserver/media/images/klimaanlagenregler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 748,
+      "word": "Kopfkissen",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kopfkissen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 578,
+              "image": "http://testserver/media/images/kopfkissen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 749,
+      "word": "Minibar",
+      "article": 2,
+      "audio": "http://testserver/media/audio/minibar.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 581,
+              "image": "http://testserver/media/images/minibar.jpg"
+          }
+      ]
+  },
+  {
+      "id": 750,
+      "word": "Nachttisch",
+      "article": 1,
+      "audio": "http://testserver/media/audio/nachttisch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Nachtkästchen",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 582,
+              "image": "http://testserver/media/images/nachttisch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 751,
+      "word": "Rasierapparat",
+      "article": 1,
+      "audio": "http://testserver/media/audio/rasierapparat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1217,
+              "image": "http://testserver/media/images/rasierapparat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 753,
+      "word": "Toilettenbürste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/toilettenburste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 589,
+              "image": "http://testserver/media/images/toilettenburste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 754,
+      "word": "Toilettenpapier",
+      "article": 3,
+      "audio": "http://testserver/media/audio/toilettenpapier.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 716,
+              "image": "http://testserver/media/images/toilettenpapier.jpg"
+          }
+      ]
+  },
+  {
+      "id": 755,
+      "word": "Toilettenpapierhalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/toilettenpapierhalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 590,
+              "image": "http://testserver/media/images/toilettenpapierhalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 756,
+      "word": "Wasserkocher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/wasserkocher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1228,
+              "image": "http://testserver/media/images/wasserkocher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 757,
+      "word": "Zahnbürste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/zahnburste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 651,
+              "image": "http://testserver/media/images/zahnburste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 758,
+      "word": "Zahnpasta",
+      "article": 2,
+      "audio": "http://testserver/media/audio/zahnpasta.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 718,
+              "image": "http://testserver/media/images/zahnpasta.jpg"
+          }
+      ]
+  },
+  {
+      "id": 759,
+      "word": "EC-Karte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/ec-karte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "EC-Karten",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 436,
+              "image": "http://testserver/media/images/ec-karte.png"
+          }
+      ]
+  },
+  {
+      "id": 761,
+      "word": "Gepäck",
+      "article": 3,
+      "audio": "http://testserver/media/audio/gepack.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1396,
+              "image": "http://testserver/media/images/gepack.jpg"
+          }
+      ]
+  },
+  {
+      "id": 762,
+      "word": "Gepäckwagen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gepackwagen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 558,
+              "image": "http://testserver/media/images/gepackwagen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 764,
+      "word": "Koffer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/koffer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1397,
+              "image": "http://testserver/media/images/koffer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 765,
+      "word": "Kreditkarte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kreditkarte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kreditkarten",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 437,
+              "image": "http://testserver/media/images/kreditkarte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 766,
+      "word": "Parkplatz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/parkplatz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1236,
+              "image": "http://testserver/media/images/parkplatz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 767,
+      "word": "Rezeption",
+      "article": 2,
+      "audio": "http://testserver/media/audio/rezeption.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 551,
+              "image": "http://testserver/media/images/rezeption.jpg"
+          }
+      ]
+  },
+  {
+      "id": 768,
+      "word": "Rezeptionsglocke",
+      "article": 2,
+      "audio": "http://testserver/media/audio/rezeptionsglocke.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1395,
+              "image": "http://testserver/media/images/rezeptionsglocke.jpg"
+          }
+      ]
+  },
+  {
+      "id": 769,
+      "word": "Sicherheitsnadel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sicherheitsnadel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1283,
+              "image": "http://testserver/media/images/sicherheitsnadel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 771,
+      "word": "Streichholz",
+      "article": 3,
+      "audio": "http://testserver/media/audio/streichholz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1284,
+              "image": "http://testserver/media/images/streichholz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 772,
+      "word": "Tasche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/tasche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1234,
+              "image": "http://testserver/media/images/tasche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 773,
+      "word": "Trolley",
+      "article": 1,
+      "audio": "http://testserver/media/audio/trolley.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 432,
+              "image": "http://testserver/media/images/trolley.jpg"
+          }
+      ]
+  },
+  {
+      "id": 776,
+      "word": "Waschmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/waschmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1153,
+              "image": "http://testserver/media/images/waschmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 778,
+      "word": "Waschmittel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/waschmittel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1242,
+              "image": "http://testserver/media/images/waschmittel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 779,
+      "word": "Wäscheständer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/waschestander.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1842,
+              "image": "http://testserver/media/images/waschestander.jpg"
+          }
+      ]
+  },
+  {
+      "id": 780,
+      "word": "Wäscheklammer",
+      "article": 2,
+      "audio": "http://testserver/media/audio/wascheklammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1243,
+              "image": "http://testserver/media/images/wascheklammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 782,
+      "word": "Waschgang",
+      "article": 1,
+      "audio": "http://testserver/media/audio/waschgang.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1244,
+              "image": "http://testserver/media/images/waschgang.jpg"
+          }
+      ]
+  },
+  {
+      "id": 783,
+      "word": "Schleuderzahl",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schleuderzahl.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1245,
+              "image": "http://testserver/media/images/schleuderzahl.jpg"
+          }
+      ]
+  },
+  {
+      "id": 784,
+      "word": "Pflegeetikett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/pflegeetikett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1246,
+              "image": "http://testserver/media/images/pflegeetikett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 786,
+      "word": "Seife",
+      "article": 2,
+      "audio": "http://testserver/media/audio/seife.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1225,
+              "image": "http://testserver/media/images/seife.jpg"
+          }
+      ]
+  },
+  {
+      "id": 797,
+      "word": "Seitenscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/seitenscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Seitenfenster",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1719,
+              "image": "http://testserver/media/images/seitenscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 798,
+      "word": "Heckscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/heckscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1375,
+              "image": "http://testserver/media/images/heckscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 799,
+      "word": "Bremspedal",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bremspedal.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1624,
+              "image": "http://testserver/media/images/bremspedal.jpg"
+          }
+      ]
+  },
+  {
+      "id": 800,
+      "word": "Gaspedal",
+      "article": 3,
+      "audio": "http://testserver/media/audio/gaspedal.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1717,
+              "image": "http://testserver/media/images/gaspedal.jpg"
+          }
+      ]
+  },
+  {
+      "id": 801,
+      "word": "Kupplung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kupplung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1424,
+              "image": "http://testserver/media/images/kupplung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 803,
+      "word": "Motoröl",
+      "article": 3,
+      "audio": "http://testserver/media/audio/motorol.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1436,
+              "image": "http://testserver/media/images/motorol.jpg"
+          }
+      ]
+  },
+  {
+      "id": 805,
+      "word": "Lenkrad",
+      "article": 3,
+      "audio": "http://testserver/media/audio/lenkrad.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1718,
+              "image": "http://testserver/media/images/lenkrad.jpg"
+          }
+      ]
+  },
+  {
+      "id": 807,
+      "word": "Reifen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/reifen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1452,
+              "image": "http://testserver/media/images/reifen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 808,
+      "word": "Fahrersitz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/fahrersitz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1716,
+              "image": "http://testserver/media/images/fahrersitz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 818,
+      "word": "Lkw",
+      "article": 1,
+      "audio": "http://testserver/media/audio/lkw.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "LKW",
+              "article": 1
+          },
+          {
+              "alt_word": "Lastkraftwagen",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1116,
+              "image": "http://testserver/media/images/lkw.jpg"
+          }
+      ]
+  },
+  {
+      "id": 832,
+      "word": "Sicherheitsgurt",
+      "article": 1,
+      "audio": "http://testserver/media/audio/sicherheitsgurt.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1804,
+              "image": "http://testserver/media/images/sicherheitsgurt.jpg"
+          }
+      ]
+  },
+  {
+      "id": 908,
+      "word": "Handtacker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handtacker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 439,
+              "image": "http://testserver/media/images/handtacker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 909,
+      "word": "Winkelmesser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/winkelmesser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 990,
+              "image": "http://testserver/media/images/winkelmesser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 912,
+      "word": "Vorhängeschloss",
+      "article": 3,
+      "audio": "http://testserver/media/audio/vorhangeschloss.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 417,
+              "image": "http://testserver/media/images/vorhangeschloss.jpg"
+          }
+      ]
+  },
+  {
+      "id": 914,
+      "word": "Zimmermannshammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zimmermannshammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1514,
+              "image": "http://testserver/media/images/zimmermannshammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 924,
+      "word": "Reibebrett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/reibebrett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1270,
+              "image": "http://testserver/media/images/reibebrett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 932,
+      "word": "Bogenzirkel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bogenzirkel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Zirkel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 991,
+              "image": "http://testserver/media/images/bogenzirkel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 937,
+      "word": "Flachzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/flachzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 771,
+              "image": "http://testserver/media/images/flachzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 938,
+      "word": "Gripzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/gripzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1031,
+              "image": "http://testserver/media/images/gripzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 945,
+      "word": "Schlagschnur",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schlagschnur.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 945,
+              "image": "http://testserver/media/images/schlagschnur.jpg"
+          }
+      ]
+  },
+  {
+      "id": 953,
+      "word": "Schraubenziehersatz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schraubenziehersatz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 419,
+              "image": "http://testserver/media/images/schraubenziehersatz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 954,
+      "word": "Holzbock",
+      "article": 1,
+      "audio": "http://testserver/media/audio/holzbock.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1607,
+              "image": "http://testserver/media/images/holzbock.jpg"
+          }
+      ]
+  },
+  {
+      "id": 955,
+      "word": "Spitzzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spitzzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 418,
+              "image": "http://testserver/media/images/spitzzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 958,
+      "word": "Staubsaugerfilter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/staubsaugerfilter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Filter",
+              "article": 1
+          },
+          {
+              "alt_word": "Lamellenfilter",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1840,
+              "image": "http://testserver/media/images/staubsaugerfilter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 959,
+      "word": "Schlauch",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schlauch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1573,
+              "image": "http://testserver/media/images/schlauch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 961,
+      "word": "Anschlagwinkel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/anschlagwinkel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 443,
+              "image": "http://testserver/media/images/anschlagwinkel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 964,
+      "word": "Drehmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/drehmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "konventionelle Drehmaschine",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1037,
+              "image": "http://testserver/media/images/drehmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 980,
+      "word": "Bargeld",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bargeld.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 435,
+              "image": "http://testserver/media/images/bargeld.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1005,
+      "word": "Erste-Hilfe-Koffer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/erste-hilfe-koffer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 547,
+              "image": "http://testserver/media/images/erste-hilfe-koffer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1006,
+      "word": "Feuerlöscher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/feuerloscher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 488,
+              "image": "http://testserver/media/images/feuerloscher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1010,
+      "word": "Container-Kran",
+      "article": 1,
+      "audio": "http://testserver/media/audio/container-kran.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Container-Brücke",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1106,
+              "image": "http://testserver/media/images/container-kran.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1012,
+      "word": "Förderband",
+      "article": 3,
+      "audio": "http://testserver/media/audio/forderband.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Fließband",
+              "article": 3
+          },
+          {
+              "alt_word": "Bandförderer",
+              "article": 1
+          },
+          {
+              "alt_word": "Transportband",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1107,
+              "image": "http://testserver/media/images/forderband.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1019,
+      "word": "Rolltor",
+      "article": 3,
+      "audio": "http://testserver/media/audio/rolltor.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1117,
+              "image": "http://testserver/media/images/rolltor.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1020,
+      "word": "Sattelzug",
+      "article": 1,
+      "audio": "http://testserver/media/audio/sattelzug.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1119,
+              "image": "http://testserver/media/images/sattelzug.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1021,
+      "word": "Transportroller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/transportroller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1120,
+              "image": "http://testserver/media/images/transportroller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1022,
+      "word": "Transportwagen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/transportwagen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1121,
+              "image": "http://testserver/media/images/transportwagen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1023,
+      "word": "Bett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1256,
+              "image": "http://testserver/media/images/bett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1034,
+      "word": "Lichtschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/lichtschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 803,
+              "image": "http://testserver/media/images/lichtschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1049,
+      "word": "Geldschein",
+      "article": 1,
+      "audio": "http://testserver/media/audio/geldschein.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 687,
+              "image": "http://testserver/media/images/geldschein.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1050,
+      "word": "Münze",
+      "article": 2,
+      "audio": "http://testserver/media/audio/munze.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 688,
+              "image": "http://testserver/media/images/munze.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1111,
+      "word": "Backrost",
+      "article": 1,
+      "audio": "http://testserver/media/audio/backrost.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Rost",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 497,
+              "image": "http://testserver/media/images/backrost.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1113,
+      "word": "Kaffeevollautomat",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kaffeevollautomat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kaffeemaschine",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 508,
+              "image": "http://testserver/media/images/kaffeevollautomat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1115,
+      "word": "Servierteller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/servierteller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 517,
+              "image": "http://testserver/media/images/servierteller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1116,
+      "word": "Tumbler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/tumbler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 519,
+              "image": "http://testserver/media/images/tumbler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1117,
+      "word": "Warmhalterost",
+      "article": 1,
+      "audio": "http://testserver/media/audio/warmhalterost.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 523,
+              "image": "http://testserver/media/images/warmhalterost.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1118,
+      "word": "Desinfektionsmittelspender",
+      "article": 1,
+      "audio": "http://testserver/media/audio/desinfektionsmittelspender.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 524,
+              "image": "http://testserver/media/images/desinfektionsmittelspender.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1119,
+      "word": "Käsebrett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kasebrett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 531,
+              "image": "http://testserver/media/images/kasebrett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1122,
+      "word": "Rührschüssel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/ruhrschussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 539,
+              "image": "http://testserver/media/images/ruhrschussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1123,
+      "word": "Ceranfeldschaber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/ceranfeldschaber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 540,
+              "image": "http://testserver/media/images/ceranfeldschaber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1126,
+      "word": "Topflappen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/topflappen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1280,
+              "image": "http://testserver/media/images/topflappen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1127,
+      "word": "Defibrillator",
+      "article": 1,
+      "audio": "http://testserver/media/audio/defibrillator.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 548,
+              "image": "http://testserver/media/images/defibrillator.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1128,
+      "word": "Notfallplan",
+      "article": 1,
+      "audio": "http://testserver/media/audio/notfallplan.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 549,
+              "image": "http://testserver/media/images/notfallplan.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1129,
+      "word": "Notausgang",
+      "article": 1,
+      "audio": "http://testserver/media/audio/notausgang.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 550,
+              "image": "http://testserver/media/images/notausgang.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1136,
+      "word": "Garderobenständer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/garderobenstander.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 559,
+              "image": "http://testserver/media/images/garderobenstander.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1138,
+      "word": "Telefonanlage",
+      "article": 2,
+      "audio": "http://testserver/media/audio/telefonanlage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 561,
+              "image": "http://testserver/media/images/telefonanlage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1139,
+      "word": "Sitzgruppe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sitzgruppe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 562,
+              "image": "http://testserver/media/images/sitzgruppe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1142,
+      "word": "Fliese",
+      "article": 2,
+      "audio": "http://testserver/media/audio/fliese.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 570,
+              "image": "http://testserver/media/images/fliese.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1143,
+      "word": "Flurschild",
+      "article": 3,
+      "audio": "http://testserver/media/audio/flurschild.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 571,
+              "image": "http://testserver/media/images/flurschild.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1144,
+      "word": "Kosmetikmülleimer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kosmetikmulleimer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 579,
+              "image": "http://testserver/media/images/kosmetikmulleimer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1145,
+      "word": "Schließzylinder",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schliezylinder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 586,
+              "image": "http://testserver/media/images/schliezylinder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1146,
+      "word": "Sicherheitssteckdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sicherheitssteckdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 588,
+              "image": "http://testserver/media/images/sicherheitssteckdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1147,
+      "word": "Waschtisch",
+      "article": 1,
+      "audio": "http://testserver/media/audio/waschtisch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1569,
+              "image": "http://testserver/media/images/waschtisch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1148,
+      "word": "Türschild",
+      "article": 3,
+      "audio": "http://testserver/media/audio/turschild.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 591,
+              "image": "http://testserver/media/images/turschild.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1149,
+      "word": "Badregal",
+      "article": 3,
+      "audio": "http://testserver/media/audio/badregal.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1570,
+              "image": "http://testserver/media/images/badregal.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1197,
+      "word": "Mikrowelle",
+      "article": 2,
+      "audio": "http://testserver/media/audio/mikrowelle.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 663,
+              "image": "http://testserver/media/images/mikrowelle.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1198,
+      "word": "Küchenmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kuchenmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 661,
+              "image": "http://testserver/media/images/kuchenmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1199,
+      "word": "Gasherd",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gasherd.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 662,
+              "image": "http://testserver/media/images/gasherd.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1200,
+      "word": "Bierkrug",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bierkrug.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 669,
+              "image": "http://testserver/media/images/bierkrug.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1203,
+      "word": "Abstandschelle",
+      "article": 2,
+      "audio": "http://testserver/media/audio/abstandschelle.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 724,
+              "image": "http://testserver/media/images/abstandschelle.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1204,
+      "word": "Abzweigdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/abzweigdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 725,
+              "image": "http://testserver/media/images/abzweigdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1205,
+      "word": "Aderendhülse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/aderendhulse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Aderendhülsen",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 726,
+              "image": "http://testserver/media/images/aderendhulse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1206,
+      "word": "Aderleitung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/aderleitung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 727,
+              "image": "http://testserver/media/images/aderleitung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1207,
+      "word": "Alarmleuchte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/alarmleuchte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 728,
+              "image": "http://testserver/media/images/alarmleuchte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1208,
+      "word": "Analogmessgerät",
+      "article": 1,
+      "audio": "http://testserver/media/audio/analogmessgerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 729,
+              "image": "http://testserver/media/images/analogmessgerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1209,
+      "word": "Anlagenmessgerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/anlagenmessgerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 730,
+              "image": "http://testserver/media/images/anlagenmessgerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1210,
+      "word": "Anschlussdatenbezeichnung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/anschlussdatenbezeichnung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 731,
+              "image": "http://testserver/media/images/anschlussdatenbezeichnung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1211,
+      "word": "Baustrahler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/baustrahler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 732,
+              "image": "http://testserver/media/images/baustrahler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1212,
+      "word": "Aufputzinstallation",
+      "article": 2,
+      "audio": "http://testserver/media/audio/aufputzinstallation.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 733,
+              "image": "http://testserver/media/images/aufputzinstallation.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1213,
+      "word": "Aufputzinstallationsrohr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/aufputzinstallationsrohr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 734,
+              "image": "http://testserver/media/images/aufputzinstallationsrohr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1214,
+      "word": "Audiosignal",
+      "article": 3,
+      "audio": "http://testserver/media/audio/audiosignal.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 735,
+              "image": "http://testserver/media/images/audiosignal.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1215,
+      "word": "Außengewinde",
+      "article": 3,
+      "audio": "http://testserver/media/audio/auengewinde.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 737,
+              "image": "http://testserver/media/images/auengewinde.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1216,
+      "word": "Bananenstecker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bananenstecker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 738,
+              "image": "http://testserver/media/images/bananenstecker.png"
+          }
+      ]
+  },
+  {
+      "id": 1217,
+      "word": "Batterie",
+      "article": 2,
+      "audio": "http://testserver/media/audio/batterie.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 739,
+              "image": "http://testserver/media/images/batterie.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1218,
+      "word": "Baustromverteiler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/baustromverteiler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 740,
+              "image": "http://testserver/media/images/baustromverteiler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1219,
+      "word": "Bedienfeld",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bedienfeld.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 741,
+              "image": "http://testserver/media/images/bedienfeld.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1220,
+      "word": "Betoninstallationsrohr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/betoninstallationsrohr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 742,
+              "image": "http://testserver/media/images/betoninstallationsrohr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1221,
+      "word": "Bohrfutter",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bohrfutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 743,
+              "image": "http://testserver/media/images/bohrfutter.png"
+          }
+      ]
+  },
+  {
+      "id": 1222,
+      "word": "Bohrfutterschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bohrfutterschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 744,
+              "image": "http://testserver/media/images/bohrfutterschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1223,
+      "word": "Bohrloch",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bohrloch.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Bohrlöcher",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 745,
+              "image": "http://testserver/media/images/bohrloch.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1224,
+      "word": "Brandschutzschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/brandschutzschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 747,
+              "image": "http://testserver/media/images/brandschutzschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1225,
+      "word": "Brüstungskanal",
+      "article": 1,
+      "audio": "http://testserver/media/audio/brustungskanal.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 748,
+              "image": "http://testserver/media/images/brustungskanal.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1226,
+      "word": "Bügelgehörschutz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bugelgehorschutz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 749,
+              "image": "http://testserver/media/images/bugelgehorschutz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1227,
+      "word": "Dämmerungsschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/dammerungsschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 750,
+              "image": "http://testserver/media/images/dammerungsschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1228,
+      "word": "Deckenleuchte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/deckenleuchte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 751,
+              "image": "http://testserver/media/images/deckenleuchte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1229,
+      "word": "Dimmer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/dimmer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 752,
+              "image": "http://testserver/media/images/dimmer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1230,
+      "word": "Dosenklemme",
+      "article": 2,
+      "audio": "http://testserver/media/audio/dosenklemme.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Dosenklemmen",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 753,
+              "image": "http://testserver/media/images/dosenklemme.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1231,
+      "word": "Draht",
+      "article": 1,
+      "audio": "http://testserver/media/audio/draht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 754,
+              "image": "http://testserver/media/images/draht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1232,
+      "word": "Dreheisenmessgerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/dreheisenmessgerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 755,
+              "image": "http://testserver/media/images/dreheisenmessgerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1233,
+      "word": "Drehfeldmessgerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/drehfeldmessgerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 756,
+              "image": "http://testserver/media/images/drehfeldmessgerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1234,
+      "word": "Drehschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/drehschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 757,
+              "image": "http://testserver/media/images/drehschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1236,
+      "word": "Druckschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/druckschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 758,
+              "image": "http://testserver/media/images/druckschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1237,
+      "word": "Durchbruchbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/durchbruchbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 759,
+              "image": "http://testserver/media/images/durchbruchbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1238,
+      "word": "Durchgangsprüfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/durchgangsprufer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 760,
+              "image": "http://testserver/media/images/durchgangsprufer.png"
+          }
+      ]
+  },
+  {
+      "id": 1239,
+      "word": "E-Check",
+      "article": 1,
+      "audio": "http://testserver/media/audio/e-check.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Elektro-Check",
+              "article": 1
+          },
+          {
+              "alt_word": "elektrische Sicherheitsprüfung",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 761,
+              "image": "http://testserver/media/images/e-check.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1240,
+      "word": "Elektrikergips",
+      "article": 1,
+      "audio": "http://testserver/media/audio/elektrikergips.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Elektriker-Gips",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 762,
+              "image": "http://testserver/media/images/elektrikergips.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1241,
+      "word": "elektrische Verteiler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/elektrische-verteiler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Verteilung",
+              "article": 2
+          },
+          {
+              "alt_word": "Sicherungskasten",
+              "article": 1
+          },
+          {
+              "alt_word": "Verteilerkasten",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 763,
+              "image": "http://testserver/media/images/elektrische-verteiler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1242,
+      "word": "Elektroinstallation",
+      "article": 2,
+      "audio": "http://testserver/media/audio/elektroinstallation.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 764,
+              "image": "http://testserver/media/images/elektroinstallation.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1243,
+      "word": "Elektrosäge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/elektrosage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 765,
+              "image": "http://testserver/media/images/elektrosage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1244,
+      "word": "Elektroschere",
+      "article": 2,
+      "audio": "http://testserver/media/audio/elektroschere.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 766,
+              "image": "http://testserver/media/images/elektroschere.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1246,
+      "word": "Entlötpumpe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/entlotpumpe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 768,
+              "image": "http://testserver/media/images/entlotpumpe.png"
+          }
+      ]
+  },
+  {
+      "id": 1247,
+      "word": "Eurostecker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/eurostecker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 769,
+              "image": "http://testserver/media/images/eurostecker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1249,
+      "word": "Flachmeißel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/flachmeiel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1574,
+              "image": "http://testserver/media/images/flachmeiel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1250,
+      "word": "Flachrundzange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/flachrundzange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 770,
+              "image": "http://testserver/media/images/flachrundzange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1252,
+      "word": "Gehörstöpsel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gehorstopsel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Gehörschutzstöpsel",
+              "article": 1
+          },
+          {
+              "alt_word": "Ohrenstöpsel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 772,
+              "image": "http://testserver/media/images/gehorstopsel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1253,
+      "word": "Heißklebepistole",
+      "article": 2,
+      "audio": "http://testserver/media/audio/heiklebepistole.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 773,
+              "image": "http://testserver/media/images/heiklebepistole.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1254,
+      "word": "Heißluftgebläse",
+      "article": 3,
+      "audio": "http://testserver/media/audio/heiluftgeblase.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 774,
+              "image": "http://testserver/media/images/heiluftgeblase.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1255,
+      "word": "Hygrometer",
+      "article": 3,
+      "audio": "http://testserver/media/audio/hygrometer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 775,
+              "image": "http://testserver/media/images/hygrometer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1256,
+      "word": "Infrarotstrahler",
+      "article": 1,
+      "audio": "http://testserver/media/audio/infrarotstrahler.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 776,
+              "image": "http://testserver/media/images/infrarotstrahler.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1257,
+      "word": "Innengewinde",
+      "article": 3,
+      "audio": "http://testserver/media/audio/innengewinde.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 777,
+              "image": "http://testserver/media/images/innengewinde.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1258,
+      "word": "inverte Stromerzeuger",
+      "article": 1,
+      "audio": "http://testserver/media/audio/inverte-stromerzeuger.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 778,
+              "image": "http://testserver/media/images/inverte-stromerzeuger.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1259,
+      "word": "Kabel",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kabel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 779,
+              "image": "http://testserver/media/images/kabel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1260,
+      "word": "Kabelbinder",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kabelbinder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 780,
+              "image": "http://testserver/media/images/kabelbinder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1261,
+      "word": "Kabeleinziehsystem",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kabeleinziehsystem.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 781,
+              "image": "http://testserver/media/images/kabeleinziehsystem.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1263,
+      "word": "Kraftstromsteckdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kraftstromsteckdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 786,
+              "image": "http://testserver/media/images/kraftstromsteckdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1264,
+      "word": "Kuparohr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kuparohr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kuparohre",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 787,
+              "image": "http://testserver/media/images/kuparohr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1265,
+      "word": "Litzenleitung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/litzenleitung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 788,
+              "image": "http://testserver/media/images/litzenleitung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1266,
+      "word": "Lochsäge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/lochsage.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 789,
+              "image": "http://testserver/media/images/lochsage.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1267,
+      "word": "Lötkolben",
+      "article": 1,
+      "audio": "http://testserver/media/audio/lotkolben.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1278,
+              "image": "http://testserver/media/images/lotkolben.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1268,
+      "word": "Lötset",
+      "article": 3,
+      "audio": "http://testserver/media/audio/lotset.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 790,
+              "image": "http://testserver/media/images/lotset.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1270,
+      "word": "Lötstation",
+      "article": 2,
+      "audio": "http://testserver/media/audio/lotstation.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 791,
+              "image": "http://testserver/media/images/lotstation.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1271,
+      "word": "Lötstelle",
+      "article": 2,
+      "audio": "http://testserver/media/audio/lotstelle.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Lötstellen",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 792,
+              "image": "http://testserver/media/images/lotstelle.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1272,
+      "word": "Lötzinn",
+      "article": 3,
+      "audio": "http://testserver/media/audio/lotzinn.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 793,
+              "image": "http://testserver/media/images/lotzinn.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1273,
+      "word": "LSA-Plus-Auflegewerkzeug",
+      "article": 3,
+      "audio": "http://testserver/media/audio/lsa-plus-auflegewerkzeug.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "LSA-Plus-Anlegewerkzeug",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 794,
+              "image": "http://testserver/media/images/lsa-plus-auflegewerkzeug.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1274,
+      "word": "Mauernutfräse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/mauernutfrase.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 808,
+              "image": "http://testserver/media/images/mauernutfrase.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1275,
+      "word": "Metalldetektor",
+      "article": 1,
+      "audio": "http://testserver/media/audio/metalldetektor.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 809,
+              "image": "http://testserver/media/images/metalldetektor.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1276,
+      "word": "Netzteil",
+      "article": 3,
+      "audio": "http://testserver/media/audio/netzteil.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 810,
+              "image": "http://testserver/media/images/netzteil.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1277,
+      "word": "Phasenprüfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/phasenprufer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 811,
+              "image": "http://testserver/media/images/phasenprufer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1278,
+      "word": "Doppelringschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/doppelringschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1575,
+              "image": "http://testserver/media/images/doppelringschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1279,
+      "word": "Ringmaulschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/ringmaulschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Maulringschlüssel",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1576,
+              "image": "http://testserver/media/images/ringmaulschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1280,
+      "word": "Schleifenimpedanzmessgerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/schleifenimpedanzmessgerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 813,
+              "image": "http://testserver/media/images/schleifenimpedanzmessgerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1281,
+      "word": "Schraubenkopf",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schraubenkopf.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 815,
+              "image": "http://testserver/media/images/schraubenkopf.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1282,
+      "word": "Schraubenmutter",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schraubenmutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Mutter",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 816,
+              "image": "http://testserver/media/images/schraubenmutter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1283,
+      "word": "Schutzschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schutzschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 817,
+              "image": "http://testserver/media/images/schutzschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1284,
+      "word": "Signalband",
+      "article": 3,
+      "audio": "http://testserver/media/audio/signalband.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 818,
+              "image": "http://testserver/media/images/signalband.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1286,
+      "word": "Stabschrauber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/stabschrauber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 819,
+              "image": "http://testserver/media/images/stabschrauber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1287,
+      "word": "Starkstromleitung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/starkstromleitung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Starkstromleitungen",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 820,
+              "image": "http://testserver/media/images/starkstromleitung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1288,
+      "word": "Steckverbinder",
+      "article": 1,
+      "audio": "http://testserver/media/audio/steckverbinder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Steckverbinder",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 821,
+              "image": "http://testserver/media/images/steckverbinder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1289,
+      "word": "Störlichtbogen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/storlichtbogen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 822,
+              "image": "http://testserver/media/images/storlichtbogen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1290,
+      "word": "Strommesszange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/strommesszange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 823,
+              "image": "http://testserver/media/images/strommesszange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1291,
+      "word": "Transformator",
+      "article": 1,
+      "audio": "http://testserver/media/audio/transformator.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 824,
+              "image": "http://testserver/media/images/transformator.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1292,
+      "word": "Trockenbauwand",
+      "article": 2,
+      "audio": "http://testserver/media/audio/trockenbauwand.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Unterputzinstallation",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 825,
+              "image": "http://testserver/media/images/trockenbauwand.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1293,
+      "word": "Unterputzdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/unterputzdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 826,
+              "image": "http://testserver/media/images/unterputzdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1297,
+      "word": "Schaltplan",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schaltplan.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 829,
+              "image": "http://testserver/media/images/schaltplan.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1298,
+      "word": "Nut",
+      "article": 2,
+      "audio": "http://testserver/media/audio/nut.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Nute",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 830,
+              "image": "http://testserver/media/images/nut.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1299,
+      "word": "Kondensator",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kondensator.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 831,
+              "image": "http://testserver/media/images/kondensator.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1300,
+      "word": "Atom",
+      "article": 3,
+      "audio": "http://testserver/media/audio/atom.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 833,
+              "image": "http://testserver/media/images/atom.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1304,
+      "word": "Atomstrom",
+      "article": 1,
+      "audio": "http://testserver/media/audio/atomstrom.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 837,
+              "image": "http://testserver/media/images/atomstrom.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1306,
+      "word": "Außenleiter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/auenleiter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 839,
+              "image": "http://testserver/media/images/auenleiter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1309,
+      "word": "Neutralleiter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/neutralleiter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 842,
+              "image": "http://testserver/media/images/neutralleiter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1328,
+      "word": "Abfallstrom",
+      "article": 1,
+      "audio": "http://testserver/media/audio/abfallstrom.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 861,
+              "image": "http://testserver/media/images/abfallstrom.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1329,
+      "word": "Amplitude",
+      "article": 2,
+      "audio": "http://testserver/media/audio/amplitude.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 862,
+              "image": "http://testserver/media/images/amplitude.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1330,
+      "word": "Dreiphasenwechselstrom",
+      "article": 1,
+      "audio": "http://testserver/media/audio/dreiphasenwechselstrom.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 863,
+              "image": "http://testserver/media/images/dreiphasenwechselstrom.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1331,
+      "word": "Gleichstrom",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gleichstrom.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 864,
+              "image": "http://testserver/media/images/gleichstrom.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1332,
+      "word": "Wechselstrom",
+      "article": 1,
+      "audio": "http://testserver/media/audio/wechselstrom.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 865,
+              "image": "http://testserver/media/images/wechselstrom.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1333,
+      "word": "Anode",
+      "article": 2,
+      "audio": "http://testserver/media/audio/anode.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 866,
+              "image": "http://testserver/media/images/anode.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1334,
+      "word": "Kathode",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kathode.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 867,
+              "image": "http://testserver/media/images/kathode.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1335,
+      "word": "Leitung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/leitung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 868,
+              "image": "http://testserver/media/images/leitung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1337,
+      "word": "Stromkreis",
+      "article": 1,
+      "audio": "http://testserver/media/audio/stromkreis.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 870,
+              "image": "http://testserver/media/images/stromkreis.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1339,
+      "word": "Verbraucher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/verbraucher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 872,
+              "image": "http://testserver/media/images/verbraucher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1375,
+      "word": "Beipackzettel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/beipackzettel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 891,
+              "image": "http://testserver/media/images/beipackzettel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1377,
+      "word": "Bordbrett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bordbrett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 894,
+              "image": "http://testserver/media/images/bordbrett.png"
+          }
+      ]
+  },
+  {
+      "id": 1403,
+      "word": "Ladegerät",
+      "article": 3,
+      "audio": "http://testserver/media/audio/ladegerat.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Batterieladegerät",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1855,
+              "image": "http://testserver/media/images/ladegerat.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1424,
+      "word": "Schwingschleifer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schwingschleifer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 947,
+              "image": "http://testserver/media/images/schwingschleifer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1426,
+      "word": "Sicherung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sicherung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 949,
+              "image": "http://testserver/media/images/sicherung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1428,
+      "word": "Sondermüll",
+      "article": 1,
+      "audio": "http://testserver/media/audio/sondermull.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 951,
+              "image": "http://testserver/media/images/sondermull.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1446,
+      "word": "Ader",
+      "article": 2,
+      "audio": "http://testserver/media/audio/ader.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 971,
+              "image": "http://testserver/media/images/ader.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1447,
+      "word": "Notausschalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/notausschalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Notausschaltknopf",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 972,
+              "image": "http://testserver/media/images/notausschalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1449,
+      "word": "Außengewindeschneider",
+      "article": 1,
+      "audio": "http://testserver/media/audio/auengewindeschneider.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 973,
+              "image": "http://testserver/media/images/auengewindeschneider.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1450,
+      "word": "Bohrvorrichtung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bohrvorrichtung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 974,
+              "image": "http://testserver/media/images/bohrvorrichtung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1452,
+      "word": "Federscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/federscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 976,
+              "image": "http://testserver/media/images/federscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1453,
+      "word": "Flügelmutter",
+      "article": 2,
+      "audio": "http://testserver/media/audio/flugelmutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 977,
+              "image": "http://testserver/media/images/flugelmutter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1454,
+      "word": "Handbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 979,
+              "image": "http://testserver/media/images/handbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1455,
+      "word": "Kegelreibahle",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kegelreibahle.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 980,
+              "image": "http://testserver/media/images/kegelreibahle.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1456,
+      "word": "Kühlmittelflasche",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kuhlmittelflasche.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 981,
+              "image": "http://testserver/media/images/kuhlmittelflasche.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1457,
+      "word": "Manometer",
+      "article": 3,
+      "audio": "http://testserver/media/audio/manometer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 982,
+              "image": "http://testserver/media/images/manometer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1458,
+      "word": "Maschinengewindebohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/maschinengewindebohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 983,
+              "image": "http://testserver/media/images/maschinengewindebohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1459,
+      "word": "Ölkanne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/olkanne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Ölkännchen",
+              "article": 3
+          }
+      ],
+      "document_image": [
+          {
+              "id": 984,
+              "image": "http://testserver/media/images/olkanne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1460,
+      "word": "Radius",
+      "article": 1,
+      "audio": "http://testserver/media/audio/radius.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 985,
+              "image": "http://testserver/media/images/radius.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1461,
+      "word": "Rändelschraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/randelschraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 986,
+              "image": "http://testserver/media/images/randelschraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1463,
+      "word": "Spax-Schraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spax-schraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Universalschraube",
+              "article": 2
+          },
+          {
+              "alt_word": "Spax",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 988,
+              "image": "http://testserver/media/images/spax-schraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1464,
+      "word": "Unterlegscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/unterlegscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 989,
+              "image": "http://testserver/media/images/unterlegscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1465,
+      "word": "Zylinderkopfschraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/zylinderkopfschraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 992,
+              "image": "http://testserver/media/images/zylinderkopfschraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1466,
+      "word": "CNC-Fräsmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/cnc-frasmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 993,
+              "image": "http://testserver/media/images/cnc-frasmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1467,
+      "word": "Eckmesserkopf",
+      "article": 1,
+      "audio": "http://testserver/media/audio/eckmesserkopf.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 994,
+              "image": "http://testserver/media/images/eckmesserkopf.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1468,
+      "word": "Einstellring",
+      "article": 1,
+      "audio": "http://testserver/media/audio/einstellring.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 995,
+              "image": "http://testserver/media/images/einstellring.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1469,
+      "word": "Formfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/formfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 996,
+              "image": "http://testserver/media/images/formfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1470,
+      "word": "Grenzrachenlehre",
+      "article": 2,
+      "audio": "http://testserver/media/audio/grenzrachenlehre.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 997,
+              "image": "http://testserver/media/images/grenzrachenlehre.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1471,
+      "word": "Kantentaster",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kantentaster.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 998,
+              "image": "http://testserver/media/images/kantentaster.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1472,
+      "word": "Messerkopf",
+      "article": 1,
+      "audio": "http://testserver/media/audio/messerkopf.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 999,
+              "image": "http://testserver/media/images/messerkopf.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1473,
+      "word": "Messuhr",
+      "article": 2,
+      "audio": "http://testserver/media/audio/messuhr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1000,
+              "image": "http://testserver/media/images/messuhr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1474,
+      "word": "Radienfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/radienfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1002,
+              "image": "http://testserver/media/images/radienfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1475,
+      "word": "Satzfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/satzfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1003,
+              "image": "http://testserver/media/images/satzfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1476,
+      "word": "Schaftfräser mit Radius",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schaftfraser-mit-radius.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1004,
+              "image": "http://testserver/media/images/schaftfraser-mit-radius.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1477,
+      "word": "T-Nutenfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/t-nutenfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1005,
+              "image": "http://testserver/media/images/t-nutenfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1478,
+      "word": "T-Nutenstein",
+      "article": 1,
+      "audio": "http://testserver/media/audio/t-nutenstein.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1006,
+              "image": "http://testserver/media/images/t-nutenstein.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1479,
+      "word": "Trapezantriebsspindel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/trapezantriebsspindel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1007,
+              "image": "http://testserver/media/images/trapezantriebsspindel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1480,
+      "word": "Universaltaster",
+      "article": 1,
+      "audio": "http://testserver/media/audio/universaltaster.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1008,
+              "image": "http://testserver/media/images/universaltaster.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1481,
+      "word": "Walzenfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/walzenfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1009,
+              "image": "http://testserver/media/images/walzenfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1482,
+      "word": "Zahnradfräser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zahnradfraser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1012,
+              "image": "http://testserver/media/images/zahnradfraser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1483,
+      "word": "Abstechdrehmeißel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/abstechdrehmeiel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1013,
+              "image": "http://testserver/media/images/abstechdrehmeiel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1485,
+      "word": "Bitsatz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bitsatz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1015,
+              "image": "http://testserver/media/images/bitsatz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1487,
+      "word": "Bolzenschneider",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bolzenschneider.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1016,
+              "image": "http://testserver/media/images/bolzenschneider.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1488,
+      "word": "Bügelprisma",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bugelprisma.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1017,
+              "image": "http://testserver/media/images/bugelprisma.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1489,
+      "word": "Doppelkörner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/doppelkorner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1018,
+              "image": "http://testserver/media/images/doppelkorner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1491,
+      "word": "Druckluftpistole",
+      "article": 2,
+      "audio": "http://testserver/media/audio/druckluftpistole.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1020,
+              "image": "http://testserver/media/images/druckluftpistole.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1492,
+      "word": "E-Motor",
+      "article": 1,
+      "audio": "http://testserver/media/audio/e-motor.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1021,
+              "image": "http://testserver/media/images/e-motor.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1493,
+      "word": "Einstechdrehmeißel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/einstechdrehmeiel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1022,
+              "image": "http://testserver/media/images/einstechdrehmeiel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1494,
+      "word": "Gegenschlag",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gegenschlag.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1023,
+              "image": "http://testserver/media/images/gegenschlag.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1495,
+      "word": "Gewindestange",
+      "article": 2,
+      "audio": "http://testserver/media/audio/gewindestange.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1024,
+              "image": "http://testserver/media/images/gewindestange.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1496,
+      "word": "Gewindestift",
+      "article": 1,
+      "audio": "http://testserver/media/audio/gewindestift.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1025,
+              "image": "http://testserver/media/images/gewindestift.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1501,
+      "word": "Innendrehmeißel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/innendrehmeiel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1033,
+              "image": "http://testserver/media/images/innendrehmeiel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1502,
+      "word": "Inbus mit Griff",
+      "article": 1,
+      "audio": "http://testserver/media/audio/inbus-mit-griff.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Inbusschlüssel mit Griff",
+              "article": 1
+          },
+          {
+              "alt_word": "Stiftschlüssel mit Griff",
+              "article": 1
+          },
+          {
+              "alt_word": "Innensechskantschlüssel mit Griff",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1034,
+              "image": "http://testserver/media/images/inbus-mit-griff.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1503,
+      "word": "Inbussatz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/inbussatz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Innensechskantschlüsselsatz",
+              "article": 1
+          },
+          {
+              "alt_word": "Inbusschlüsselsatz",
+              "article": 1
+          },
+          {
+              "alt_word": "Stiftschlüsselsatz",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1035,
+              "image": "http://testserver/media/images/inbussatz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1504,
+      "word": "Klebekerze",
+      "article": 2,
+      "audio": "http://testserver/media/audio/klebekerze.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Klebekerzen",
+              "article": 4
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1036,
+              "image": "http://testserver/media/images/klebekerze.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1505,
+      "word": "Körnerplatte",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kornerplatte.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1038,
+              "image": "http://testserver/media/images/kornerplatte.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1506,
+      "word": "Kugellager",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kugellager.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1040,
+              "image": "http://testserver/media/images/kugellager.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1507,
+      "word": "Kraftmessdose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kraftmessdose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Kraftaufnehmer",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1041,
+              "image": "http://testserver/media/images/kraftmessdose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1509,
+      "word": "Akku-Ladestation",
+      "article": 2,
+      "audio": "http://testserver/media/audio/akku-ladestation.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Ladestation",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1043,
+              "image": "http://testserver/media/images/akku-ladestation.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1510,
+      "word": "Lastenkran",
+      "article": 1,
+      "audio": "http://testserver/media/audio/lastenkran.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1044,
+              "image": "http://testserver/media/images/lastenkran.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1511,
+      "word": "mitlaufende Spitze",
+      "article": 2,
+      "audio": "http://testserver/media/audio/mitlaufende-spitze.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1045,
+              "image": "http://testserver/media/images/mitlaufende-spitze.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1512,
+      "word": "O-Ring",
+      "article": 1,
+      "audio": "http://testserver/media/audio/o-ring.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1046,
+              "image": "http://testserver/media/images/o-ring.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1513,
+      "word": "Passstift",
+      "article": 1,
+      "audio": "http://testserver/media/audio/passstift.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1047,
+              "image": "http://testserver/media/images/passstift.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1514,
+      "word": "Poliervlies",
+      "article": 3,
+      "audio": "http://testserver/media/audio/poliervlies.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1048,
+              "image": "http://testserver/media/images/poliervlies.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1515,
+      "word": "Prisma",
+      "article": 3,
+      "audio": "http://testserver/media/audio/prisma.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1049,
+              "image": "http://testserver/media/images/prisma.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1517,
+      "word": "Reduzieröse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/reduzierose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1051,
+              "image": "http://testserver/media/images/reduzierose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1518,
+      "word": "Richtbank",
+      "article": 2,
+      "audio": "http://testserver/media/audio/richtbank.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1052,
+              "image": "http://testserver/media/images/richtbank.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1519,
+      "word": "Rohrschere",
+      "article": 2,
+      "audio": "http://testserver/media/audio/rohrschere.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1053,
+              "image": "http://testserver/media/images/rohrschere.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1520,
+      "word": "Säulenbohrmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/saulenbohrmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1054,
+              "image": "http://testserver/media/images/saulenbohrmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1521,
+      "word": "Schlauchschere",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schlauchschere.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1055,
+              "image": "http://testserver/media/images/schlauchschere.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1522,
+      "word": "Schleifpapierhalter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schleifpapierhalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1056,
+              "image": "http://testserver/media/images/schleifpapierhalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1523,
+      "word": "Schnellspanner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schnellspanner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1057,
+              "image": "http://testserver/media/images/schnellspanner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1525,
+      "word": "Schweißerkabine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schweierkabine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1060,
+              "image": "http://testserver/media/images/schweierkabine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1526,
+      "word": "Sicherungsring",
+      "article": 1,
+      "audio": "http://testserver/media/audio/sicherungsring.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1061,
+              "image": "http://testserver/media/images/sicherungsring.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1527,
+      "word": "Spannfeder",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spannfeder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Feder",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1062,
+              "image": "http://testserver/media/images/spannfeder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1528,
+      "word": "Spannfutter",
+      "article": 3,
+      "audio": "http://testserver/media/audio/spannfutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1063,
+              "image": "http://testserver/media/images/spannfutter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1529,
+      "word": "Spannhülse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spannhulse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1064,
+              "image": "http://testserver/media/images/spannhulse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1530,
+      "word": "Spanntreppe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spanntreppe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1065,
+              "image": "http://testserver/media/images/spanntreppe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1531,
+      "word": "Tafelschere",
+      "article": 2,
+      "audio": "http://testserver/media/audio/tafelschere.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1066,
+              "image": "http://testserver/media/images/tafelschere.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1532,
+      "word": "Tiefenmaßstab",
+      "article": 1,
+      "audio": "http://testserver/media/audio/tiefenmastab.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1067,
+              "image": "http://testserver/media/images/tiefenmastab.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1533,
+      "word": "Trennstemmer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/trennstemmer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1068,
+              "image": "http://testserver/media/images/trennstemmer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1534,
+      "word": "Werkzeugwagen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/werkzeugwagen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1069,
+              "image": "http://testserver/media/images/werkzeugwagen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1536,
+      "word": "Austreiber",
+      "article": 1,
+      "audio": "http://testserver/media/audio/austreiber.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1071,
+              "image": "http://testserver/media/images/austreiber.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1537,
+      "word": "Feilenbürste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/feilenburste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1073,
+              "image": "http://testserver/media/images/feilenburste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1538,
+      "word": "Flachspanner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/flachspanner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1074,
+              "image": "http://testserver/media/images/flachspanner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1539,
+      "word": "Haarwinkel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/haarwinkel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1075,
+              "image": "http://testserver/media/images/haarwinkel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1540,
+      "word": "Schlichtfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schlichtfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1078,
+              "image": "http://testserver/media/images/schlichtfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1541,
+      "word": "Schlosserfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schlosserfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1079,
+              "image": "http://testserver/media/images/schlosserfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1542,
+      "word": "Senkkopfschraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/senkkopfschraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1080,
+              "image": "http://testserver/media/images/senkkopfschraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1543,
+      "word": "Schruppfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schruppfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1081,
+              "image": "http://testserver/media/images/schruppfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1544,
+      "word": "Spannpratze",
+      "article": 2,
+      "audio": "http://testserver/media/audio/spannpratze.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1082,
+              "image": "http://testserver/media/images/spannpratze.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1545,
+      "word": "Stahlmaßstab",
+      "article": 1,
+      "audio": "http://testserver/media/audio/stahlmastab.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1083,
+              "image": "http://testserver/media/images/stahlmastab.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1546,
+      "word": "Vierkantfeile",
+      "article": 2,
+      "audio": "http://testserver/media/audio/vierkantfeile.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1084,
+              "image": "http://testserver/media/images/vierkantfeile.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1547,
+      "word": "Werkbank",
+      "article": 2,
+      "audio": "http://testserver/media/audio/werkbank.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1085,
+              "image": "http://testserver/media/images/werkbank.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1555,
+      "word": "Kreide",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kreide.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1087,
+              "image": "http://testserver/media/images/kreide.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1556,
+      "word": "Pinsel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/pinsel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1088,
+              "image": "http://testserver/media/images/pinsel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1557,
+      "word": "Schäferkiste",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schaferkiste.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1089,
+              "image": "http://testserver/media/images/schaferkiste.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1558,
+      "word": "Spiritus",
+      "article": 1,
+      "audio": "http://testserver/media/audio/spiritus.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1090,
+              "image": "http://testserver/media/images/spiritus.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1559,
+      "word": "Sprühreiniger",
+      "article": 1,
+      "audio": "http://testserver/media/audio/spruhreiniger.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1091,
+              "image": "http://testserver/media/images/spruhreiniger.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1573,
+      "word": "Sechskantschraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sechskantschraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1599,
+              "image": "http://testserver/media/images/sechskantschraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1594,
+      "word": "Heftklammern",
+      "article": 4,
+      "audio": "http://testserver/media/audio/heftklammern.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1126,
+              "image": "http://testserver/media/images/heftklammern.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1595,
+      "word": "Lagerplatzetikett",
+      "article": 3,
+      "audio": "http://testserver/media/audio/lagerplatzetikett.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1127,
+              "image": "http://testserver/media/images/lagerplatzetikett.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1596,
+      "word": "Stempel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/stempel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1128,
+              "image": "http://testserver/media/images/stempel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1599,
+      "word": "Stempelkissen",
+      "article": 3,
+      "audio": "http://testserver/media/audio/stempelkissen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1852,
+              "image": "http://testserver/media/images/stempelkissen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1623,
+      "word": "Dose",
+      "article": 2,
+      "audio": "http://testserver/media/audio/dose.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1296,
+              "image": "http://testserver/media/images/dose.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1684,
+      "word": "Brandmelder",
+      "article": 1,
+      "audio": "http://testserver/media/audio/brandmelder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1324,
+              "image": "http://testserver/media/images/brandmelder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1685,
+      "word": "Kapselgehörschutz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kapselgehorschutz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1325,
+              "image": "http://testserver/media/images/kapselgehorschutz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1699,
+      "word": "KFZ-Werkstatt",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kfz-werkstatt.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1346,
+              "image": "http://testserver/media/images/kfz-werkstatt.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1701,
+      "word": "Prüfwerkstatt",
+      "article": 2,
+      "audio": "http://testserver/media/audio/prufwerkstatt.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1348,
+              "image": "http://testserver/media/images/prufwerkstatt.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1707,
+      "word": "Werkzeugkoffer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/werkzeugkoffer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1584,
+              "image": "http://testserver/media/images/werkzeugkoffer.png"
+          }
+      ]
+  },
+  {
+      "id": 1709,
+      "word": "Fahrzeugbrief",
+      "article": 1,
+      "audio": "http://testserver/media/audio/fahrzeugbrief.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1350,
+              "image": "http://testserver/media/images/fahrzeugbrief.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1711,
+      "word": "Fahrzeugschein",
+      "article": 1,
+      "audio": "http://testserver/media/audio/fahrzeugschein.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1351,
+              "image": "http://testserver/media/images/fahrzeugschein.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1713,
+      "word": "Feinstaubplakette",
+      "article": 2,
+      "audio": "http://testserver/media/audio/feinstaubplakette.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1352,
+              "image": "http://testserver/media/images/feinstaubplakette.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1716,
+      "word": "Prüfplakette",
+      "article": 2,
+      "audio": "http://testserver/media/audio/prufplakette.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1354,
+              "image": "http://testserver/media/images/prufplakette.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1717,
+      "word": "Serviceheft",
+      "article": 3,
+      "audio": "http://testserver/media/audio/serviceheft.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1355,
+              "image": "http://testserver/media/images/serviceheft.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1718,
+      "word": "Typenschild",
+      "article": 3,
+      "audio": "http://testserver/media/audio/typenschild.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1356,
+              "image": "http://testserver/media/images/typenschild.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1732,
+      "word": "Beifahrertür",
+      "article": 2,
+      "audio": "http://testserver/media/audio/beifahrertur.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1369,
+              "image": "http://testserver/media/images/beifahrertur.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1733,
+      "word": "Dachreling",
+      "article": 2,
+      "audio": "http://testserver/media/audio/dachreling.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1370,
+              "image": "http://testserver/media/images/dachreling.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1734,
+      "word": "Fahrertür",
+      "article": 2,
+      "audio": "http://testserver/media/audio/fahrertur.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1371,
+              "image": "http://testserver/media/images/fahrertur.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1735,
+      "word": "Fahrzeugfront",
+      "article": 2,
+      "audio": "http://testserver/media/audio/fahrzeugfront.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1372,
+              "image": "http://testserver/media/images/fahrzeugfront.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1736,
+      "word": "Fahrzeugheck",
+      "article": 3,
+      "audio": "http://testserver/media/audio/fahrzeugheck.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1373,
+              "image": "http://testserver/media/images/fahrzeugheck.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1737,
+      "word": "Frontscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/frontscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1374,
+              "image": "http://testserver/media/images/frontscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1738,
+      "word": "Kofferraum",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kofferraum.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1376,
+              "image": "http://testserver/media/images/kofferraum.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1739,
+      "word": "Kotflügel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kotflugel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1377,
+              "image": "http://testserver/media/images/kotflugel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1740,
+      "word": "Kühlergrill",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kuhlergrill.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1378,
+              "image": "http://testserver/media/images/kuhlergrill.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1741,
+      "word": "Ladeanschluss",
+      "article": 1,
+      "audio": "http://testserver/media/audio/ladeanschluss.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1379,
+              "image": "http://testserver/media/images/ladeanschluss.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1742,
+      "word": "Motorhaube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/motorhaube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1380,
+              "image": "http://testserver/media/images/motorhaube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1743,
+      "word": "Motorhaubenschloss",
+      "article": 3,
+      "audio": "http://testserver/media/audio/motorhaubenschloss.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1381,
+              "image": "http://testserver/media/images/motorhaubenschloss.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1744,
+      "word": "Schweller",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schweller.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1382,
+              "image": "http://testserver/media/images/schweller.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1747,
+      "word": "Türgriff",
+      "article": 1,
+      "audio": "http://testserver/media/audio/turgriff.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1386,
+              "image": "http://testserver/media/images/turgriff.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1748,
+      "word": "Türschloss",
+      "article": 3,
+      "audio": "http://testserver/media/audio/turschloss.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1387,
+              "image": "http://testserver/media/images/turschloss.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1754,
+      "word": "Ablagefach",
+      "article": 3,
+      "audio": "http://testserver/media/audio/ablagefach.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1400,
+              "image": "http://testserver/media/images/ablagefach.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1755,
+      "word": "Airbag",
+      "article": 1,
+      "audio": "http://testserver/media/audio/airbag.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1398,
+              "image": "http://testserver/media/images/airbag.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1757,
+      "word": "Aschenbecher",
+      "article": 1,
+      "audio": "http://testserver/media/audio/aschenbecher.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1399,
+              "image": "http://testserver/media/images/aschenbecher.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1758,
+      "word": "Mittelarmlehne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/mittelarmlehne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Armlehne",
+              "article": 2
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1401,
+              "image": "http://testserver/media/images/mittelarmlehne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1761,
+      "word": "Handbremshebel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handbremshebel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1402,
+              "image": "http://testserver/media/images/handbremshebel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1762,
+      "word": "Gurtschloss",
+      "article": 3,
+      "audio": "http://testserver/media/audio/gurtschloss.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1403,
+              "image": "http://testserver/media/images/gurtschloss.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1763,
+      "word": "Fußraum",
+      "article": 1,
+      "audio": "http://testserver/media/audio/furaum.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1404,
+              "image": "http://testserver/media/images/furaum.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1767,
+      "word": "Handgriff",
+      "article": 1,
+      "audio": "http://testserver/media/audio/handgriff.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1408,
+              "image": "http://testserver/media/images/handgriff.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1768,
+      "word": "Handschuhfach",
+      "article": 3,
+      "audio": "http://testserver/media/audio/handschuhfach.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1409,
+              "image": "http://testserver/media/images/handschuhfach.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1770,
+      "word": "Instrumententafel",
+      "article": 2,
+      "audio": "http://testserver/media/audio/instrumententafel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1411,
+              "image": "http://testserver/media/images/instrumententafel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1771,
+      "word": "Kofferraumabdeckung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kofferraumabdeckung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1412,
+              "image": "http://testserver/media/images/kofferraumabdeckung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1773,
+      "word": "Kupplungspedal",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kupplungspedal.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1414,
+              "image": "http://testserver/media/images/kupplungspedal.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1776,
+      "word": "Rücksitz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/rucksitz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1417,
+              "image": "http://testserver/media/images/rucksitz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1777,
+      "word": "Schalthebel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schalthebel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1418,
+              "image": "http://testserver/media/images/schalthebel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1779,
+      "word": "Sicherungskasten",
+      "article": 1,
+      "audio": "http://testserver/media/audio/sicherungskasten.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1420,
+              "image": "http://testserver/media/images/sicherungskasten.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1780,
+      "word": "Sonnenblende",
+      "article": 2,
+      "audio": "http://testserver/media/audio/sonnenblende.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1421,
+              "image": "http://testserver/media/images/sonnenblende.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1781,
+      "word": "Türöffner",
+      "article": 1,
+      "audio": "http://testserver/media/audio/turoffner.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1422,
+              "image": "http://testserver/media/images/turoffner.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1783,
+      "word": "Anlasser",
+      "article": 1,
+      "audio": "http://testserver/media/audio/anlasser.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1426,
+              "image": "http://testserver/media/images/anlasser.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1784,
+      "word": "Batterieklemme",
+      "article": 2,
+      "audio": "http://testserver/media/audio/batterieklemme.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1427,
+              "image": "http://testserver/media/images/batterieklemme.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1785,
+      "word": "Bremsflüssigkeit",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bremsflussigkeit.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1428,
+              "image": "http://testserver/media/images/bremsflussigkeit.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1786,
+      "word": "Keilriemen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/keilriemen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1429,
+              "image": "http://testserver/media/images/keilriemen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1788,
+      "word": "Kühlflüssigkeit",
+      "article": 2,
+      "audio": "http://testserver/media/audio/kuhlflussigkeit.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1431,
+              "image": "http://testserver/media/images/kuhlflussigkeit.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1789,
+      "word": "Lichtmaschine",
+      "article": 2,
+      "audio": "http://testserver/media/audio/lichtmaschine.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1432,
+              "image": "http://testserver/media/images/lichtmaschine.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1792,
+      "word": "Motorabdeckung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/motorabdeckung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1435,
+              "image": "http://testserver/media/images/motorabdeckung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1793,
+      "word": "Ölfilter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/olfilter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1437,
+              "image": "http://testserver/media/images/olfilter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1797,
+      "word": "Waschwasserbehälter",
+      "article": 1,
+      "audio": "http://testserver/media/audio/waschwasserbehalter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1440,
+              "image": "http://testserver/media/images/waschwasserbehalter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1798,
+      "word": "Zahnriemen",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zahnriemen.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1441,
+              "image": "http://testserver/media/images/zahnriemen.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1799,
+      "word": "Feder",
+      "article": 2,
+      "audio": "http://testserver/media/audio/feder.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1597,
+              "image": "http://testserver/media/images/feder.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1804,
+      "word": "Abgasendrohr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/abgasendrohr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1453,
+              "image": "http://testserver/media/images/abgasendrohr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1805,
+      "word": "Abgasrohr",
+      "article": 3,
+      "audio": "http://testserver/media/audio/abgasrohr.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1454,
+              "image": "http://testserver/media/images/abgasrohr.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1807,
+      "word": "Auspuffblende",
+      "article": 2,
+      "audio": "http://testserver/media/audio/auspuffblende.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1455,
+              "image": "http://testserver/media/images/auspuffblende.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1808,
+      "word": "Auswuchtgewicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/auswuchtgewicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1456,
+              "image": "http://testserver/media/images/auswuchtgewicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1809,
+      "word": "Bremsbelag",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bremsbelag.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1457,
+              "image": "http://testserver/media/images/bremsbelag.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1810,
+      "word": "Bremsleitung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bremsleitung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1458,
+              "image": "http://testserver/media/images/bremsleitung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1811,
+      "word": "Bremssattel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bremssattel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1459,
+              "image": "http://testserver/media/images/bremssattel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1812,
+      "word": "Bremsscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/bremsscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1460,
+              "image": "http://testserver/media/images/bremsscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1813,
+      "word": "Federbein",
+      "article": 3,
+      "audio": "http://testserver/media/audio/federbein.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1461,
+              "image": "http://testserver/media/images/federbein.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1814,
+      "word": "Felge",
+      "article": 2,
+      "audio": "http://testserver/media/audio/felge.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1462,
+              "image": "http://testserver/media/images/felge.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1815,
+      "word": "Führungslenker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/fuhrungslenker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1463,
+              "image": "http://testserver/media/images/fuhrungslenker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1818,
+      "word": "Kugelgelenk",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kugelgelenk.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1465,
+              "image": "http://testserver/media/images/kugelgelenk.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1819,
+      "word": "Lambdasonde",
+      "article": 2,
+      "audio": "http://testserver/media/audio/lambdasonde.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1466,
+              "image": "http://testserver/media/images/lambdasonde.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1820,
+      "word": "Mittelschalldämpfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/mittelschalldampfer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1467,
+              "image": "http://testserver/media/images/mittelschalldampfer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1821,
+      "word": "Ölwanne",
+      "article": 2,
+      "audio": "http://testserver/media/audio/olwanne.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1468,
+              "image": "http://testserver/media/images/olwanne.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1822,
+      "word": "Radaufhängung",
+      "article": 2,
+      "audio": "http://testserver/media/audio/radaufhangung.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1469,
+              "image": "http://testserver/media/images/radaufhangung.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1823,
+      "word": "Radmutter",
+      "article": 2,
+      "audio": "http://testserver/media/audio/radmutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1470,
+              "image": "http://testserver/media/images/radmutter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1824,
+      "word": "Reifenprofil",
+      "article": 3,
+      "audio": "http://testserver/media/audio/reifenprofil.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1471,
+              "image": "http://testserver/media/images/reifenprofil.png"
+          }
+      ]
+  },
+  {
+      "id": 1825,
+      "word": "Scheibenbremse",
+      "article": 2,
+      "audio": "http://testserver/media/audio/scheibenbremse.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1472,
+              "image": "http://testserver/media/images/scheibenbremse.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1826,
+      "word": "Stabilisator",
+      "article": 1,
+      "audio": "http://testserver/media/audio/stabilisator.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1480,
+              "image": "http://testserver/media/images/stabilisator.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1827,
+      "word": "Stoßdämpfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/stodampfer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1473,
+              "image": "http://testserver/media/images/stodampfer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1830,
+      "word": "Ringschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/ringschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1476,
+              "image": "http://testserver/media/images/ringschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1831,
+      "word": "Kunststoffhammer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/kunststoffhammer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1477,
+              "image": "http://testserver/media/images/kunststoffhammer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1833,
+      "word": "Zündkerzenschlüssel",
+      "article": 1,
+      "audio": "http://testserver/media/audio/zundkerzenschlussel.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1479,
+              "image": "http://testserver/media/images/zundkerzenschlussel.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1834,
+      "word": "Abblendlicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/abblendlicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1483,
+              "image": "http://testserver/media/images/abblendlicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1835,
+      "word": "Blinklicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/blinklicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1484,
+              "image": "http://testserver/media/images/blinklicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1836,
+      "word": "Bremslicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/bremslicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1485,
+              "image": "http://testserver/media/images/bremslicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1837,
+      "word": "Fernlicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/fernlicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1486,
+              "image": "http://testserver/media/images/fernlicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1839,
+      "word": "Kennzeichenlicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/kennzeichenlicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1488,
+              "image": "http://testserver/media/images/kennzeichenlicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1840,
+      "word": "Rückfahrlicht",
+      "article": 3,
+      "audio": "http://testserver/media/audio/ruckfahrlicht.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1489,
+              "image": "http://testserver/media/images/ruckfahrlicht.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1841,
+      "word": "Scheinwerfer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/scheinwerfer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1490,
+              "image": "http://testserver/media/images/scheinwerfer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1844,
+      "word": "Bordcomputer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bordcomputer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1491,
+              "image": "http://testserver/media/images/bordcomputer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1845,
+      "word": "Einparkhilfe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/einparkhilfe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1492,
+              "image": "http://testserver/media/images/einparkhilfe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1846,
+      "word": "Hupe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/hupe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1493,
+              "image": "http://testserver/media/images/hupe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1848,
+      "word": "Scheibenwischintervall",
+      "article": 3,
+      "audio": "http://testserver/media/audio/scheibenwischintervall.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1495,
+              "image": "http://testserver/media/images/scheibenwischintervall.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1850,
+      "word": "Wischautomatik",
+      "article": 2,
+      "audio": "http://testserver/media/audio/wischautomatik.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1497,
+              "image": "http://testserver/media/images/wischautomatik.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1851,
+      "word": "Gefahrenstofflager",
+      "article": 3,
+      "audio": "http://testserver/media/audio/gefahrenstofflager.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1498,
+              "image": "http://testserver/media/images/gefahrenstofflager.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1852,
+      "word": "Mundschutz",
+      "article": 1,
+      "audio": "http://testserver/media/audio/mundschutz.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1499,
+              "image": "http://testserver/media/images/mundschutz.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1857,
+      "word": "Schleifset",
+      "article": 3,
+      "audio": "http://testserver/media/audio/schleifset.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1504,
+              "image": "http://testserver/media/images/schleifset.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1864,
+      "word": "Bandschleifer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/bandschleifer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1516,
+              "image": "http://testserver/media/images/bandschleifer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1874,
+      "word": "Schleifscheibe",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schleifscheibe.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1526,
+              "image": "http://testserver/media/images/schleifscheibe.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1875,
+      "word": "Steinbohrer",
+      "article": 1,
+      "audio": "http://testserver/media/audio/steinbohrer.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1527,
+              "image": "http://testserver/media/images/steinbohrer.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1887,
+      "word": "Maschinenschraubstock",
+      "article": 1,
+      "audio": "http://testserver/media/audio/maschinenschraubstock.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1533,
+              "image": "http://testserver/media/images/maschinenschraubstock.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1888,
+      "word": "Schleifblock",
+      "article": 1,
+      "audio": "http://testserver/media/audio/schleifblock.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1534,
+              "image": "http://testserver/media/images/schleifblock.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1889,
+      "word": "Starkstromstecker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/starkstromstecker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1535,
+              "image": "http://testserver/media/images/starkstromstecker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1896,
+      "word": "D3-Leim",
+      "article": 1,
+      "audio": "http://testserver/media/audio/d3-leim.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1539,
+              "image": "http://testserver/media/images/d3-leim.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1897,
+      "word": "Einschraubhaken",
+      "article": 1,
+      "audio": "http://testserver/media/audio/einschraubhaken.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1540,
+              "image": "http://testserver/media/images/einschraubhaken.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1898,
+      "word": "Hutmutter",
+      "article": 2,
+      "audio": "http://testserver/media/audio/hutmutter.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1541,
+              "image": "http://testserver/media/images/hutmutter.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1900,
+      "word": "Schlossschraube",
+      "article": 2,
+      "audio": "http://testserver/media/audio/schlossschraube.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1543,
+              "image": "http://testserver/media/images/schlossschraube.jpg"
+          }
+      ]
+  },
+  {
+      "id": 1973,
+      "word": "Textmarker",
+      "article": 1,
+      "audio": "http://testserver/media/audio/textmarker.mp3",
+      "word_type": "Nomen",
+      "alternatives": [],
+      "document_image": [
+          {
+              "id": 1627,
+              "image": "http://testserver/media/images/textmarker.jpg"
+          }
+      ]
+  },
+  {
+      "id": 2139,
+      "word": "Arbeitsschuh",
+      "article": 1,
+      "audio": "http://testserver/media/audio/arbeitsschuh.mp3",
+      "word_type": "Nomen",
+      "alternatives": [
+          {
+              "alt_word": "Sicherheitsschuh",
+              "article": 1
+          }
+      ],
+      "document_image": [
+          {
+              "id": 1849,
+              "image": "http://testserver/media/images/arbeitsschuh.jpg"
+          }
+      ]
+  }
+]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add the possibility to retrieve public vocabulary words

### Proposed changes
<!-- Describe this PR in more detail. -->
- Extend the queryset of the `/words` endpoint when an API key is given
- Adapt tests

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #404
