### PR TITLE
Filter feedback by object creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#353](https://github.com/digitalfabrik/lunes-cms/issues/353) ] Filter feedback by creator of related objects
+
 
 2024.5.1
 --------

--- a/lunes_cms/cms/admins/feedback_admin.py
+++ b/lunes_cms/cms/admins/feedback_admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin, messages
+
 from django.utils.translation import gettext_lazy as _
 
+from ..feedback_filter import filter_feedback_by_creator
 from ..models import Feedback
 
 
@@ -66,6 +68,14 @@ class FeedbackAdmin(admin.ModelAdmin):
                 "The selected feedback entries were successfully marked as unread.",
             ),
         )
+
+    def get_queryset(self, request):
+        feedback_entries = super().get_queryset(request)
+
+        if not request.user.is_superuser:
+            return filter_feedback_by_creator(feedback_entries, request.user)
+
+        return feedback_entries
 
     class Media:
         """

--- a/lunes_cms/cms/feedback_filter.py
+++ b/lunes_cms/cms/feedback_filter.py
@@ -1,0 +1,41 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+
+from .models import Discipline, TrainingSet, Document
+
+
+def filter_feedback_by_creator(feedback_queryset, user):
+    """
+    Exclude feedback entries that are not related to objects created by the user
+    """
+
+    # Collect content type ID of discipline/trainingset/document model
+    discipline_type_id = ContentType.objects.get(model="discipline").id
+    trainingset_type_id = ContentType.objects.get(model="trainingset").id
+    document_type_id = ContentType.objects.get(model="document").id
+
+    # Collect IDs disciplines/training sets/documents created by the user
+    user_discipline_ids = [
+        discipline.id
+        for discipline in Discipline.objects.filter(created_by__in=user.groups.all())
+    ]
+    user_trainingset_ids = [
+        trainingset.id
+        for trainingset in TrainingSet.objects.filter(created_by__in=user.groups.all())
+    ]
+    user_document_ids = [
+        document.id
+        for document in Document.objects.filter(created_by__in=user.groups.all())
+    ]
+
+    # content_object field of feedback object cannot be used for direct query
+    # Use content_type and object_id instead
+    user_feedback_entries = feedback_queryset.filter(
+        Q(content_type=discipline_type_id, object_id__in=user_discipline_ids)
+        | (
+            Q(content_type=trainingset_type_id, object_id__in=user_trainingset_ids)
+            | Q(content_type=document_type_id, object_id__in=user_document_ids)
+        )
+    )
+
+    return user_feedback_entries

--- a/lunes_cms/cms/fixtures/test_data.json
+++ b/lunes_cms/cms/fixtures/test_data.json
@@ -58,7 +58,8 @@
         ["add_trainingset", "cms", "trainingset"],
         ["change_trainingset", "cms", "trainingset"],
         ["delete_trainingset", "cms", "trainingset"],
-        ["view_trainingset", "cms", "trainingset"]
+        ["view_trainingset", "cms", "trainingset"],
+        ["view_feedback", "cms", "feedback"]
       ]
     }
   },
@@ -24825,5 +24826,25 @@
     "model": "cms.sponsor",
     "pk": 2,
     "fields": { "name": "Bundesagentur für Arbeit", "url": "https://www.arbeitsagentur.de/", "logo": "" }
+  },
+  {
+    "model": "cms.feedback",
+    "pk": 1,
+    "fields": {
+      "content_type": 1,
+      "object_id": 15,
+      "comment": "Good",
+      "created_date": "2022-06-28T23:21:07.074Z"
+    }
+  },
+  {
+    "model": "cms.feedback",
+    "pk": 2,
+    "fields": {
+      "content_type": 2,
+      "object_id": 36,
+      "comment": "Nice",
+      "created_date": "2022-06-28T23:21:07.074Z"
+    }
   }
 ]

--- a/lunes_cms/cms/templates/admin/base.html
+++ b/lunes_cms/cms/templates/admin/base.html
@@ -2,14 +2,14 @@
 
 {% block extrajs %}
     <script>
-        let unread_feedback_cnt = {{ unread_feedback_cnt }};
+        let unread_feedback_count = {{ unread_feedback_count }};
         // Get the navigation item for the feedback menu entry
         let feedbackNavItem = $("#jazzy-sidebar a.nav-link[href$='/admin/cms/feedback/']");
         // If unread feedback exists, show counter
-        if (feedbackNavItem && unread_feedback_cnt > 0) {
+        if (feedbackNavItem && unread_feedback_count > 0) {
             // Create span element for counter
             let counterSpan = $(document.createElement("span"));
-            counterSpan.text(unread_feedback_cnt);
+            counterSpan.text(unread_feedback_count);
             counterSpan.addClass("position-absolute text-center rounded-circle bg-danger ml-2 px-1");
             counterSpan.css("min-width", "22.5px");
             // Append counter to the feedback link

--- a/lunes_cms/core/context_processors.py
+++ b/lunes_cms/core/context_processors.py
@@ -2,6 +2,7 @@
 Context processors pass additional variables to templates (see :ref:`context-processors`).
 """
 from ..cms.models import Feedback
+from ..cms.feedback_filter import filter_feedback_by_creator
 
 
 def feedback_processor(request):
@@ -14,4 +15,11 @@ def feedback_processor(request):
     :return: The template context containing the number of unread feedback entries
     :rtype: dict
     """
-    return {"unread_feedback_cnt": Feedback.objects.filter(read_by=None).count()}
+    unread_feedback_entries = Feedback.objects.filter(read_by=None)
+
+    if not request.user.is_superuser:
+        unread_feedback_entries = filter_feedback_by_creator(
+            unread_feedback_entries, request.user
+        )
+
+    return {"unread_feedback_count": unread_feedback_entries.count()}

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-06 10:40+0000\n"
+"POT-Creation-Date: 2024-05-22 08:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,20 +98,20 @@ msgstr "Bild"
 msgid "singular article"
 msgstr "Singular-Artikel"
 
-#: cms/admins/feedback_admin.py:32
+#: cms/admins/feedback_admin.py:34
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: cms/admins/feedback_admin.py:47
+#: cms/admins/feedback_admin.py:49
 msgid "The selected feedback entries were successfully marked as read."
 msgstr ""
 "Die ausgewählten Feedback-Einträge wurden erfolgreich als gelesen markiert."
 
-#: cms/admins/feedback_admin.py:51
+#: cms/admins/feedback_admin.py:53
 msgid "Mark as unread"
 msgstr "Als ungelesen markieren"
 
-#: cms/admins/feedback_admin.py:66
+#: cms/admins/feedback_admin.py:68
 msgid "The selected feedback entries were successfully marked as unread."
 msgstr ""
 "Die ausgewählten Feedback-Einträge wurden erfolgreich als ungelesen markiert."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the feedback view so admin users see all the feedback entries but non_admin users only feedback entries related to the objects they created.

### Proposed changes
<!-- Describe this PR in more detail. -->
- add a new query to exclude feedback entries that are not related to the user, if they are not admin.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #353 
