### PR TITLE
Enable pylint rules 1

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,11 +8,7 @@ disable=missing-module-docstring,
         too-few-public-methods,
         too-many-ancestors,
         duplicate-code,
-        missing-function-docstring,
         consider-using-with,
-        arguments-differ,
-        empty-docstring,
-        raise-missing-from,
-        property-with-parameters
+        arguments-differ
 
 enable = useless-suppression

--- a/lunes_cms/api/v1/serializers/discipline_serializer.py
+++ b/lunes_cms/api/v1/serializers/discipline_serializer.py
@@ -42,7 +42,7 @@ class DisciplineSerializer(FallbackIconSerializer):
 
 
         :param disc: Discipline instance
-        :type disc: models.Discipline
+        :type disc: ~lunes_cms.cms.models.discipline.Discipline
         :return: sum of children
         :rtype: int
         """

--- a/lunes_cms/api/v1/serializers/feedback_serializer.py
+++ b/lunes_cms/api/v1/serializers/feedback_serializer.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
@@ -26,7 +27,8 @@ class FeedbackSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         try:
             attrs["content_type"].model_class().objects.get(pk=attrs["object_id"])
-        except:
+        except ObjectDoesNotExist as e:
+            print(e)
             raise serializers.ValidationError(
                 {
                     "object_id": [
@@ -35,7 +37,7 @@ class FeedbackSerializer(serializers.ModelSerializer):
                         ),
                     ]
                 }
-            )
+            ) from e
         return attrs
 
     class Meta:

--- a/lunes_cms/api/v1/serializers/group_serializer.py
+++ b/lunes_cms/api/v1/serializers/group_serializer.py
@@ -33,7 +33,7 @@ class GroupSerializer(serializers.ModelSerializer):
         contain at least one training set.
 
         :param disc: Discipline instance
-        :type disc: models.Discipline
+        :type disc: ~lunes_cms.cms.models.discipline.Discipline
         :return: sum of children
         :rtype: int
         """

--- a/lunes_cms/cms/admins/discipline_admin.py
+++ b/lunes_cms/cms/admins/discipline_admin.py
@@ -55,7 +55,7 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         :param request: current user request
         :type request: django.http.request
         :param obj: discipline object
-        :type obj: models.Discipline
+        :type obj: ~lunes_cms.cms.models.discipline.Discipline
         :param form: employed model form
         :type form: ModelForm
         :param change: True if change on existing model
@@ -274,6 +274,15 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         ordering="modules_released_order",
     )
     def modules_released(self, obj):
+        """
+        returns HTML Tag of the link to released training sets related to the discipline
+
+        :param obj: Discipline object
+        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+
+        :return: HTML Tag of the link to released training sets related to the discipline
+        :rtype: str
+        """
         if not obj.is_leaf_node():
             return obj.children_modules_released
         trainingset_list = reverse("admin:cms_trainingset_changelist")
@@ -286,6 +295,15 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         ordering="modules_unreleased_order",
     )
     def modules_unreleased(self, obj):
+        """
+        returns HTML Tag of the link to unreleased training sets related to the discipline
+
+        :param obj: Discipline object
+        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+
+        :return: HTML Tag of the link to unreleased training sets related to the discipline
+        :rtype: str
+        """
         if not obj.is_leaf_node():
             return obj.children_modules_unreleased
         trainingset_list = reverse("admin:cms_trainingset_changelist")
@@ -298,6 +316,15 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         ordering="-words_released_order",
     )
     def words_released(self, obj):
+        """
+        returns HTML Tag of the link to released words in the relased training sets related to the descipline
+
+        :param obj: Discipline object
+        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+
+        :return:
+        :rtype: str
+        """
         if not obj.is_leaf_node():
             return obj.children_words_released
         document_list = reverse("admin:cms_document_changelist")
@@ -313,7 +340,7 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         Include creator group of discipline in list display
 
         :param obj: Discipline object
-        :type obj: models.Discipline
+        :type obj: ~lunes_cms.cms.models.discipline.Discipline
 
         :return: Either static admin group or user group
         :rtype: str

--- a/lunes_cms/cms/admins/training_set_admin.py
+++ b/lunes_cms/cms/admins/training_set_admin.py
@@ -69,7 +69,7 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         :param request: current user request
         :type request: django.http.request
         :param obj: training set object
-        :type obj: models.TrainingSet
+        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
         :param form: employed model form
         :type form: ModelForm
         :param change: True if change on existing model
@@ -296,6 +296,14 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         ordering="-words",
     )
     def words(self, obj):
+        """
+        returns HTML tag of the link to the list of words related to the training set
+
+        :param obj: Training set object
+        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :return: HTML tag of the link to the list of words related to the training set
+        :rtype: str
+        """
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
             f"<a href={document_list}?training+set={obj.id}>{obj.words}</a>"
@@ -306,6 +314,14 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         ordering="-words_released",
     )
     def words_released(self, obj):
+        """
+        returns HTML tag of the link to the list of released words related to the training set
+
+        :param obj: Training set object
+        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :return: HTML tag of the link to the list of released words related to the training set
+        :rtype: str
+        """
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
             f"<a href={document_list}?training+set={obj.id}&images=approved>{obj.words_released}</a>"
@@ -316,6 +332,14 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         ordering="-words_unreleased",
     )
     def words_unreleased(self, obj):
+        """
+        returns HTML tag of the Link to the list of unreleased words related to the training set
+
+        :param obj: Training set object
+        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :return: HTML tag of the Link to the list of unreleased words related to the training set
+        :rtype: str
+        """
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
             f"<a href={document_list}?training+set={obj.id}&images=no-approved>{obj.words_unreleased}</a>"
@@ -326,7 +350,7 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         Display related disciplines in list display
 
         :param obj: Training set object
-        :type obj: models.TrainingSet
+        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: comma separated list of related disciplines
         :rtype: str
         """
@@ -339,7 +363,7 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         Include creator group of discipline in list display
 
         :param obj: Training set object
-        :type obj: models.TrainingSet
+        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: Either static admin group or user group
         :rtype: str
         """

--- a/lunes_cms/cms/models/document.py
+++ b/lunes_cms/cms/models/document.py
@@ -63,15 +63,13 @@ class Document(models.Model):
     feedback = GenericRelation(Feedback)
 
     @property
-    def converted(self, content_type="audio/mpeg"):
+    def converted(self):
         """
         Function that converts the uploaded audio to .mp3 and
         returns the converted file
 
         :param self: A handle to the :class:`models.Document`
         :type self: class: `models.Document`
-        :param content_type: content type of the converted file, defaults to "audio/mpeg"
-        :type request: content_type
 
         :return: File containing .mp3 audio
         :rtype: .mp3 File
@@ -85,7 +83,7 @@ class Document(models.Model):
 
         converted_audiofile = File(file=open(new_path, "rb"), name=Path(new_path))
         converted_audiofile.name = Path(new_path).name
-        converted_audiofile.content_type = content_type
+        converted_audiofile.content_type = "audio/mpeg"
         converted_audiofile.size = os.path.getsize(new_path)
         os.remove(new_path)
         return converted_audiofile

--- a/lunes_cms/cms/models/group_api_key.py
+++ b/lunes_cms/cms/models/group_api_key.py
@@ -131,13 +131,22 @@ class GroupAPIKey(models.Model):
 
     @classmethod
     def get_from_token(cls, token):
+        """
+        returns a group api which maches to the given token
+
+        :param token: token
+        :type token: str
+
+        :return: Group API Key object
+        :rtype: ~lunes_cms.cms.models.group_api_key.GroupAPIKey
+        """
         try:
             return cls.objects.get(
                 Q(token=token, revoked=False)
                 & (Q(expiry_date__isnull=True) | Q(expiry_date__gt=now()))
             )
-        except cls.DoesNotExist:
-            raise PermissionDenied()
+        except cls.DoesNotExist as e:
+            raise PermissionDenied() from e
 
     def __str__(self):
         """

--- a/lunes_cms/cms/utils.py
+++ b/lunes_cms/cms/utils.py
@@ -75,7 +75,7 @@ def get_child_count(disc):
     parent of a discipline that contains one.
 
     :param disc: Discipline instance
-    :type disc: models.Discipline
+    :type disc: ~lunes_cms.cms.models.discipline.Discipline
 
     :return: sum of children
     :rtype: int
@@ -93,7 +93,7 @@ def get_training_set_count(disc):
     child elements.
 
     :param disc: Discipline instance
-    :type disc: models.Discipline
+    :type disc: ~lunes_cms.cms.models.discipline.Discipline
 
     :return: sum of training sets
     :rtype: int

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-04 13:05+0000\n"
+"POT-Creation-Date: 2023-10-07 11:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,18 +21,18 @@ msgstr ""
 msgid "API"
 msgstr "API"
 
-#: api/v1/serializers/feedback_serializer.py:21
+#: api/v1/serializers/feedback_serializer.py:22
 msgid ""
 "The content type must be either 'discipline', 'training set' or 'document'."
 msgstr ""
 "Der Inhaltstyp muss entweder 'discipline', 'trainingset' oder 'document' "
 "sein."
 
-#: api/v1/serializers/feedback_serializer.py:33
+#: api/v1/serializers/feedback_serializer.py:35
 msgid "{} with id {} does not exist."
 msgstr "{} mit der ID {} existiert nicht."
 
-#: cms/admin.py:35 cms/admins/training_set_admin.py:335 cms/forms.py:46
+#: cms/admin.py:35 cms/admins/training_set_admin.py:359 cms/forms.py:46
 #: cms/forms.py:48 cms/list_filter.py:14 cms/models/discipline.py:101
 msgid "disciplines"
 msgstr "Modulgruppen"
@@ -41,8 +41,8 @@ msgstr "Modulgruppen"
 msgid "training sets"
 msgstr "Module"
 
-#: cms/admin.py:37 cms/forms.py:52 cms/forms.py:53 cms/models/document.py:114
-#: cms/models/document.py:115
+#: cms/admin.py:37 cms/forms.py:52 cms/forms.py:53 cms/models/document.py:112
+#: cms/models/document.py:113
 msgid "vocabulary"
 msgstr "Vokabeln"
 
@@ -66,16 +66,16 @@ msgstr "Ausgewählte Modulgruppen zurückhalten"
 msgid "released modules"
 msgstr "veröffentlichte Module"
 
-#: cms/admins/discipline_admin.py:285
+#: cms/admins/discipline_admin.py:294
 msgid "unreleased modules"
 msgstr "unveröffentlichte Module"
 
-#: cms/admins/discipline_admin.py:297
+#: cms/admins/discipline_admin.py:315
 msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
-#: cms/admins/discipline_admin.py:309 cms/admins/document_admin.py:147
-#: cms/admins/training_set_admin.py:352
+#: cms/admins/discipline_admin.py:336 cms/admins/document_admin.py:147
+#: cms/admins/training_set_admin.py:376
 msgid "creator group"
 msgstr "Besitzergruppe"
 
@@ -169,11 +169,11 @@ msgstr[1] "Die Module {} wurden erfolgreich zurückgehalten."
 msgid "words"
 msgstr "Vokabeln"
 
-#: cms/admins/training_set_admin.py:305
+#: cms/admins/training_set_admin.py:313
 msgid "published words"
 msgstr "veröffentlichte Vokabeln"
 
-#: cms/admins/training_set_admin.py:315
+#: cms/admins/training_set_admin.py:331
 msgid "unpublished words"
 msgstr "unveröffentlichte Vokabeln"
 
@@ -402,15 +402,15 @@ msgstr "QR-Code"
 msgid "Download QR code"
 msgstr "QR-Code herunterladen"
 
-#: cms/models/group_api_key.py:147
+#: cms/models/group_api_key.py:156
 msgid "{}: Token for the group \"{}\""
 msgstr "{}: Token für die Gruppe \"{}\""
 
-#: cms/models/group_api_key.py:154
+#: cms/models/group_api_key.py:163
 msgid "API Key"
 msgstr "API-Key"
 
-#: cms/models/group_api_key.py:155
+#: cms/models/group_api_key.py:164
 msgid "API Keys"
 msgstr "API-Keys"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR enables pylint rules which are currently disabled.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Enable `raise-missiong-from`
- Enable `empty-docstring`
- Enable `missing-function-docsring`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: (#499, partially)
