### PR TITLE
Improve admin list filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#478](https://github.com/digitalfabrik/lunes-cms/issues/478) ] Add possibility to set example sentence
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add module and vocabulary counters to discipline list
+* [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add vocabulary counters to training set list
 
 
 2023.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add module and vocabulary counters to discipline list
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add vocabulary counters to training set list
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Group discipline filter by parent discipline
+* [ [#368](https://github.com/digitalfabrik/lunes-cms/issues/368) ] Limit training set filter options by selected discipline and vice versa
 
 
 2023.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#478](https://github.com/digitalfabrik/lunes-cms/issues/478) ] Add possibility to set example sentence
+* [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add module and vocabulary counters to discipline list
 
 
 2023.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#478](https://github.com/digitalfabrik/lunes-cms/issues/478) ] Add possibility to set example sentence
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add module and vocabulary counters to discipline list
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add vocabulary counters to training set list
+* [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Group discipline filter by parent discipline
 
 
 2023.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Add vocabulary counters to training set list
 * [ [#490](https://github.com/digitalfabrik/lunes-cms/issues/490) ] Group discipline filter by parent discipline
 * [ [#368](https://github.com/digitalfabrik/lunes-cms/issues/368) ] Limit training set filter options by selected discipline and vice versa
+* [ [#476](https://github.com/digitalfabrik/lunes-cms/issues/476) ] Add possibility to filter vocabulary by released training sets
 
 
 2023.5.0

--- a/lunes_cms/cms/admin.py
+++ b/lunes_cms/cms/admin.py
@@ -51,30 +51,8 @@ def get_app_list(self, request):
 
 
 admin.AdminSite.get_app_list = get_app_list
-admin.site.register(
-    Discipline,
-    DisciplineAdmin,
-    list_display=(
-        "tree_actions",
-        "indented_title",
-        "released",
-        "creator_group",
-    ),
-    list_display_links=("indented_title",),
-)
-admin.site.register(
-    TrainingSet,
-    TrainingSetAdmin,
-    list_display=(
-        "tree_actions",
-        "indented_title",
-        "title",
-        "released",
-        "related_disciplines",
-        "creator_group",
-    ),
-    list_display_links=("indented_title",),
-)
+admin.site.register(Discipline, DisciplineAdmin)
+admin.site.register(TrainingSet, TrainingSetAdmin)
 admin.site.register(Document, DocumentAdmin)
 admin.site.register(GroupAPIKey, GroupAPIKeyAdmin)
 admin.site.register(Feedback, FeedbackAdmin)

--- a/lunes_cms/cms/admins/discipline_admin.py
+++ b/lunes_cms/cms/admins/discipline_admin.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
+from django.db.models import Count, F, Q
+from django.db.models.functions import Greatest
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from mptt.admin import DraggableMPTTAdmin
@@ -25,8 +29,24 @@ class DisciplineAdmin(DraggableMPTTAdmin):
     ]
     readonly_fields = ["created_by", "image_tag"]
     search_fields = ["title"]
+    list_display = [
+        "tree_actions",
+        "indented_title",
+        "released",
+        "modules_released",
+        "modules_unreleased",
+        "words_released",
+        "creator_group",
+    ]
+    list_display_links = ["indented_title"]
+    list_filter = ["released"]
     actions = ["delete_selected", "make_released", "make_unreleased"]
     list_per_page = 25
+
+    def get_list_display(self, request):
+        if request.user.is_superuser:
+            return self.list_display
+        return [display for display in self.list_display if display != "words_released"]
 
     def save_model(self, request, obj, form, change):
         """
@@ -77,10 +97,115 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         :return: adjusted queryset
         :rtype: QuerySet
         """
-        qs = super(DisciplineAdmin, self).get_queryset(request)
+        qs = super().get_queryset(request)
         if request.user.is_superuser:
-            return qs.filter(creator_is_admin=True)
-        return qs.filter(created_by__in=request.user.groups.all())
+            return qs.filter(creator_is_admin=True).annotate(
+                modules_released=Count(
+                    "training_sets",
+                    filter=Q(
+                        training_sets__creator_is_admin=True,
+                        training_sets__released=True,
+                    ),
+                    distinct=True,
+                ),
+                modules_unreleased=Count(
+                    "training_sets",
+                    filter=Q(
+                        training_sets__creator_is_admin=True,
+                        training_sets__released=False,
+                    ),
+                    distinct=True,
+                ),
+                children_modules_released=Count(
+                    "children__training_sets",
+                    filter=Q(
+                        children__creator_is_admin=True,
+                        children__training_sets__creator_is_admin=True,
+                        children__training_sets__released=True,
+                    ),
+                    distinct=True,
+                ),
+                children_modules_unreleased=Count(
+                    "children__training_sets",
+                    filter=Q(
+                        children__creator_is_admin=True,
+                        children__training_sets__creator_is_admin=True,
+                        children__training_sets__released=False,
+                    ),
+                    distinct=True,
+                ),
+                words_released=Count(
+                    "training_sets__documents",
+                    filter=Q(
+                        training_sets__released=True,
+                        training_sets__documents__creator_is_admin=True,
+                        training_sets__documents__document_image__confirmed=True,
+                    ),
+                    distinct=True,
+                ),
+                children_words_released=Count(
+                    "children__training_sets__documents",
+                    filter=Q(
+                        children__creator_is_admin=True,
+                        children__training_sets__released=True,
+                        children__training_sets__documents__creator_is_admin=True,
+                        children__training_sets__documents__document_image__confirmed=True,
+                    ),
+                    distinct=True,
+                ),
+                modules_released_order=Greatest(
+                    "modules_released", "children_modules_released"
+                ),
+                modules_unreleased_order=Greatest(
+                    "modules_unreleased", "children_modules_unreleased"
+                ),
+                words_released_order=Greatest(
+                    "words_released", "children_words_released"
+                ),
+            )
+        user_groups = request.user.groups.all()
+        return qs.filter(created_by__in=user_groups).annotate(
+            modules_released=Count(
+                "training_sets",
+                filter=Q(
+                    training_sets__created_by__in=user_groups,
+                    training_sets__released=True,
+                ),
+                distinct=True,
+            ),
+            modules_unreleased=Count(
+                "training_sets",
+                filter=Q(
+                    training_sets__created_by__in=user_groups,
+                    training_sets__released=False,
+                ),
+                distinct=True,
+            ),
+            children_modules_released=Count(
+                "children__training_sets",
+                filter=Q(
+                    children__created_by__in=user_groups,
+                    children__training_sets__created_by__in=user_groups,
+                    children__training_sets__released=True,
+                ),
+                distinct=True,
+            ),
+            children_modules_unreleased=Count(
+                "children__training_sets",
+                filter=Q(
+                    children__created_by__in=user_groups,
+                    children__training_sets__created_by__in=user_groups,
+                    children__training_sets__released=False,
+                ),
+                distinct=True,
+            ),
+            modules_released_order=Greatest(
+                "modules_released", "children_modules_released"
+            ),
+            modules_unreleased_order=Greatest(
+                "modules_unreleased", "children_modules_unreleased"
+            ),
+        )
 
     def get_form(self, request, obj=None, **kwargs):
         """
@@ -145,6 +270,45 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         """
         queryset.update(released=False)
 
+    @admin.display(
+        description=_("released modules"),
+        ordering="modules_released_order",
+    )
+    def modules_released(self, obj):
+        if not obj.is_leaf_node():
+            return obj.children_modules_released
+        trainingset_list = reverse("admin:cms_trainingset_changelist")
+        return mark_safe(
+            f"<a href={trainingset_list}?disciplines={obj.id}&released__exact=1>{obj.modules_released}</a>"
+        )
+
+    @admin.display(
+        description=_("unreleased modules"),
+        ordering="modules_unreleased_order",
+    )
+    def modules_unreleased(self, obj):
+        if not obj.is_leaf_node():
+            return obj.children_modules_unreleased
+        trainingset_list = reverse("admin:cms_trainingset_changelist")
+        return mark_safe(
+            f"<a href={trainingset_list}?disciplines={obj.id}&released__exact=0>{obj.modules_unreleased}</a>"
+        )
+
+    @admin.display(
+        description=_("published words in released modules"),
+        ordering="-words_released_order",
+    )
+    def words_released(self, obj):
+        if not obj.is_leaf_node():
+            return obj.children_words_released
+        document_list = reverse("admin:cms_document_changelist")
+        return mark_safe(
+            f"<a href={document_list}?disciplines={obj.id}&assigned=released&images=approved>{obj.words_released}</a>"
+        )
+
+    @admin.display(
+        description=_("creator group"),
+    )
     def creator_group(self, obj):
         """
         Include creator group of discipline in list display
@@ -161,8 +325,6 @@ class DisciplineAdmin(DraggableMPTTAdmin):
             return obj.created_by
         else:
             return None
-
-    creator_group.short_description = _("creator group")
 
     class Media:
         js = ("js/image_preview.js",)

--- a/lunes_cms/cms/admins/document_admin.py
+++ b/lunes_cms/cms/admins/document_admin.py
@@ -42,8 +42,8 @@ class DocumentAdmin(admin.ModelAdmin):
     list_filter = (
         DocumentDisciplineListFilter,
         DocumentTrainingSetListFilter,
-        ApprovedImageListFilter,
         AssignedListFilter,
+        ApprovedImageListFilter,
     )
     list_per_page = 25
 

--- a/lunes_cms/cms/list_filter.py
+++ b/lunes_cms/cms/list_filter.py
@@ -149,16 +149,22 @@ class DocumentTrainingSetListFilter(admin.SimpleListFilter):
         return queryset
 
 
+NONE = "none"
+PENDING = "pending"
+APPROVED = "approved"
+NO_APPROVED = "no-approved"
+
+
 class ApprovedImageListFilter(admin.SimpleListFilter):
     """
     Filter for approved images within document list display.
     Inherits from `admin.SimpleListFilter`.
     """
 
-    title = _("approved images")
+    title = _("Images")
 
     # Parameter for the filter that will be used in the URL query.
-    parameter_name = "approvedimages"
+    parameter_name = "images"
 
     default_value = None
 
@@ -176,9 +182,10 @@ class ApprovedImageListFilter(admin.SimpleListFilter):
         :rtype: list
         """
         return (
-            (1, _("at least one approved image")),
-            (2, _("at least one pending image")),
-            (3, _("no images")),
+            (APPROVED, _("At least one approved image")),
+            (PENDING, _("At least one pending image")),
+            (NO_APPROVED, _("No approved images")),
+            (NONE, _("No images")),
         )
 
     def queryset(self, request, queryset):
@@ -196,12 +203,14 @@ class ApprovedImageListFilter(admin.SimpleListFilter):
         """
 
         if self.value():
-            if int(self.value()) == 1:
-                return queryset.filter(document_image__confirmed=True).distinct()
-            if int(self.value()) == 2:
-                return queryset.filter(document_image__confirmed=False).distinct()
-            if int(self.value()) == 3:
+            if self.value() == NONE:
                 return queryset.filter(document_image__isnull=True).distinct()
+            elif self.value() == PENDING:
+                return queryset.filter(document_image__confirmed=False).distinct()
+            elif self.value() == APPROVED:
+                return queryset.filter(document_image__confirmed=True).distinct()
+            elif self.value() == NO_APPROVED:
+                return queryset.exclude(document_image__confirmed=True).distinct()
         return queryset
 
 

--- a/lunes_cms/cms/templates/admin/discipline_filter.html
+++ b/lunes_cms/cms/templates/admin/discipline_filter.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+{% load admin_filter_tags %}
+
+<div class="form-group">
+    <select class="form-control search-filter" style="width: 100%;" tabindex="-1" aria-hidden="true" data-name="{{ field_name }}">
+        <option value="">{{ title }}</option>
+        <option value="">---------</option>
+        {% group_discipline_filter_choices choices as grouped_choices %}
+        {% for choice in grouped_choices.options %}
+            {% if choice.name %}
+                <option data-name="{{ choice.name }}" value="{{ choice.value }}" {% if choice.selected %}selected {% endif %}>
+                    {{ choice.display }}
+                </option>
+            {% endif %}
+        {% endfor %}
+        {% for parent, choices in grouped_choices.optgroups.items %}
+            <optgroup label="{{ parent }}">
+                {% for choice in choices %}
+                    {% if choice.name %}
+                        <option data-name="{{ choice.name }}" value="{{ choice.value }}" {% if choice.selected %}selected {% endif %}>
+                            {{ choice.display }}
+                        </option>
+                    {% endif %}
+                {% endfor %}
+            </optgroup>
+        {% endfor %}
+    </select>
+</div>

--- a/lunes_cms/cms/templatetags/__init__.py
+++ b/lunes_cms/cms/templatetags/__init__.py
@@ -1,0 +1,8 @@
+"""
+Template tags are our custom extension of the :doc:`django:ref/templates/builtins` of :doc:`django:ref/templates/language`.
+
+Tags are used to provide arbitrary logic in the rendering process and are surrounded by ``{%`` and ``%}``.
+Filters transform the values of variables and are surrounded by ``{{`` and ``}}``.
+
+See :doc:`django:howto/custom-template-tags` for more information.
+"""

--- a/lunes_cms/cms/templatetags/admin_filter_tags.py
+++ b/lunes_cms/cms/templatetags/admin_filter_tags.py
@@ -1,0 +1,37 @@
+"""
+This is a collection of admin filter tags and filters
+"""
+from collections import defaultdict
+import logging
+
+from django import template
+
+logger = logging.getLogger(__name__)
+register = template.Library()
+
+
+@register.simple_tag
+def group_discipline_filter_choices(choices):
+    """
+    Group the discipline options by their parent discipline
+
+    :param choices: The flat choices
+    :type choices: list [ dict ]
+
+    :return: The grouped choices
+    :rtype: dict
+    """
+    options = []
+    optgroups = defaultdict(list)
+    delimiter = " \u2794 "
+    for choice in choices:
+        if delimiter not in choice["display"]:
+            options.append(choice)
+        else:
+            parent, child = choice["display"].split(delimiter)
+            choice["display"] = child
+            optgroups[parent].append(choice)
+    return {
+        "options": options,
+        "optgroups": dict(optgroups),
+    }

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -37,7 +37,7 @@ msgstr "{} mit der ID {} existiert nicht."
 msgid "disciplines"
 msgstr "Modulgruppen"
 
-#: cms/admin.py:34 cms/list_filter.py:101 cms/models/training_set.py:91
+#: cms/admin.py:34 cms/list_filter.py:104 cms/models/training_set.py:91
 msgid "training sets"
 msgstr "Module"
 
@@ -198,31 +198,31 @@ msgstr ""
 "Sie können nur Module veröffentlichen, die mindestens {} Vokabeln mit "
 "bestätigten Bildern enthalten."
 
-#: cms/list_filter.py:154
+#: cms/list_filter.py:158
 msgid "approved images"
 msgstr "Bestätigte Bilder"
 
-#: cms/list_filter.py:175
+#: cms/list_filter.py:179
 msgid "at least one approved image"
 msgstr "Mind. ein bestätigtes Bild"
 
-#: cms/list_filter.py:176
+#: cms/list_filter.py:180
 msgid "at least one pending image"
 msgstr "Mind. ein unbestätigtes Bild"
 
-#: cms/list_filter.py:177
+#: cms/list_filter.py:181
 msgid "no images"
 msgstr "Keine Bilder"
 
-#: cms/list_filter.py:210
+#: cms/list_filter.py:214
 msgid "assigned & unassigned"
 msgstr "Zugewiesen & unzugewiesen"
 
-#: cms/list_filter.py:231
+#: cms/list_filter.py:235
 msgid "unassigned only"
 msgstr "keinem Modul zugewiesen"
 
-#: cms/list_filter.py:232
+#: cms/list_filter.py:236
 msgid "assigned only"
 msgstr "Mind. einem Modul zugewiesen"
 

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -33,11 +33,11 @@ msgid "{} with id {} does not exist."
 msgstr "{} mit der ID {} existiert nicht."
 
 #: cms/admin.py:33 cms/admins/training_set_admin.py:335 cms/forms.py:48
-#: cms/forms.py:50 cms/list_filter.py:14 cms/models/discipline.py:102
+#: cms/forms.py:50 cms/list_filter.py:15 cms/models/discipline.py:102
 msgid "disciplines"
 msgstr "Modulgruppen"
 
-#: cms/admin.py:34 cms/list_filter.py:102 cms/models/training_set.py:91
+#: cms/admin.py:34 cms/list_filter.py:101 cms/models/training_set.py:91
 msgid "training sets"
 msgstr "Module"
 
@@ -198,31 +198,31 @@ msgstr ""
 "Sie können nur Module veröffentlichen, die mindestens {} Vokabeln mit "
 "bestätigten Bildern enthalten."
 
-#: cms/list_filter.py:155
+#: cms/list_filter.py:154
 msgid "approved images"
 msgstr "Bestätigte Bilder"
 
-#: cms/list_filter.py:176
+#: cms/list_filter.py:175
 msgid "at least one approved image"
 msgstr "Mind. ein bestätigtes Bild"
 
-#: cms/list_filter.py:177
+#: cms/list_filter.py:176
 msgid "at least one pending image"
 msgstr "Mind. ein unbestätigtes Bild"
 
-#: cms/list_filter.py:178
+#: cms/list_filter.py:177
 msgid "no images"
 msgstr "Keine Bilder"
 
-#: cms/list_filter.py:211
+#: cms/list_filter.py:210
 msgid "assigned & unassigned"
 msgstr "Zugewiesen & unzugewiesen"
 
-#: cms/list_filter.py:232
+#: cms/list_filter.py:231
 msgid "unassigned only"
 msgstr "keinem Modul zugewiesen"
 
-#: cms/list_filter.py:233
+#: cms/list_filter.py:232
 msgid "assigned only"
 msgstr "Mind. einem Modul zugewiesen"
 

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -32,7 +32,7 @@ msgstr ""
 msgid "{} with id {} does not exist."
 msgstr "{} mit der ID {} existiert nicht."
 
-#: cms/admin.py:33 cms/admins/training_set_admin.py:257 cms/forms.py:48
+#: cms/admin.py:33 cms/admins/training_set_admin.py:335 cms/forms.py:48
 #: cms/forms.py:50 cms/list_filter.py:14 cms/models/discipline.py:102
 msgid "disciplines"
 msgstr "Modulgruppen"
@@ -75,7 +75,7 @@ msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
 #: cms/admins/discipline_admin.py:310 cms/admins/document_admin.py:149
-#: cms/admins/training_set_admin.py:275
+#: cms/admins/training_set_admin.py:353
 msgid "creator group"
 msgstr "Besitzergruppe"
 
@@ -119,11 +119,11 @@ msgstr ""
 msgid "logo"
 msgstr "Logo"
 
-#: cms/admins/training_set_admin.py:137
+#: cms/admins/training_set_admin.py:185
 msgid "Release selected training sets"
 msgstr "Ausgewählte Module veröffentlichen"
 
-#: cms/admins/training_set_admin.py:172
+#: cms/admins/training_set_admin.py:220
 msgid ""
 "The training set {} could not be released because it contains less than {} "
 "vocabulary words with confirmed images."
@@ -137,33 +137,45 @@ msgstr[1] ""
 "Die Module {} konnten nicht veröffentlicht werden, da sie weniger als {} "
 "Vokabeln mit bestätigten Bildern enthalten."
 
-#: cms/admins/training_set_admin.py:185
+#: cms/admins/training_set_admin.py:233
 msgid "The training set {} is already released."
 msgid_plural "The training sets {} are already released."
 msgstr[0] "Das Modul {} ist bereits veröffentlicht."
 msgstr[1] "Die Module {} sind bereits veröffentlicht."
 
-#: cms/admins/training_set_admin.py:199
+#: cms/admins/training_set_admin.py:247
 msgid "The training set {} was successfully released."
 msgid_plural "The training sets {} were successfully released."
 msgstr[0] "Das Modul {} wurde erfolgreich veröffentlicht."
 msgstr[1] "Die Module {} wurden erfolgreich veröffentlicht."
 
-#: cms/admins/training_set_admin.py:205
+#: cms/admins/training_set_admin.py:253
 msgid "Unrelease selected training sets"
 msgstr "Ausgewählte Module zurückhalten"
 
-#: cms/admins/training_set_admin.py:229
+#: cms/admins/training_set_admin.py:277
 msgid "The training set {} is already unreleased."
 msgid_plural "The training sets {} are already unreleased."
 msgstr[0] "Das Modul {} ist bereits zurückgehalten."
 msgstr[1] "Die Module {} sind bereits zurückgehalten."
 
-#: cms/admins/training_set_admin.py:240
+#: cms/admins/training_set_admin.py:288
 msgid "The training set {} was successfully unreleased."
 msgid_plural "The training sets {} were successfully unreleased."
 msgstr[0] "Das Modul {} wurde erfolgreich zurückgehalten."
 msgstr[1] "Die Module {} wurden erfolgreich zurückgehalten."
+
+#: cms/admins/training_set_admin.py:295
+msgid "words"
+msgstr "Vokabeln"
+
+#: cms/admins/training_set_admin.py:305
+msgid "published words"
+msgstr "veröffentlichte Vokabeln"
+
+#: cms/admins/training_set_admin.py:315
+msgid "unpublished words"
+msgstr "unveröffentlichte Vokabeln"
 
 #: cms/apps.py:12
 msgid "vocabulary management"
@@ -533,12 +545,6 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
-
-#~ msgid "published words"
-#~ msgstr "veröffentlichte Vokabeln"
-
-#~ msgid "unpublished words"
-#~ msgstr "unveröffentlichte Vokabeln"
 
 #~ msgid "Images"
 #~ msgstr "Bilder"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -218,17 +218,29 @@ msgstr "Keine bestätigten Bilder"
 msgid "No images"
 msgstr "Keine Bilder"
 
-#: cms/list_filter.py:223
-msgid "assigned & unassigned"
-msgstr "Zugewiesen & unzugewiesen"
+#: cms/list_filter.py:230
+msgid "Assignments"
+msgstr "Zuweisungen"
 
-#: cms/list_filter.py:244
-msgid "unassigned only"
-msgstr "keinem Modul zugewiesen"
+#: cms/list_filter.py:251
+msgid "Not assigned to any module"
+msgstr "Keinem Modul zugewiesen"
 
-#: cms/list_filter.py:245
-msgid "assigned only"
+#: cms/list_filter.py:252
+msgid "Assigned to at least one module"
 msgstr "Mind. einem Modul zugewiesen"
+
+#: cms/list_filter.py:253
+msgid "Assigned to released modules"
+msgstr "Veröffentlichten Modulen zugewiesen"
+
+#: cms/list_filter.py:256
+msgid "Assigned to released modules in released disciplines"
+msgstr "Veröffentlichten Modulen in veröffentlichten Modulgruppen zugewiesen"
+
+#: cms/list_filter.py:258
+msgid "Assigned to unreleased modules"
+msgstr "Unveröffentlichten Modulen zugewiesen"
 
 #: cms/models/alternative_word.py:13 cms/models/alternative_word.py:37
 msgid "alternative word"
@@ -550,27 +562,20 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 msgid "help"
 msgstr "Hilfe"
 
-#~ msgid "Assignments"
-#~ msgstr "Zuweisungen"
+#~ msgid "assigned & unassigned"
+#~ msgstr "Zugewiesen & unzugewiesen"
 
-#~ msgid "Not assigned to any module"
-#~ msgstr "Keinem Modul zugewiesen"
+#~ msgid "unassigned only"
+#~ msgstr "keinem Modul zugewiesen"
 
-#~ msgid "Assigned to at least one module"
+#~ msgid "assigned only"
 #~ msgstr "Mind. einem Modul zugewiesen"
-
-#~ msgid "Assigned to released modules"
-#~ msgstr "Veröffentlichten Modulen zugewiesen"
-
-#~ msgid "Assigned to released modules in released disciplines"
-#~ msgstr ""
-#~ "Veröffentlichten Modulen in veröffentlichten Modulgruppen zugewiesen"
-
-#~ msgid "Assigned to unreleased modules"
-#~ msgstr "Unveröffentlichten Modulen zugewiesen"
 
 #~ msgid "approved images"
 #~ msgstr "Bestätigte Bilder"
+
+#~ msgid "Assigned & unassigned"
+#~ msgstr "Zugewiesen & unzugewiesen"
 
 #~ msgid "Published words"
 #~ msgstr "Veröffentlichte Vokabeln"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -198,31 +198,35 @@ msgstr ""
 "Sie können nur Module veröffentlichen, die mindestens {} Vokabeln mit "
 "bestätigten Bildern enthalten."
 
-#: cms/list_filter.py:158
-msgid "approved images"
-msgstr "Bestätigte Bilder"
+#: cms/list_filter.py:164
+msgid "Images"
+msgstr "Bilder"
 
-#: cms/list_filter.py:179
-msgid "at least one approved image"
+#: cms/list_filter.py:185
+msgid "At least one approved image"
 msgstr "Mind. ein bestätigtes Bild"
 
-#: cms/list_filter.py:180
-msgid "at least one pending image"
+#: cms/list_filter.py:186
+msgid "At least one pending image"
 msgstr "Mind. ein unbestätigtes Bild"
 
-#: cms/list_filter.py:181
-msgid "no images"
+#: cms/list_filter.py:187
+msgid "No approved images"
+msgstr "Keine bestätigten Bilder"
+
+#: cms/list_filter.py:188
+msgid "No images"
 msgstr "Keine Bilder"
 
-#: cms/list_filter.py:214
+#: cms/list_filter.py:223
 msgid "assigned & unassigned"
 msgstr "Zugewiesen & unzugewiesen"
 
-#: cms/list_filter.py:235
+#: cms/list_filter.py:244
 msgid "unassigned only"
 msgstr "keinem Modul zugewiesen"
 
-#: cms/list_filter.py:236
+#: cms/list_filter.py:245
 msgid "assigned only"
 msgstr "Mind. einem Modul zugewiesen"
 
@@ -546,12 +550,6 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 msgid "help"
 msgstr "Hilfe"
 
-#~ msgid "Images"
-#~ msgstr "Bilder"
-
-#~ msgid "No approved images"
-#~ msgstr "Keine bestätigten Bilder"
-
 #~ msgid "Assignments"
 #~ msgstr "Zuweisungen"
 
@@ -570,6 +568,9 @@ msgstr "Hilfe"
 
 #~ msgid "Assigned to unreleased modules"
 #~ msgstr "Unveröffentlichten Modulen zugewiesen"
+
+#~ msgid "approved images"
+#~ msgstr "Bestätigte Bilder"
 
 #~ msgid "Published words"
 #~ msgstr "Veröffentlichte Vokabeln"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-16 11:54+0000\n"
+"POT-Creation-Date: 2023-07-18 11:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,15 +54,27 @@ msgstr "API Keys"
 msgid "feedback"
 msgstr "Feedback"
 
-#: cms/admins/discipline_admin.py:122
+#: cms/admins/discipline_admin.py:247
 msgid "Release selected disciplines"
 msgstr "Ausgewählte Modulgruppen veröffentlichen"
 
-#: cms/admins/discipline_admin.py:135
+#: cms/admins/discipline_admin.py:260
 msgid "Unrelease selected disciplines"
 msgstr "Ausgewählte Modulgruppen zurückhalten"
 
-#: cms/admins/discipline_admin.py:165 cms/admins/document_admin.py:149
+#: cms/admins/discipline_admin.py:274
+msgid "released modules"
+msgstr "veröffentlichte Module"
+
+#: cms/admins/discipline_admin.py:286
+msgid "unreleased modules"
+msgstr "unveröffentlichte Module"
+
+#: cms/admins/discipline_admin.py:298
+msgid "published words in released modules"
+msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
+
+#: cms/admins/discipline_admin.py:310 cms/admins/document_admin.py:149
 #: cms/admins/training_set_admin.py:275
 msgid "creator group"
 msgstr "Besitzergruppe"
@@ -180,19 +192,19 @@ msgstr "Bestätigte Bilder"
 
 #: cms/list_filter.py:176
 msgid "at least one approved image"
-msgstr "Min. 1 bestätigtes Bild"
+msgstr "Mind. ein bestätigtes Bild"
 
 #: cms/list_filter.py:177
 msgid "at least one pending image"
-msgstr "Min. 1 unbestätigtes Bild"
+msgstr "Mind. ein unbestätigtes Bild"
 
 #: cms/list_filter.py:178
 msgid "no images"
-msgstr "keine Bilder"
+msgstr "Keine Bilder"
 
 #: cms/list_filter.py:211
 msgid "assigned & unassigned"
-msgstr "zugewiesene und unzugewiesene Vokabeln"
+msgstr "Zugewiesen & unzugewiesen"
 
 #: cms/list_filter.py:232
 msgid "unassigned only"
@@ -200,7 +212,7 @@ msgstr "keinem Modul zugewiesen"
 
 #: cms/list_filter.py:233
 msgid "assigned only"
-msgstr "zu Modul zugewiesen"
+msgstr "Mind. einem Modul zugewiesen"
 
 #: cms/models/alternative_word.py:13 cms/models/alternative_word.py:37
 msgid "alternative word"
@@ -521,6 +533,46 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
+
+#~ msgid "published words"
+#~ msgstr "veröffentlichte Vokabeln"
+
+#~ msgid "unpublished words"
+#~ msgstr "unveröffentlichte Vokabeln"
+
+#~ msgid "Images"
+#~ msgstr "Bilder"
+
+#~ msgid "No approved images"
+#~ msgstr "Keine bestätigten Bilder"
+
+#~ msgid "Assignments"
+#~ msgstr "Zuweisungen"
+
+#~ msgid "Not assigned to any module"
+#~ msgstr "Keinem Modul zugewiesen"
+
+#~ msgid "Assigned to at least one module"
+#~ msgstr "Mind. einem Modul zugewiesen"
+
+#~ msgid "Assigned to released modules"
+#~ msgstr "Veröffentlichten Modulen zugewiesen"
+
+#~ msgid "Assigned to released modules in released disciplines"
+#~ msgstr ""
+#~ "Veröffentlichten Modulen in veröffentlichten Modulgruppen zugewiesen"
+
+#~ msgid "Assigned to unreleased modules"
+#~ msgstr "Unveröffentlichten Modulen zugewiesen"
+
+#~ msgid "Published words"
+#~ msgstr "Veröffentlichte Vokabeln"
+
+#~ msgid "Unpublished words"
+#~ msgstr "Unveröffentlichte Vokabeln"
+
+#~ msgid "Released modules"
+#~ msgstr "Veröffentlichte Module"
 
 #~ msgid "icon_file"
 #~ msgstr "Icon"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This adds a few improvements for the admin list filters

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add module and vocabulary counters to discipline list
- Add vocabulary counters to training set list
- Group discipline filter by parent discipline
- Limit training set filter options by selected discipline and vice versa
- Add possibility to filter vocabulary with no approved images
- Add possibility to filter vocabulary by released training sets

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #368
Fixes: #476
