### PR TITLE
Use different logo on login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#404](https://github.com/digitalfabrik/lunes-cms/issues/404) ] Deliver protected vocabulary words in API
+* [ [#412](https://github.com/digitalfabrik/lunes-cms/issues/412) ] Use different logo on login form
 
 
 2022.8.0

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -449,6 +449,8 @@ JAZZMIN_SETTINGS = {
     "site_header": _("Lunes Administration"),
     "site_logo": "images/logo.svg",
     "site_icon": "images/logo.svg",
+    "login_logo": "images/logo-lunes.svg",
+    "login_logo_dark": "images/logo-lunes-dark.svg",
     "site_logo_classes": "",
     "changeform_format": "collapsible",
     "language_chooser": True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages =
 	lunes_cms
 install_requires =
 	django==3.2.16
-	django-jazzmin==2.5.0
+	django-jazzmin==2.6.0
 	django-mptt==0.14.0
 	django-qr-code==3.1.1
 	djangorestframework==3.14.0


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since today's release, [django-jazzmin 2.6.0](https://pypi.org/project/django-jazzmin/#history) finally supports [different logos on the login form](https://github.com/farridav/django-jazzmin/pull/397).

### Proposed changes
<!-- Describe this PR in more detail. -->
Before:
| Light mode | Dark mode |
|------------|-----------|
| ![Screenshot 2022-11-03 at 20-44-23 Anmelden Lunes-Verwaltung](https://user-images.githubusercontent.com/16021269/199820098-cd23ed26-678b-4d36-aec0-ecbe9d78c9b4.png) | ![Screenshot 2022-11-03 at 20-44-32 Anmelden Lunes-Verwaltung](https://user-images.githubusercontent.com/16021269/199820123-2a6c1424-6153-4c9e-8824-ca10f097ec0b.png) |

After:
| Light mode | Dark mode |
|------------|-----------|
| ![Screenshot 2022-11-03 at 20-39-56 Anmelden Lunes-Verwaltung](https://user-images.githubusercontent.com/16021269/199820160-a25e978c-2197-41ff-a28c-199d1658446c.png) | ![Screenshot 2022-11-03 at 20-39-34 Anmelden Lunes-Verwaltung](https://user-images.githubusercontent.com/16021269/199820185-121d2577-09f5-4aec-9c53-db84aea8a777.png) |


