### PR TITLE
Enable grouped version updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "django"
         versions: [">=4.0"]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
GitHub released [grouped version updates for Dependabot in public beta](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/) now.
This should hopefully result in only one dependabot PR per month which contains all version updates, instead of one PR per dependency.

Also see config docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups