### PR TITLE
Undo incompatibility for v1 API

### DIFF
--- a/lunes_cms/api/v1/serializers/document_serializer.py
+++ b/lunes_cms/api/v1/serializers/document_serializer.py
@@ -14,6 +14,8 @@ class DocumentSerializer(serializers.ModelSerializer):
     alternatives = AlternativeWordSerializer(many=True, read_only=True)
     document_image = DocumentImageSerializer(many=True, read_only=True)
 
+    article = serializers.IntegerField(source="singular_article")
+
     class Meta:
         """
         Define model and the corresponding fields
@@ -23,6 +25,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "word",
+            "article",
             "singular_article",
             "audio",
             "word_type",

--- a/tests/api/expected-results/words.json
+++ b/tests/api/expected-results/words.json
@@ -2,6 +2,7 @@
   {
     "id": 2,
     "word": "Schere",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schere.mp3",
     "word_type": "Nomen",
@@ -17,6 +18,7 @@
   {
     "id": 3,
     "word": "Schlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schlussel.mp3",
     "word_type": "Nomen",
@@ -32,6 +34,7 @@
   {
     "id": 4,
     "word": "Buch",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/buch.mp3",
     "word_type": "Nomen",
@@ -47,6 +50,7 @@
   {
     "id": 6,
     "word": "Akkuschrauber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/akkuschrauber.mp3",
     "word_type": "Nomen",
@@ -62,6 +66,7 @@
   {
     "id": 7,
     "word": "Bohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bohrer.mp3",
     "word_type": "Nomen",
@@ -82,6 +87,7 @@
   {
     "id": 8,
     "word": "Bohrmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bohrmaschine.mp3",
     "word_type": "Nomen",
@@ -102,6 +108,7 @@
   {
     "id": 9,
     "word": "Dübel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/dubel.mp3",
     "word_type": "Nomen",
@@ -117,6 +124,7 @@
   {
     "id": 10,
     "word": "Feile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/feile.mp3",
     "word_type": "Nomen",
@@ -132,6 +140,7 @@
   {
     "id": 11,
     "word": "Gerüst",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/gerust.mp3",
     "word_type": "Nomen",
@@ -147,6 +156,7 @@
   {
     "id": 12,
     "word": "Leiter",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/leiter.mp3",
     "word_type": "Nomen",
@@ -162,6 +172,7 @@
   {
     "id": 13,
     "word": "Maßband",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/maband.mp3",
     "word_type": "Nomen",
@@ -177,6 +188,7 @@
   {
     "id": 14,
     "word": "Meißel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/meiel.mp3",
     "word_type": "Nomen",
@@ -192,6 +204,7 @@
   {
     "id": 15,
     "word": "Messer",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/messer.mp3",
     "word_type": "Nomen",
@@ -207,6 +220,7 @@
   {
     "id": 16,
     "word": "Schubkarre",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schubkarre.mp3",
     "word_type": "Nomen",
@@ -227,6 +241,7 @@
   {
     "id": 17,
     "word": "Zollstock",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zollstock.mp3",
     "word_type": "Nomen",
@@ -251,6 +266,7 @@
   {
     "id": 18,
     "word": "Arbeitshandschuh",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/arbeitshandschuh.mp3",
     "word_type": "Nomen",
@@ -271,6 +287,7 @@
   {
     "id": 20,
     "word": "Besen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/besen.mp3",
     "word_type": "Nomen",
@@ -286,6 +303,7 @@
   {
     "id": 21,
     "word": "Eimer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/eimer.mp3",
     "word_type": "Nomen",
@@ -301,6 +319,7 @@
   {
     "id": 22,
     "word": "Gehörschutz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gehorschutz.mp3",
     "word_type": "Nomen",
@@ -316,6 +335,7 @@
   {
     "id": 23,
     "word": "Hammer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/hammer.mp3",
     "word_type": "Nomen",
@@ -331,6 +351,7 @@
   {
     "id": 24,
     "word": "Kabeltrommel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kabeltrommel.mp3",
     "word_type": "Nomen",
@@ -346,6 +367,7 @@
   {
     "id": 25,
     "word": "Klebeband",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/klebeband.mp3",
     "word_type": "Nomen",
@@ -361,6 +383,7 @@
   {
     "id": 26,
     "word": "Schraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schraube.mp3",
     "word_type": "Nomen",
@@ -376,6 +399,7 @@
   {
     "id": 27,
     "word": "Schraubenzieher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schraubenzieher.mp3",
     "word_type": "Nomen",
@@ -396,6 +420,7 @@
   {
     "id": 28,
     "word": "Schraubenschlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schraubenschlussel.mp3",
     "word_type": "Nomen",
@@ -416,6 +441,7 @@
   {
     "id": 29,
     "word": "Schutzbrille",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schutzbrille.mp3",
     "word_type": "Nomen",
@@ -436,6 +462,7 @@
   {
     "id": 30,
     "word": "Schutzhelm",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schutzhelm.mp3",
     "word_type": "Nomen",
@@ -451,6 +478,7 @@
   {
     "id": 31,
     "word": "Staubsauger",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/staubsauger.mp3",
     "word_type": "Nomen",
@@ -466,6 +494,7 @@
   {
     "id": 32,
     "word": "Wasserwaage",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/wasserwaage.mp3",
     "word_type": "Nomen",
@@ -481,6 +510,7 @@
   {
     "id": 33,
     "word": "Abisolierzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/abisolierzange.mp3",
     "word_type": "Nomen",
@@ -496,6 +526,7 @@
   {
     "id": 34,
     "word": "Bohrkrone",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bohrkrone.mp3",
     "word_type": "Nomen",
@@ -511,6 +542,7 @@
   {
     "id": 35,
     "word": "Crimpzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/crimpzange.mp3",
     "word_type": "Nomen",
@@ -531,6 +563,7 @@
   {
     "id": 49,
     "word": "Gipsbecher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gipsbecher.mp3",
     "word_type": "Nomen",
@@ -551,6 +584,7 @@
   {
     "id": 66,
     "word": "Schleifpapier",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/schleifpapier.mp3",
     "word_type": "Nomen",
@@ -566,6 +600,7 @@
   {
     "id": 116,
     "word": "Seitenschneider",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/seitenschneider.mp3",
     "word_type": "Nomen",
@@ -581,6 +616,7 @@
   {
     "id": 117,
     "word": "Spannungsprüfer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/spannungsprufer.mp3",
     "word_type": "Nomen",
@@ -601,6 +637,7 @@
   {
     "id": 118,
     "word": "Steckdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/steckdose.mp3",
     "word_type": "Nomen",
@@ -616,6 +653,7 @@
   {
     "id": 119,
     "word": "Badewanne",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/badewanne.mp3",
     "word_type": "Nomen",
@@ -631,6 +669,7 @@
   {
     "id": 120,
     "word": "Doppelmaulschlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/doppelmaulschlussel.mp3",
     "word_type": "Nomen",
@@ -651,6 +690,7 @@
   {
     "id": 123,
     "word": "Toilette",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/toilette.mp3",
     "word_type": "Nomen",
@@ -671,6 +711,7 @@
   {
     "id": 124,
     "word": "Waschbecken",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/waschbecken.mp3",
     "word_type": "Nomen",
@@ -686,6 +727,7 @@
   {
     "id": 125,
     "word": "Wasserhahn",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/wasserhahn.mp3",
     "word_type": "Nomen",
@@ -706,6 +748,7 @@
   {
     "id": 126,
     "word": "Wasserpumpenzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/wasserpumpenzange.mp3",
     "word_type": "Nomen",
@@ -721,6 +764,7 @@
   {
     "id": 132,
     "word": "Elektrohammer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/elektrohammer.mp3",
     "word_type": "Nomen",
@@ -736,6 +780,7 @@
   {
     "id": 133,
     "word": "Spachtel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/spachtel.mp3",
     "word_type": "Nomen",
@@ -760,6 +805,7 @@
   {
     "id": 135,
     "word": "Antennendose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/antennendose.mp3",
     "word_type": "Nomen",
@@ -775,6 +821,7 @@
   {
     "id": 136,
     "word": "Kreuzerder",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kreuzerder.mp3",
     "word_type": "Nomen",
@@ -790,6 +837,7 @@
   {
     "id": 139,
     "word": "Leuchtmittel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/leuchtmittel.mp3",
     "word_type": "Nomen",
@@ -810,6 +858,7 @@
   {
     "id": 140,
     "word": "Arbeitskleidung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/arbeitskleidung.mp3",
     "word_type": "Nomen",
@@ -825,6 +874,7 @@
   {
     "id": 141,
     "word": "Putzlappen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/putzlappen.mp3",
     "word_type": "Nomen",
@@ -849,6 +899,7 @@
   {
     "id": 142,
     "word": "Mülleimer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/mulleimer.mp3",
     "word_type": "Nomen",
@@ -869,6 +920,7 @@
   {
     "id": 143,
     "word": "Bleistift",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bleistift.mp3",
     "word_type": "Nomen",
@@ -884,6 +936,7 @@
   {
     "id": 144,
     "word": "Zimmermannsbleistift",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zimmermannsbleistift.mp3",
     "word_type": "Nomen",
@@ -904,6 +957,7 @@
   {
     "id": 145,
     "word": "Werkzeugkiste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/werkzeugkiste.mp3",
     "word_type": "Nomen",
@@ -924,6 +978,7 @@
   {
     "id": 146,
     "word": "Abdeckfolie",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/abdeckfolie.mp3",
     "word_type": "Nomen",
@@ -939,6 +994,7 @@
   {
     "id": 151,
     "word": "Föhn",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/fohn.mp3",
     "word_type": "Nomen",
@@ -959,6 +1015,7 @@
   {
     "id": 156,
     "word": "Kamm",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kamm.mp3",
     "word_type": "Nomen",
@@ -974,6 +1031,7 @@
   {
     "id": 157,
     "word": "Spiegel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/spiegel.mp3",
     "word_type": "Nomen",
@@ -989,6 +1047,7 @@
   {
     "id": 160,
     "word": "Handbügelsäge",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/handbugelsage.mp3",
     "word_type": "Nomen",
@@ -1009,6 +1068,7 @@
   {
     "id": 161,
     "word": "Nageleisen",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/nageleisen.mp3",
     "word_type": "Nomen",
@@ -1045,6 +1105,7 @@
   {
     "id": 167,
     "word": "Winkel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/winkel.mp3",
     "word_type": "Nomen",
@@ -1069,6 +1130,7 @@
   {
     "id": 175,
     "word": "Drehmomentschlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/drehmomentschlussel.mp3",
     "word_type": "Nomen",
@@ -1089,6 +1151,7 @@
   {
     "id": 181,
     "word": "Ratsche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/ratsche.mp3",
     "word_type": "Nomen",
@@ -1109,6 +1172,7 @@
   {
     "id": 183,
     "word": "Schweißgerät",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/schweigerat.mp3",
     "word_type": "Nomen",
@@ -1124,6 +1188,7 @@
   {
     "id": 186,
     "word": "Schürze",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schurze.mp3",
     "word_type": "Nomen",
@@ -1139,6 +1204,7 @@
   {
     "id": 187,
     "word": "Ofenhandschuh",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/ofenhandschuh.mp3",
     "word_type": "Nomen",
@@ -1154,6 +1220,7 @@
   {
     "id": 188,
     "word": "Kittel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kittel.mp3",
     "word_type": "Nomen",
@@ -1169,6 +1236,7 @@
   {
     "id": 189,
     "word": "Backofen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/backofen.mp3",
     "word_type": "Nomen",
@@ -1184,6 +1252,7 @@
   {
     "id": 201,
     "word": "Cutter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/cutter.mp3",
     "word_type": "Nomen",
@@ -1220,6 +1289,7 @@
   {
     "id": 202,
     "word": "Betonmischer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/betonmischer.mp3",
     "word_type": "Nomen",
@@ -1235,6 +1305,7 @@
   {
     "id": 208,
     "word": "Schaufel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schaufel.mp3",
     "word_type": "Nomen",
@@ -1250,6 +1321,7 @@
   {
     "id": 211,
     "word": "Sackkarre",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/sackkarre.mp3",
     "word_type": "Nomen",
@@ -1270,6 +1342,7 @@
   {
     "id": 214,
     "word": "Bügelmessschraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bugelmessschraube.mp3",
     "word_type": "Nomen",
@@ -1285,6 +1358,7 @@
   {
     "id": 215,
     "word": "Drehwerkzeug",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/drehwerkzeug.mp3",
     "word_type": "Nomen",
@@ -1300,6 +1374,7 @@
   {
     "id": 216,
     "word": "universelle Fräsmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/universelle-frasmaschine.mp3",
     "word_type": "Nomen",
@@ -1328,6 +1403,7 @@
   {
     "id": 217,
     "word": "Grenzlehrdorn",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/grenzlehrdorn.mp3",
     "word_type": "Nomen",
@@ -1343,6 +1419,7 @@
   {
     "id": 218,
     "word": "Körner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/korner.mp3",
     "word_type": "Nomen",
@@ -1363,6 +1440,7 @@
   {
     "id": 219,
     "word": "Messschieber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/messschieber.mp3",
     "word_type": "Nomen",
@@ -1378,6 +1456,7 @@
   {
     "id": 220,
     "word": "Schweißgeschirr",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/schweigeschirr.mp3",
     "word_type": "Nomen",
@@ -1393,6 +1472,7 @@
   {
     "id": 221,
     "word": "Dusche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/dusche.mp3",
     "word_type": "Nomen",
@@ -1408,6 +1488,7 @@
   {
     "id": 223,
     "word": "Kreissäge",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kreissage.mp3",
     "word_type": "Nomen",
@@ -1423,6 +1504,7 @@
   {
     "id": 224,
     "word": "Nagel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/nagel.mp3",
     "word_type": "Nomen",
@@ -1443,6 +1525,7 @@
   {
     "id": 225,
     "word": "Pumpenzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/pumpenzange.mp3",
     "word_type": "Nomen",
@@ -1458,6 +1541,7 @@
   {
     "id": 226,
     "word": "Stichsäge",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/stichsage.mp3",
     "word_type": "Nomen",
@@ -1473,6 +1557,7 @@
   {
     "id": 227,
     "word": "Zange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/zange.mp3",
     "word_type": "Nomen",
@@ -1493,6 +1578,7 @@
   {
     "id": 228,
     "word": "Akku-Winkelschleifer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/akku-winkelschleifer.mp3",
     "word_type": "Nomen",
@@ -1513,6 +1599,7 @@
   {
     "id": 231,
     "word": "Filzstift",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/filzstift.mp3",
     "word_type": "Nomen",
@@ -1533,6 +1620,7 @@
   {
     "id": 237,
     "word": "Handfeger",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/handfeger.mp3",
     "word_type": "Nomen",
@@ -1557,6 +1645,7 @@
   {
     "id": 238,
     "word": "Isolierband",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/isolierband.mp3",
     "word_type": "Nomen",
@@ -1577,6 +1666,7 @@
   {
     "id": 260,
     "word": "Warnweste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/warnweste.mp3",
     "word_type": "Nomen",
@@ -1597,6 +1687,7 @@
   {
     "id": 261,
     "word": "Arbeitshose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/arbeitshose.mp3",
     "word_type": "Nomen",
@@ -1612,6 +1703,7 @@
   {
     "id": 262,
     "word": "Arbeitsjacke",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/arbeitsjacke.mp3",
     "word_type": "Nomen",
@@ -1627,6 +1719,7 @@
   {
     "id": 263,
     "word": "Bohrstange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bohrstange.mp3",
     "word_type": "Nomen",
@@ -1642,6 +1735,7 @@
   {
     "id": 265,
     "word": "Flachsenker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/flachsenker.mp3",
     "word_type": "Nomen",
@@ -1657,6 +1751,7 @@
   {
     "id": 266,
     "word": "Gewindefräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gewindefraser.mp3",
     "word_type": "Nomen",
@@ -1672,6 +1767,7 @@
   {
     "id": 267,
     "word": "Gewindeschneider",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gewindeschneider.mp3",
     "word_type": "Nomen",
@@ -1687,6 +1783,7 @@
   {
     "id": 268,
     "word": "Handreibahle",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/handreibahle.mp3",
     "word_type": "Nomen",
@@ -1707,6 +1804,7 @@
   {
     "id": 269,
     "word": "Industriestaubsauger",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/industriestaubsauger.mp3",
     "word_type": "Nomen",
@@ -1727,6 +1825,7 @@
   {
     "id": 270,
     "word": "Kegelsenker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kegelsenker.mp3",
     "word_type": "Nomen",
@@ -1742,6 +1841,7 @@
   {
     "id": 271,
     "word": "Mülltonne",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/mulltonne.mp3",
     "word_type": "Nomen",
@@ -1757,6 +1857,7 @@
   {
     "id": 272,
     "word": "Nutenfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/nutenfraser.mp3",
     "word_type": "Nomen",
@@ -1772,6 +1873,7 @@
   {
     "id": 274,
     "word": "Rändel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/randel.mp3",
     "word_type": "Nomen",
@@ -1787,6 +1889,7 @@
   {
     "id": 275,
     "word": "Rohrzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/rohrzange.mp3",
     "word_type": "Nomen",
@@ -1802,6 +1905,7 @@
   {
     "id": 276,
     "word": "Schaftfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schaftfraser.mp3",
     "word_type": "Nomen",
@@ -1817,6 +1921,7 @@
   {
     "id": 277,
     "word": "Scheibenfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/scheibenfraser.mp3",
     "word_type": "Nomen",
@@ -1832,6 +1937,7 @@
   {
     "id": 280,
     "word": "Wendeschneidplatte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/wendeschneidplatte.mp3",
     "word_type": "Nomen",
@@ -1847,6 +1953,7 @@
   {
     "id": 281,
     "word": "Winkelfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/winkelfraser.mp3",
     "word_type": "Nomen",
@@ -1862,6 +1969,7 @@
   {
     "id": 282,
     "word": "Zentrierbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zentrierbohrer.mp3",
     "word_type": "Nomen",
@@ -1877,6 +1985,7 @@
   {
     "id": 284,
     "word": "zweipolige Phasenprüfer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zweipolige-phasenprufer.mp3",
     "word_type": "Nomen",
@@ -1897,6 +2006,7 @@
   {
     "id": 285,
     "word": "LAN-Tester",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/lan-tester.mp3",
     "word_type": "Nomen",
@@ -1917,6 +2027,7 @@
   {
     "id": 286,
     "word": "digitale Messschieber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/digitale-messschieber.mp3",
     "word_type": "Nomen",
@@ -1937,6 +2048,7 @@
   {
     "id": 290,
     "word": "NC-Anbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/nc-anbohrer.mp3",
     "word_type": "Nomen",
@@ -1957,6 +2069,7 @@
   {
     "id": 292,
     "word": "Schlagbohrmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schlagbohrmaschine.mp3",
     "word_type": "Nomen",
@@ -1972,6 +2085,7 @@
   {
     "id": 300,
     "word": "Kreissägeblatt",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kreissageblatt.mp3",
     "word_type": "Nomen",
@@ -1987,6 +2101,7 @@
   {
     "id": 301,
     "word": "Schlangenbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schlangenbohrer.mp3",
     "word_type": "Nomen",
@@ -2002,6 +2117,7 @@
   {
     "id": 302,
     "word": "Langbandschleifmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/langbandschleifmaschine.mp3",
     "word_type": "Nomen",
@@ -2017,6 +2133,7 @@
   {
     "id": 303,
     "word": "Schleifigel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schleifigel.mp3",
     "word_type": "Nomen",
@@ -2032,6 +2149,7 @@
   {
     "id": 304,
     "word": "Schraubstock",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schraubstock.mp3",
     "word_type": "Nomen",
@@ -2047,6 +2165,7 @@
   {
     "id": 309,
     "word": "Kehrblech",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kehrblech.mp3",
     "word_type": "Nomen",
@@ -2067,6 +2186,7 @@
   {
     "id": 311,
     "word": "Säbelsägeblatt",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/sabelsageblatt.mp3",
     "word_type": "Nomen",
@@ -2082,6 +2202,7 @@
   {
     "id": 315,
     "word": "Ständerbohrmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/standerbohrmaschine.mp3",
     "word_type": "Nomen",
@@ -2097,6 +2218,7 @@
   {
     "id": 320,
     "word": "Breitbandschleifmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/breitbandschleifmaschine.mp3",
     "word_type": "Nomen",
@@ -2112,6 +2234,7 @@
   {
     "id": 322,
     "word": "Winkelschleifer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/winkelschleifer.mp3",
     "word_type": "Nomen",
@@ -2132,6 +2255,7 @@
   {
     "id": 323,
     "word": "Bithalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bithalter.mp3",
     "word_type": "Nomen",
@@ -2152,6 +2276,7 @@
   {
     "id": 324,
     "word": "Bit",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bit.mp3",
     "word_type": "Nomen",
@@ -2172,6 +2297,7 @@
   {
     "id": 335,
     "word": "Exzenterschleifer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/exzenterschleifer.mp3",
     "word_type": "Nomen",
@@ -2187,6 +2313,7 @@
   {
     "id": 337,
     "word": "Inbus",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/inbus.mp3",
     "word_type": "Nomen",
@@ -2215,6 +2342,7 @@
   {
     "id": 343,
     "word": "Locher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/locher.mp3",
     "word_type": "Nomen",
@@ -2230,6 +2358,7 @@
   {
     "id": 350,
     "word": "Desinfektionsmittel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/desinfektionsmittel.mp3",
     "word_type": "Nomen",
@@ -2250,6 +2379,7 @@
   {
     "id": 360,
     "word": "Einweghandschuh",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/einweghandschuh.mp3",
     "word_type": "Nomen",
@@ -2270,6 +2400,7 @@
   {
     "id": 361,
     "word": "Mund-Nase-Schutz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/mund-nase-schutz.mp3",
     "word_type": "Nomen",
@@ -2294,6 +2425,7 @@
   {
     "id": 401,
     "word": "Kabelentmantler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kabelentmantler.mp3",
     "word_type": "Nomen",
@@ -2314,6 +2446,7 @@
   {
     "id": 402,
     "word": "Kabelmesser",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kabelmesser.mp3",
     "word_type": "Nomen",
@@ -2329,6 +2462,7 @@
   {
     "id": 403,
     "word": "Kabelschere",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kabelschere.mp3",
     "word_type": "Nomen",
@@ -2344,6 +2478,7 @@
   {
     "id": 415,
     "word": "Ordner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/ordner.mp3",
     "word_type": "Nomen",
@@ -2359,6 +2494,7 @@
   {
     "id": 418,
     "word": "Tacker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/tacker.mp3",
     "word_type": "Nomen",
@@ -2374,6 +2510,7 @@
   {
     "id": 419,
     "word": "Telefon",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/telefon.mp3",
     "word_type": "Nomen",
@@ -2389,6 +2526,7 @@
   {
     "id": 425,
     "word": "Kugelschreiber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kugelschreiber.mp3",
     "word_type": "Nomen",
@@ -2404,6 +2542,7 @@
   {
     "id": 436,
     "word": "Halbrundfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/halbrundfeile.mp3",
     "word_type": "Nomen",
@@ -2419,6 +2558,7 @@
   {
     "id": 438,
     "word": "Metall-Bügelsäge",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/metall-bugelsage.mp3",
     "word_type": "Nomen",
@@ -2439,6 +2579,7 @@
   {
     "id": 441,
     "word": "Rundfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/rundfeile.mp3",
     "word_type": "Nomen",
@@ -2454,6 +2595,7 @@
   {
     "id": 473,
     "word": "Dreikantfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/dreikantfeile.mp3",
     "word_type": "Nomen",
@@ -2469,6 +2611,7 @@
   {
     "id": 474,
     "word": "Flachstumpffeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/flachstumpffeile.mp3",
     "word_type": "Nomen",
@@ -2484,6 +2627,7 @@
   {
     "id": 476,
     "word": "Kombinationszange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kombinationszange.mp3",
     "word_type": "Nomen",
@@ -2504,6 +2648,7 @@
   {
     "id": 477,
     "word": "Kraft-Seitenschneider",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kraft-seitenschneider.mp3",
     "word_type": "Nomen",
@@ -2519,6 +2664,7 @@
   {
     "id": 484,
     "word": "Schlosserhammer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schlosserhammer.mp3",
     "word_type": "Nomen",
@@ -2534,6 +2680,7 @@
   {
     "id": 508,
     "word": "Schwamm",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schwamm.mp3",
     "word_type": "Nomen",
@@ -2549,6 +2696,7 @@
   {
     "id": 509,
     "word": "Spülmittel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/spulmittel.mp3",
     "word_type": "Nomen",
@@ -2564,6 +2712,7 @@
   {
     "id": 510,
     "word": "Küchentuch",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kuchentuch.mp3",
     "word_type": "Nomen",
@@ -2579,6 +2728,7 @@
   {
     "id": 511,
     "word": "Geschirrtuch",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/geschirrtuch.mp3",
     "word_type": "Nomen",
@@ -2599,6 +2749,7 @@
   {
     "id": 512,
     "word": "Spülbürste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spulburste.mp3",
     "word_type": "Nomen",
@@ -2614,6 +2765,7 @@
   {
     "id": 513,
     "word": "Spülbecken",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/spulbecken.mp3",
     "word_type": "Nomen",
@@ -2629,6 +2781,7 @@
   {
     "id": 514,
     "word": "Elektroherd",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/elektroherd.mp3",
     "word_type": "Nomen",
@@ -2649,6 +2802,7 @@
   {
     "id": 515,
     "word": "Herdplatte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/herdplatte.mp3",
     "word_type": "Nomen",
@@ -2664,6 +2818,7 @@
   {
     "id": 516,
     "word": "Suppe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/suppe.mp3",
     "word_type": "Nomen",
@@ -2679,6 +2834,7 @@
   {
     "id": 518,
     "word": "Butter",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/butter.mp3",
     "word_type": "Nomen",
@@ -2694,6 +2850,7 @@
   {
     "id": 522,
     "word": "Schüssel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schussel.mp3",
     "word_type": "Nomen",
@@ -2709,6 +2866,7 @@
   {
     "id": 523,
     "word": "Sieb",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/sieb.mp3",
     "word_type": "Nomen",
@@ -2724,6 +2882,7 @@
   {
     "id": 524,
     "word": "Topf",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/topf.mp3",
     "word_type": "Nomen",
@@ -2739,6 +2898,7 @@
   {
     "id": 525,
     "word": "Pfanne",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/pfanne.mp3",
     "word_type": "Nomen",
@@ -2754,6 +2914,7 @@
   {
     "id": 528,
     "word": "Platte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/platte.mp3",
     "word_type": "Nomen",
@@ -2769,6 +2930,7 @@
   {
     "id": 529,
     "word": "Salatbesteck",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/salatbesteck.mp3",
     "word_type": "Nomen",
@@ -2784,6 +2946,7 @@
   {
     "id": 530,
     "word": "Schale",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schale.mp3",
     "word_type": "Nomen",
@@ -2799,6 +2962,7 @@
   {
     "id": 531,
     "word": "Flaschenöffner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/flaschenoffner.mp3",
     "word_type": "Nomen",
@@ -2814,6 +2978,7 @@
   {
     "id": 532,
     "word": "Besteck",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/besteck.mp3",
     "word_type": "Nomen",
@@ -2829,6 +2994,7 @@
   {
     "id": 533,
     "word": "Löffel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/loffel.mp3",
     "word_type": "Nomen",
@@ -2844,6 +3010,7 @@
   {
     "id": 534,
     "word": "Gabel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/gabel.mp3",
     "word_type": "Nomen",
@@ -2859,6 +3026,7 @@
   {
     "id": 535,
     "word": "Geschirr",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/geschirr.mp3",
     "word_type": "Nomen",
@@ -2874,6 +3042,7 @@
   {
     "id": 536,
     "word": "Tasse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/tasse.mp3",
     "word_type": "Nomen",
@@ -2889,6 +3058,7 @@
   {
     "id": 537,
     "word": "Teller",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/teller.mp3",
     "word_type": "Nomen",
@@ -2904,6 +3074,7 @@
   {
     "id": 538,
     "word": "Gedeck",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/gedeck.mp3",
     "word_type": "Nomen",
@@ -2919,6 +3090,7 @@
   {
     "id": 539,
     "word": "Unterteller",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/unterteller.mp3",
     "word_type": "Nomen",
@@ -2939,6 +3111,7 @@
   {
     "id": 540,
     "word": "Flasche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/flasche.mp3",
     "word_type": "Nomen",
@@ -2954,6 +3127,7 @@
   {
     "id": 541,
     "word": "Glas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/glas.mp3",
     "word_type": "Nomen",
@@ -2969,6 +3143,7 @@
   {
     "id": 542,
     "word": "Bierglas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bierglas.mp3",
     "word_type": "Nomen",
@@ -2984,6 +3159,7 @@
   {
     "id": 543,
     "word": "Weinglas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/weinglas.mp3",
     "word_type": "Nomen",
@@ -2999,6 +3175,7 @@
   {
     "id": 544,
     "word": "Sektglas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/sektglas.mp3",
     "word_type": "Nomen",
@@ -3014,6 +3191,7 @@
   {
     "id": 545,
     "word": "Schnapsglas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/schnapsglas.mp3",
     "word_type": "Nomen",
@@ -3029,6 +3207,7 @@
   {
     "id": 546,
     "word": "Eierbecher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/eierbecher.mp3",
     "word_type": "Nomen",
@@ -3044,6 +3223,7 @@
   {
     "id": 547,
     "word": "Kanne",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kanne.mp3",
     "word_type": "Nomen",
@@ -3059,6 +3239,7 @@
   {
     "id": 548,
     "word": "Krug",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/krug.mp3",
     "word_type": "Nomen",
@@ -3079,6 +3260,7 @@
   {
     "id": 549,
     "word": "Serviette",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/serviette.mp3",
     "word_type": "Nomen",
@@ -3094,6 +3276,7 @@
   {
     "id": 553,
     "word": "Gewindebohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gewindebohrer.mp3",
     "word_type": "Nomen",
@@ -3109,6 +3292,7 @@
   {
     "id": 559,
     "word": "Kreisschneider",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kreisschneider.mp3",
     "word_type": "Nomen",
@@ -3124,6 +3308,7 @@
   {
     "id": 567,
     "word": "Spiralbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/spiralbohrer.mp3",
     "word_type": "Nomen",
@@ -3139,6 +3324,7 @@
   {
     "id": 568,
     "word": "Walzenstirnfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/walzenstirnfraser.mp3",
     "word_type": "Nomen",
@@ -3154,6 +3340,7 @@
   {
     "id": 589,
     "word": "Auflaufform",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/auflaufform.mp3",
     "word_type": "Nomen",
@@ -3169,6 +3356,7 @@
   {
     "id": 595,
     "word": "Tischdecke",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/tischdecke.mp3",
     "word_type": "Nomen",
@@ -3184,6 +3372,7 @@
   {
     "id": 596,
     "word": "Vase",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/vase.mp3",
     "word_type": "Nomen",
@@ -3199,6 +3388,7 @@
   {
     "id": 599,
     "word": "Backblech",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/backblech.mp3",
     "word_type": "Nomen",
@@ -3214,6 +3404,7 @@
   {
     "id": 613,
     "word": "Schneebesen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schneebesen.mp3",
     "word_type": "Nomen",
@@ -3234,6 +3425,7 @@
   {
     "id": 617,
     "word": "Teigschaber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/teigschaber.mp3",
     "word_type": "Nomen",
@@ -3249,6 +3441,7 @@
   {
     "id": 636,
     "word": "Butterdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/butterdose.mp3",
     "word_type": "Nomen",
@@ -3264,6 +3457,7 @@
   {
     "id": 638,
     "word": "Zuckerspender",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zuckerspender.mp3",
     "word_type": "Nomen",
@@ -3279,6 +3473,7 @@
   {
     "id": 641,
     "word": "GN-Behälter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gn-behalter.mp3",
     "word_type": "Nomen",
@@ -3294,6 +3489,7 @@
   {
     "id": 646,
     "word": "Teeglas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/teeglas.mp3",
     "word_type": "Nomen",
@@ -3309,6 +3505,7 @@
   {
     "id": 649,
     "word": "Dosenöffner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/dosenoffner.mp3",
     "word_type": "Nomen",
@@ -3324,6 +3521,7 @@
   {
     "id": 651,
     "word": "Pinsel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/pinsel.mp3",
     "word_type": "Nomen",
@@ -3339,6 +3537,7 @@
   {
     "id": 654,
     "word": "Backpapier",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/backpapier.mp3",
     "word_type": "Nomen",
@@ -3354,6 +3553,7 @@
   {
     "id": 656,
     "word": "Dunstabzugshaube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/dunstabzugshaube.mp3",
     "word_type": "Nomen",
@@ -3374,6 +3574,7 @@
   {
     "id": 667,
     "word": "Kaffeemaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kaffeemaschine.mp3",
     "word_type": "Nomen",
@@ -3394,6 +3595,7 @@
   {
     "id": 668,
     "word": "Kühlschrank",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kuhlschrank.mp3",
     "word_type": "Nomen",
@@ -3409,6 +3611,7 @@
   {
     "id": 670,
     "word": "Thermoskanne",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/thermoskanne.mp3",
     "word_type": "Nomen",
@@ -3424,6 +3627,7 @@
   {
     "id": 671,
     "word": "Omelett",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/omelett.mp3",
     "word_type": "Nomen",
@@ -3439,6 +3643,7 @@
   {
     "id": 673,
     "word": "Spiegelei",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/spiegelei.mp3",
     "word_type": "Nomen",
@@ -3454,6 +3659,7 @@
   {
     "id": 674,
     "word": "Haferflocken",
+    "article": 4,
     "singular_article": 4,
     "audio": "http://testserver/media/audio/haferflocken.mp3",
     "word_type": "Nomen",
@@ -3469,6 +3675,7 @@
   {
     "id": 675,
     "word": "Rotwein",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/rotwein.mp3",
     "word_type": "Nomen",
@@ -3484,6 +3691,7 @@
   {
     "id": 676,
     "word": "Weißwein",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/weiwein.mp3",
     "word_type": "Nomen",
@@ -3499,6 +3707,7 @@
   {
     "id": 678,
     "word": "Bier",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bier.mp3",
     "word_type": "Nomen",
@@ -3514,6 +3723,7 @@
   {
     "id": 679,
     "word": "Eistee",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/eistee.mp3",
     "word_type": "Nomen",
@@ -3529,6 +3739,7 @@
   {
     "id": 680,
     "word": "Saft",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/saft.mp3",
     "word_type": "Nomen",
@@ -3544,6 +3755,7 @@
   {
     "id": 681,
     "word": "Eiswürfel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/eiswurfel.mp3",
     "word_type": "Nomen",
@@ -3559,6 +3771,7 @@
   {
     "id": 682,
     "word": "Honig",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/honig.mp3",
     "word_type": "Nomen",
@@ -3574,6 +3787,7 @@
   {
     "id": 683,
     "word": "Marmelade",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/marmelade.mp3",
     "word_type": "Nomen",
@@ -3589,6 +3803,7 @@
   {
     "id": 685,
     "word": "Tee",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/tee.mp3",
     "word_type": "Nomen",
@@ -3604,6 +3819,7 @@
   {
     "id": 686,
     "word": "Teebeutel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/teebeutel.mp3",
     "word_type": "Nomen",
@@ -3619,6 +3835,7 @@
   {
     "id": 687,
     "word": "Kaffee",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kaffee.mp3",
     "word_type": "Nomen",
@@ -3634,6 +3851,7 @@
   {
     "id": 688,
     "word": "Kaffeefilter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kaffeefilter.mp3",
     "word_type": "Nomen",
@@ -3649,6 +3867,7 @@
   {
     "id": 689,
     "word": "Milch",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/milch.mp3",
     "word_type": "Nomen",
@@ -3664,6 +3883,7 @@
   {
     "id": 691,
     "word": "Öl",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/ol.mp3",
     "word_type": "Nomen",
@@ -3679,6 +3899,7 @@
   {
     "id": 692,
     "word": "Müsli",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/musli.mp3",
     "word_type": "Nomen",
@@ -3694,6 +3915,7 @@
   {
     "id": 693,
     "word": "Zahnstocher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zahnstocher.mp3",
     "word_type": "Nomen",
@@ -3709,6 +3931,7 @@
   {
     "id": 698,
     "word": "Korkenzieher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/korkenzieher.mp3",
     "word_type": "Nomen",
@@ -3724,6 +3947,7 @@
   {
     "id": 700,
     "word": "Chafing-Dish",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/chafing-dish.mp3",
     "word_type": "Nomen",
@@ -3739,6 +3963,7 @@
   {
     "id": 701,
     "word": "Cocktailglas",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/cocktailglas.mp3",
     "word_type": "Nomen",
@@ -3754,6 +3979,7 @@
   {
     "id": 702,
     "word": "Espressotasse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/espressotasse.mp3",
     "word_type": "Nomen",
@@ -3769,6 +3995,7 @@
   {
     "id": 703,
     "word": "Kaffeelöffel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kaffeeloffel.mp3",
     "word_type": "Nomen",
@@ -3784,6 +4011,7 @@
   {
     "id": 704,
     "word": "Kuchengabel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kuchengabel.mp3",
     "word_type": "Nomen",
@@ -3799,6 +4027,7 @@
   {
     "id": 705,
     "word": "Kaffeeportionierer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kaffeeportionierer.mp3",
     "word_type": "Nomen",
@@ -3814,6 +4043,7 @@
   {
     "id": 706,
     "word": "Kuchenteller",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kuchenteller.mp3",
     "word_type": "Nomen",
@@ -3829,6 +4059,7 @@
   {
     "id": 707,
     "word": "Schieferplatte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schieferplatte.mp3",
     "word_type": "Nomen",
@@ -3849,6 +4080,7 @@
   {
     "id": 709,
     "word": "Suppenteller",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/suppenteller.mp3",
     "word_type": "Nomen",
@@ -3864,6 +4096,7 @@
   {
     "id": 710,
     "word": "Kaffeetasse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kaffeetasse.mp3",
     "word_type": "Nomen",
@@ -3879,6 +4112,7 @@
   {
     "id": 713,
     "word": "Bodenwischgerät",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bodenwischgerat.mp3",
     "word_type": "Nomen",
@@ -3894,6 +4128,7 @@
   {
     "id": 714,
     "word": "Papierhandtuch",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/papierhandtuch.mp3",
     "word_type": "Nomen",
@@ -3909,6 +4144,7 @@
   {
     "id": 715,
     "word": "Papierhandtuchspender",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/papierhandtuchspender.mp3",
     "word_type": "Nomen",
@@ -3924,6 +4160,7 @@
   {
     "id": 716,
     "word": "Reinigungsbürste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/reinigungsburste.mp3",
     "word_type": "Nomen",
@@ -3939,6 +4176,7 @@
   {
     "id": 717,
     "word": "Reinigungshandschuh",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/reinigungshandschuh.mp3",
     "word_type": "Nomen",
@@ -3959,6 +4197,7 @@
   {
     "id": 718,
     "word": "Reinigungsmittel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/reinigungsmittel.mp3",
     "word_type": "Nomen",
@@ -3974,6 +4213,7 @@
   {
     "id": 719,
     "word": "Reinigungswagen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/reinigungswagen.mp3",
     "word_type": "Nomen",
@@ -3989,6 +4229,7 @@
   {
     "id": 720,
     "word": "Seifenspender",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/seifenspender.mp3",
     "word_type": "Nomen",
@@ -4004,6 +4245,7 @@
   {
     "id": 721,
     "word": "Sprühflasche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spruhflasche.mp3",
     "word_type": "Nomen",
@@ -4019,6 +4261,7 @@
   {
     "id": 723,
     "word": "Staubsaugerbeutel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/staubsaugerbeutel.mp3",
     "word_type": "Nomen",
@@ -4034,6 +4277,7 @@
   {
     "id": 724,
     "word": "Wischbezug",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/wischbezug.mp3",
     "word_type": "Nomen",
@@ -4049,6 +4293,7 @@
   {
     "id": 726,
     "word": "Bademantel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bademantel.mp3",
     "word_type": "Nomen",
@@ -4064,6 +4309,7 @@
   {
     "id": 727,
     "word": "Badezimmer",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/badezimmer.mp3",
     "word_type": "Nomen",
@@ -4079,6 +4325,7 @@
   {
     "id": 728,
     "word": "Balkon",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/balkon.mp3",
     "word_type": "Nomen",
@@ -4094,6 +4341,7 @@
   {
     "id": 729,
     "word": "Bettdecke",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bettdecke.mp3",
     "word_type": "Nomen",
@@ -4109,6 +4357,7 @@
   {
     "id": 730,
     "word": "Bettwäsche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bettwasche.mp3",
     "word_type": "Nomen",
@@ -4124,6 +4373,7 @@
   {
     "id": 731,
     "word": "Doppelbett",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/doppelbett.mp3",
     "word_type": "Nomen",
@@ -4139,6 +4389,7 @@
   {
     "id": 732,
     "word": "Duschkopf",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/duschkopf.mp3",
     "word_type": "Nomen",
@@ -4154,6 +4405,7 @@
   {
     "id": 733,
     "word": "Einzelbett",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/einzelbett.mp3",
     "word_type": "Nomen",
@@ -4169,6 +4421,7 @@
   {
     "id": 734,
     "word": "Fenster",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/fenster.mp3",
     "word_type": "Nomen",
@@ -4184,6 +4437,7 @@
   {
     "id": 735,
     "word": "Fernbedienung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/fernbedienung.mp3",
     "word_type": "Nomen",
@@ -4199,6 +4453,7 @@
   {
     "id": 736,
     "word": "Fernseher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/fernseher.mp3",
     "word_type": "Nomen",
@@ -4214,6 +4469,7 @@
   {
     "id": 738,
     "word": "Garderobe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/garderobe.mp3",
     "word_type": "Nomen",
@@ -4229,6 +4485,7 @@
   {
     "id": 739,
     "word": "Gardine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/gardine.mp3",
     "word_type": "Nomen",
@@ -4244,6 +4501,7 @@
   {
     "id": 740,
     "word": "Handtuch",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/handtuch.mp3",
     "word_type": "Nomen",
@@ -4259,6 +4517,7 @@
   {
     "id": 741,
     "word": "Handtuchhalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/handtuchhalter.mp3",
     "word_type": "Nomen",
@@ -4274,6 +4533,7 @@
   {
     "id": 742,
     "word": "Handtuchstange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/handtuchstange.mp3",
     "word_type": "Nomen",
@@ -4289,6 +4549,7 @@
   {
     "id": 743,
     "word": "Hoteltresor",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/hoteltresor.mp3",
     "word_type": "Nomen",
@@ -4317,6 +4578,7 @@
   {
     "id": 745,
     "word": "Kleiderbügel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kleiderbugel.mp3",
     "word_type": "Nomen",
@@ -4332,6 +4594,7 @@
   {
     "id": 746,
     "word": "Kleiderschrank",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kleiderschrank.mp3",
     "word_type": "Nomen",
@@ -4347,6 +4610,7 @@
   {
     "id": 747,
     "word": "Klimaanlagenregler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/klimaanlagenregler.mp3",
     "word_type": "Nomen",
@@ -4362,6 +4626,7 @@
   {
     "id": 748,
     "word": "Kopfkissen",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kopfkissen.mp3",
     "word_type": "Nomen",
@@ -4377,6 +4642,7 @@
   {
     "id": 749,
     "word": "Minibar",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/minibar.mp3",
     "word_type": "Nomen",
@@ -4392,6 +4658,7 @@
   {
     "id": 750,
     "word": "Nachttisch",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/nachttisch.mp3",
     "word_type": "Nomen",
@@ -4412,6 +4679,7 @@
   {
     "id": 751,
     "word": "Rasierapparat",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/rasierapparat.mp3",
     "word_type": "Nomen",
@@ -4427,6 +4695,7 @@
   {
     "id": 753,
     "word": "Toilettenbürste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/toilettenburste.mp3",
     "word_type": "Nomen",
@@ -4442,6 +4711,7 @@
   {
     "id": 754,
     "word": "Toilettenpapier",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/toilettenpapier.mp3",
     "word_type": "Nomen",
@@ -4457,6 +4727,7 @@
   {
     "id": 755,
     "word": "Toilettenpapierhalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/toilettenpapierhalter.mp3",
     "word_type": "Nomen",
@@ -4472,6 +4743,7 @@
   {
     "id": 756,
     "word": "Wasserkocher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/wasserkocher.mp3",
     "word_type": "Nomen",
@@ -4487,6 +4759,7 @@
   {
     "id": 757,
     "word": "Zahnbürste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/zahnburste.mp3",
     "word_type": "Nomen",
@@ -4502,6 +4775,7 @@
   {
     "id": 758,
     "word": "Zahnpasta",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/zahnpasta.mp3",
     "word_type": "Nomen",
@@ -4517,6 +4791,7 @@
   {
     "id": 759,
     "word": "EC-Karte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/ec-karte.mp3",
     "word_type": "Nomen",
@@ -4537,6 +4812,7 @@
   {
     "id": 761,
     "word": "Gepäck",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/gepack.mp3",
     "word_type": "Nomen",
@@ -4552,6 +4828,7 @@
   {
     "id": 762,
     "word": "Gepäckwagen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gepackwagen.mp3",
     "word_type": "Nomen",
@@ -4567,6 +4844,7 @@
   {
     "id": 764,
     "word": "Koffer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/koffer.mp3",
     "word_type": "Nomen",
@@ -4582,6 +4860,7 @@
   {
     "id": 765,
     "word": "Kreditkarte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kreditkarte.mp3",
     "word_type": "Nomen",
@@ -4602,6 +4881,7 @@
   {
     "id": 766,
     "word": "Parkplatz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/parkplatz.mp3",
     "word_type": "Nomen",
@@ -4617,6 +4897,7 @@
   {
     "id": 767,
     "word": "Rezeption",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/rezeption.mp3",
     "word_type": "Nomen",
@@ -4632,6 +4913,7 @@
   {
     "id": 768,
     "word": "Rezeptionsglocke",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/rezeptionsglocke.mp3",
     "word_type": "Nomen",
@@ -4647,6 +4929,7 @@
   {
     "id": 769,
     "word": "Sicherheitsnadel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/sicherheitsnadel.mp3",
     "word_type": "Nomen",
@@ -4662,6 +4945,7 @@
   {
     "id": 771,
     "word": "Streichholz",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/streichholz.mp3",
     "word_type": "Nomen",
@@ -4677,6 +4961,7 @@
   {
     "id": 772,
     "word": "Tasche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/tasche.mp3",
     "word_type": "Nomen",
@@ -4692,6 +4977,7 @@
   {
     "id": 773,
     "word": "Trolley",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/trolley.mp3",
     "word_type": "Nomen",
@@ -4707,6 +4993,7 @@
   {
     "id": 776,
     "word": "Waschmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/waschmaschine.mp3",
     "word_type": "Nomen",
@@ -4722,6 +5009,7 @@
   {
     "id": 778,
     "word": "Waschmittel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/waschmittel.mp3",
     "word_type": "Nomen",
@@ -4737,6 +5025,7 @@
   {
     "id": 779,
     "word": "Wäscheständer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/waschestander.mp3",
     "word_type": "Nomen",
@@ -4752,6 +5041,7 @@
   {
     "id": 780,
     "word": "Wäscheklammer",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/wascheklammer.mp3",
     "word_type": "Nomen",
@@ -4767,6 +5057,7 @@
   {
     "id": 782,
     "word": "Waschgang",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/waschgang.mp3",
     "word_type": "Nomen",
@@ -4782,6 +5073,7 @@
   {
     "id": 783,
     "word": "Schleuderzahl",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schleuderzahl.mp3",
     "word_type": "Nomen",
@@ -4797,6 +5089,7 @@
   {
     "id": 784,
     "word": "Pflegeetikett",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/pflegeetikett.mp3",
     "word_type": "Nomen",
@@ -4812,6 +5105,7 @@
   {
     "id": 786,
     "word": "Seife",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/seife.mp3",
     "word_type": "Nomen",
@@ -4827,6 +5121,7 @@
   {
     "id": 908,
     "word": "Handtacker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/handtacker.mp3",
     "word_type": "Nomen",
@@ -4842,6 +5137,7 @@
   {
     "id": 909,
     "word": "Winkelmesser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/winkelmesser.mp3",
     "word_type": "Nomen",
@@ -4857,6 +5153,7 @@
   {
     "id": 912,
     "word": "Vorhängeschloss",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/vorhangeschloss.mp3",
     "word_type": "Nomen",
@@ -4872,6 +5169,7 @@
   {
     "id": 932,
     "word": "Bogenzirkel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bogenzirkel.mp3",
     "word_type": "Nomen",
@@ -4892,6 +5190,7 @@
   {
     "id": 937,
     "word": "Flachzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/flachzange.mp3",
     "word_type": "Nomen",
@@ -4907,6 +5206,7 @@
   {
     "id": 938,
     "word": "Gripzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/gripzange.mp3",
     "word_type": "Nomen",
@@ -4922,6 +5222,7 @@
   {
     "id": 945,
     "word": "Schlagschnur",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schlagschnur.mp3",
     "word_type": "Nomen",
@@ -4937,6 +5238,7 @@
   {
     "id": 953,
     "word": "Schraubenziehersatz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schraubenziehersatz.mp3",
     "word_type": "Nomen",
@@ -4952,6 +5254,7 @@
   {
     "id": 954,
     "word": "Holzbock",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/holzbock.mp3",
     "word_type": "Nomen",
@@ -4967,6 +5270,7 @@
   {
     "id": 955,
     "word": "Spitzzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spitzzange.mp3",
     "word_type": "Nomen",
@@ -4982,6 +5286,7 @@
   {
     "id": 958,
     "word": "Staubsaugerfilter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/staubsaugerfilter.mp3",
     "word_type": "Nomen",
@@ -5006,6 +5311,7 @@
   {
     "id": 959,
     "word": "Schlauch",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schlauch.mp3",
     "word_type": "Nomen",
@@ -5021,6 +5327,7 @@
   {
     "id": 961,
     "word": "Anschlagwinkel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/anschlagwinkel.mp3",
     "word_type": "Nomen",
@@ -5036,6 +5343,7 @@
   {
     "id": 964,
     "word": "Drehmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/drehmaschine.mp3",
     "word_type": "Nomen",
@@ -5056,6 +5364,7 @@
   {
     "id": 980,
     "word": "Bargeld",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bargeld.mp3",
     "word_type": "Nomen",
@@ -5071,6 +5380,7 @@
   {
     "id": 1005,
     "word": "Erste-Hilfe-Koffer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/erste-hilfe-koffer.mp3",
     "word_type": "Nomen",
@@ -5086,6 +5396,7 @@
   {
     "id": 1006,
     "word": "Feuerlöscher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/feuerloscher.mp3",
     "word_type": "Nomen",
@@ -5101,6 +5412,7 @@
   {
     "id": 1023,
     "word": "Bett",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bett.mp3",
     "word_type": "Nomen",
@@ -5116,6 +5428,7 @@
   {
     "id": 1034,
     "word": "Lichtschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/lichtschalter.mp3",
     "word_type": "Nomen",
@@ -5131,6 +5444,7 @@
   {
     "id": 1049,
     "word": "Geldschein",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/geldschein.mp3",
     "word_type": "Nomen",
@@ -5146,6 +5460,7 @@
   {
     "id": 1050,
     "word": "Münze",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/munze.mp3",
     "word_type": "Nomen",
@@ -5161,6 +5476,7 @@
   {
     "id": 1111,
     "word": "Backrost",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/backrost.mp3",
     "word_type": "Nomen",
@@ -5181,6 +5497,7 @@
   {
     "id": 1113,
     "word": "Kaffeevollautomat",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kaffeevollautomat.mp3",
     "word_type": "Nomen",
@@ -5201,6 +5518,7 @@
   {
     "id": 1115,
     "word": "Servierteller",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/servierteller.mp3",
     "word_type": "Nomen",
@@ -5216,6 +5534,7 @@
   {
     "id": 1116,
     "word": "Tumbler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/tumbler.mp3",
     "word_type": "Nomen",
@@ -5231,6 +5550,7 @@
   {
     "id": 1117,
     "word": "Warmhalterost",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/warmhalterost.mp3",
     "word_type": "Nomen",
@@ -5246,6 +5566,7 @@
   {
     "id": 1118,
     "word": "Desinfektionsmittelspender",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/desinfektionsmittelspender.mp3",
     "word_type": "Nomen",
@@ -5261,6 +5582,7 @@
   {
     "id": 1119,
     "word": "Käsebrett",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kasebrett.mp3",
     "word_type": "Nomen",
@@ -5276,6 +5598,7 @@
   {
     "id": 1122,
     "word": "Rührschüssel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/ruhrschussel.mp3",
     "word_type": "Nomen",
@@ -5291,6 +5614,7 @@
   {
     "id": 1123,
     "word": "Ceranfeldschaber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/ceranfeldschaber.mp3",
     "word_type": "Nomen",
@@ -5306,6 +5630,7 @@
   {
     "id": 1126,
     "word": "Topflappen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/topflappen.mp3",
     "word_type": "Nomen",
@@ -5321,6 +5646,7 @@
   {
     "id": 1127,
     "word": "Defibrillator",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/defibrillator.mp3",
     "word_type": "Nomen",
@@ -5336,6 +5662,7 @@
   {
     "id": 1128,
     "word": "Notfallplan",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/notfallplan.mp3",
     "word_type": "Nomen",
@@ -5351,6 +5678,7 @@
   {
     "id": 1129,
     "word": "Notausgang",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/notausgang.mp3",
     "word_type": "Nomen",
@@ -5366,6 +5694,7 @@
   {
     "id": 1136,
     "word": "Garderobenständer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/garderobenstander.mp3",
     "word_type": "Nomen",
@@ -5381,6 +5710,7 @@
   {
     "id": 1138,
     "word": "Telefonanlage",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/telefonanlage.mp3",
     "word_type": "Nomen",
@@ -5396,6 +5726,7 @@
   {
     "id": 1139,
     "word": "Sitzgruppe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/sitzgruppe.mp3",
     "word_type": "Nomen",
@@ -5411,6 +5742,7 @@
   {
     "id": 1142,
     "word": "Fliese",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/fliese.mp3",
     "word_type": "Nomen",
@@ -5426,6 +5758,7 @@
   {
     "id": 1143,
     "word": "Flurschild",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/flurschild.mp3",
     "word_type": "Nomen",
@@ -5441,6 +5774,7 @@
   {
     "id": 1144,
     "word": "Kosmetikmülleimer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kosmetikmulleimer.mp3",
     "word_type": "Nomen",
@@ -5456,6 +5790,7 @@
   {
     "id": 1145,
     "word": "Schließzylinder",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schliezylinder.mp3",
     "word_type": "Nomen",
@@ -5471,6 +5806,7 @@
   {
     "id": 1146,
     "word": "Sicherheitssteckdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/sicherheitssteckdose.mp3",
     "word_type": "Nomen",
@@ -5486,6 +5822,7 @@
   {
     "id": 1147,
     "word": "Waschtisch",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/waschtisch.mp3",
     "word_type": "Nomen",
@@ -5501,6 +5838,7 @@
   {
     "id": 1148,
     "word": "Türschild",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/turschild.mp3",
     "word_type": "Nomen",
@@ -5516,6 +5854,7 @@
   {
     "id": 1149,
     "word": "Badregal",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/badregal.mp3",
     "word_type": "Nomen",
@@ -5531,6 +5870,7 @@
   {
     "id": 1197,
     "word": "Mikrowelle",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/mikrowelle.mp3",
     "word_type": "Nomen",
@@ -5546,6 +5886,7 @@
   {
     "id": 1198,
     "word": "Küchenmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kuchenmaschine.mp3",
     "word_type": "Nomen",
@@ -5561,6 +5902,7 @@
   {
     "id": 1199,
     "word": "Gasherd",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gasherd.mp3",
     "word_type": "Nomen",
@@ -5576,6 +5918,7 @@
   {
     "id": 1200,
     "word": "Bierkrug",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bierkrug.mp3",
     "word_type": "Nomen",
@@ -5591,6 +5934,7 @@
   {
     "id": 1203,
     "word": "Abstandschelle",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/abstandschelle.mp3",
     "word_type": "Nomen",
@@ -5606,6 +5950,7 @@
   {
     "id": 1204,
     "word": "Abzweigdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/abzweigdose.mp3",
     "word_type": "Nomen",
@@ -5621,6 +5966,7 @@
   {
     "id": 1205,
     "word": "Aderendhülse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/aderendhulse.mp3",
     "word_type": "Nomen",
@@ -5641,6 +5987,7 @@
   {
     "id": 1206,
     "word": "Aderleitung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/aderleitung.mp3",
     "word_type": "Nomen",
@@ -5656,6 +6003,7 @@
   {
     "id": 1207,
     "word": "Alarmleuchte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/alarmleuchte.mp3",
     "word_type": "Nomen",
@@ -5671,6 +6019,7 @@
   {
     "id": 1208,
     "word": "Analogmessgerät",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/analogmessgerat.mp3",
     "word_type": "Nomen",
@@ -5686,6 +6035,7 @@
   {
     "id": 1209,
     "word": "Anlagenmessgerät",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/anlagenmessgerat.mp3",
     "word_type": "Nomen",
@@ -5701,6 +6051,7 @@
   {
     "id": 1210,
     "word": "Anschlussdatenbezeichnung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/anschlussdatenbezeichnung.mp3",
     "word_type": "Nomen",
@@ -5716,6 +6067,7 @@
   {
     "id": 1211,
     "word": "Baustrahler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/baustrahler.mp3",
     "word_type": "Nomen",
@@ -5731,6 +6083,7 @@
   {
     "id": 1212,
     "word": "Aufputzinstallation",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/aufputzinstallation.mp3",
     "word_type": "Nomen",
@@ -5746,6 +6099,7 @@
   {
     "id": 1213,
     "word": "Aufputzinstallationsrohr",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/aufputzinstallationsrohr.mp3",
     "word_type": "Nomen",
@@ -5761,6 +6115,7 @@
   {
     "id": 1214,
     "word": "Audiosignal",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/audiosignal.mp3",
     "word_type": "Nomen",
@@ -5776,6 +6131,7 @@
   {
     "id": 1215,
     "word": "Außengewinde",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/auengewinde.mp3",
     "word_type": "Nomen",
@@ -5791,6 +6147,7 @@
   {
     "id": 1216,
     "word": "Bananenstecker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bananenstecker.mp3",
     "word_type": "Nomen",
@@ -5806,6 +6163,7 @@
   {
     "id": 1217,
     "word": "Batterie",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/batterie.mp3",
     "word_type": "Nomen",
@@ -5821,6 +6179,7 @@
   {
     "id": 1218,
     "word": "Baustromverteiler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/baustromverteiler.mp3",
     "word_type": "Nomen",
@@ -5836,6 +6195,7 @@
   {
     "id": 1219,
     "word": "Bedienfeld",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bedienfeld.mp3",
     "word_type": "Nomen",
@@ -5851,6 +6211,7 @@
   {
     "id": 1220,
     "word": "Betoninstallationsrohr",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/betoninstallationsrohr.mp3",
     "word_type": "Nomen",
@@ -5866,6 +6227,7 @@
   {
     "id": 1221,
     "word": "Bohrfutter",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bohrfutter.mp3",
     "word_type": "Nomen",
@@ -5881,6 +6243,7 @@
   {
     "id": 1222,
     "word": "Bohrfutterschlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bohrfutterschlussel.mp3",
     "word_type": "Nomen",
@@ -5896,6 +6259,7 @@
   {
     "id": 1223,
     "word": "Bohrloch",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bohrloch.mp3",
     "word_type": "Nomen",
@@ -5916,6 +6280,7 @@
   {
     "id": 1224,
     "word": "Brandschutzschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/brandschutzschalter.mp3",
     "word_type": "Nomen",
@@ -5931,6 +6296,7 @@
   {
     "id": 1225,
     "word": "Brüstungskanal",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/brustungskanal.mp3",
     "word_type": "Nomen",
@@ -5946,6 +6312,7 @@
   {
     "id": 1226,
     "word": "Bügelgehörschutz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bugelgehorschutz.mp3",
     "word_type": "Nomen",
@@ -5961,6 +6328,7 @@
   {
     "id": 1227,
     "word": "Dämmerungsschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/dammerungsschalter.mp3",
     "word_type": "Nomen",
@@ -5976,6 +6344,7 @@
   {
     "id": 1228,
     "word": "Deckenleuchte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/deckenleuchte.mp3",
     "word_type": "Nomen",
@@ -5991,6 +6360,7 @@
   {
     "id": 1229,
     "word": "Dimmer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/dimmer.mp3",
     "word_type": "Nomen",
@@ -6006,6 +6376,7 @@
   {
     "id": 1230,
     "word": "Dosenklemme",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/dosenklemme.mp3",
     "word_type": "Nomen",
@@ -6026,6 +6397,7 @@
   {
     "id": 1231,
     "word": "Draht",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/draht.mp3",
     "word_type": "Nomen",
@@ -6041,6 +6413,7 @@
   {
     "id": 1232,
     "word": "Dreheisenmessgerät",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/dreheisenmessgerat.mp3",
     "word_type": "Nomen",
@@ -6056,6 +6429,7 @@
   {
     "id": 1233,
     "word": "Drehfeldmessgerät",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/drehfeldmessgerat.mp3",
     "word_type": "Nomen",
@@ -6071,6 +6445,7 @@
   {
     "id": 1234,
     "word": "Drehschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/drehschalter.mp3",
     "word_type": "Nomen",
@@ -6086,6 +6461,7 @@
   {
     "id": 1236,
     "word": "Druckschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/druckschalter.mp3",
     "word_type": "Nomen",
@@ -6101,6 +6477,7 @@
   {
     "id": 1237,
     "word": "Durchbruchbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/durchbruchbohrer.mp3",
     "word_type": "Nomen",
@@ -6116,6 +6493,7 @@
   {
     "id": 1238,
     "word": "Durchgangsprüfer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/durchgangsprufer.mp3",
     "word_type": "Nomen",
@@ -6131,6 +6509,7 @@
   {
     "id": 1239,
     "word": "E-Check",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/e-check.mp3",
     "word_type": "Nomen",
@@ -6155,6 +6534,7 @@
   {
     "id": 1240,
     "word": "Elektrikergips",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/elektrikergips.mp3",
     "word_type": "Nomen",
@@ -6175,6 +6555,7 @@
   {
     "id": 1241,
     "word": "elektrische Verteiler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/elektrische-verteiler.mp3",
     "word_type": "Nomen",
@@ -6203,6 +6584,7 @@
   {
     "id": 1242,
     "word": "Elektroinstallation",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/elektroinstallation.mp3",
     "word_type": "Nomen",
@@ -6218,6 +6600,7 @@
   {
     "id": 1243,
     "word": "Elektrosäge",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/elektrosage.mp3",
     "word_type": "Nomen",
@@ -6233,6 +6616,7 @@
   {
     "id": 1244,
     "word": "Elektroschere",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/elektroschere.mp3",
     "word_type": "Nomen",
@@ -6248,6 +6632,7 @@
   {
     "id": 1246,
     "word": "Entlötpumpe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/entlotpumpe.mp3",
     "word_type": "Nomen",
@@ -6263,6 +6648,7 @@
   {
     "id": 1247,
     "word": "Eurostecker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/eurostecker.mp3",
     "word_type": "Nomen",
@@ -6278,6 +6664,7 @@
   {
     "id": 1249,
     "word": "Flachmeißel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/flachmeiel.mp3",
     "word_type": "Nomen",
@@ -6293,6 +6680,7 @@
   {
     "id": 1250,
     "word": "Flachrundzange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/flachrundzange.mp3",
     "word_type": "Nomen",
@@ -6308,6 +6696,7 @@
   {
     "id": 1252,
     "word": "Gehörstöpsel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gehorstopsel.mp3",
     "word_type": "Nomen",
@@ -6332,6 +6721,7 @@
   {
     "id": 1253,
     "word": "Heißklebepistole",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/heiklebepistole.mp3",
     "word_type": "Nomen",
@@ -6347,6 +6737,7 @@
   {
     "id": 1254,
     "word": "Heißluftgebläse",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/heiluftgeblase.mp3",
     "word_type": "Nomen",
@@ -6362,6 +6753,7 @@
   {
     "id": 1255,
     "word": "Hygrometer",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/hygrometer.mp3",
     "word_type": "Nomen",
@@ -6377,6 +6769,7 @@
   {
     "id": 1256,
     "word": "Infrarotstrahler",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/infrarotstrahler.mp3",
     "word_type": "Nomen",
@@ -6392,6 +6785,7 @@
   {
     "id": 1257,
     "word": "Innengewinde",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/innengewinde.mp3",
     "word_type": "Nomen",
@@ -6407,6 +6801,7 @@
   {
     "id": 1258,
     "word": "inverte Stromerzeuger",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/inverte-stromerzeuger.mp3",
     "word_type": "Nomen",
@@ -6422,6 +6817,7 @@
   {
     "id": 1259,
     "word": "Kabel",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kabel.mp3",
     "word_type": "Nomen",
@@ -6437,6 +6833,7 @@
   {
     "id": 1260,
     "word": "Kabelbinder",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kabelbinder.mp3",
     "word_type": "Nomen",
@@ -6452,6 +6849,7 @@
   {
     "id": 1261,
     "word": "Kabeleinziehsystem",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kabeleinziehsystem.mp3",
     "word_type": "Nomen",
@@ -6467,6 +6865,7 @@
   {
     "id": 1263,
     "word": "Kraftstromsteckdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kraftstromsteckdose.mp3",
     "word_type": "Nomen",
@@ -6482,6 +6881,7 @@
   {
     "id": 1264,
     "word": "Kuparohr",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kuparohr.mp3",
     "word_type": "Nomen",
@@ -6502,6 +6902,7 @@
   {
     "id": 1265,
     "word": "Litzenleitung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/litzenleitung.mp3",
     "word_type": "Nomen",
@@ -6517,6 +6918,7 @@
   {
     "id": 1266,
     "word": "Lochsäge",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/lochsage.mp3",
     "word_type": "Nomen",
@@ -6532,6 +6934,7 @@
   {
     "id": 1267,
     "word": "Lötkolben",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/lotkolben.mp3",
     "word_type": "Nomen",
@@ -6547,6 +6950,7 @@
   {
     "id": 1268,
     "word": "Lötset",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/lotset.mp3",
     "word_type": "Nomen",
@@ -6562,6 +6966,7 @@
   {
     "id": 1270,
     "word": "Lötstation",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/lotstation.mp3",
     "word_type": "Nomen",
@@ -6577,6 +6982,7 @@
   {
     "id": 1271,
     "word": "Lötstelle",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/lotstelle.mp3",
     "word_type": "Nomen",
@@ -6597,6 +7003,7 @@
   {
     "id": 1272,
     "word": "Lötzinn",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/lotzinn.mp3",
     "word_type": "Nomen",
@@ -6612,6 +7019,7 @@
   {
     "id": 1273,
     "word": "LSA-Plus-Auflegewerkzeug",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/lsa-plus-auflegewerkzeug.mp3",
     "word_type": "Nomen",
@@ -6632,6 +7040,7 @@
   {
     "id": 1274,
     "word": "Mauernutfräse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/mauernutfrase.mp3",
     "word_type": "Nomen",
@@ -6647,6 +7056,7 @@
   {
     "id": 1275,
     "word": "Metalldetektor",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/metalldetektor.mp3",
     "word_type": "Nomen",
@@ -6662,6 +7072,7 @@
   {
     "id": 1276,
     "word": "Netzteil",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/netzteil.mp3",
     "word_type": "Nomen",
@@ -6677,6 +7088,7 @@
   {
     "id": 1277,
     "word": "Phasenprüfer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/phasenprufer.mp3",
     "word_type": "Nomen",
@@ -6692,6 +7104,7 @@
   {
     "id": 1278,
     "word": "Doppelringschlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/doppelringschlussel.mp3",
     "word_type": "Nomen",
@@ -6707,6 +7120,7 @@
   {
     "id": 1279,
     "word": "Ringmaulschlüssel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/ringmaulschlussel.mp3",
     "word_type": "Nomen",
@@ -6727,6 +7141,7 @@
   {
     "id": 1280,
     "word": "Schleifenimpedanzmessgerät",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/schleifenimpedanzmessgerat.mp3",
     "word_type": "Nomen",
@@ -6742,6 +7157,7 @@
   {
     "id": 1281,
     "word": "Schraubenkopf",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schraubenkopf.mp3",
     "word_type": "Nomen",
@@ -6757,6 +7173,7 @@
   {
     "id": 1282,
     "word": "Schraubenmutter",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schraubenmutter.mp3",
     "word_type": "Nomen",
@@ -6777,6 +7194,7 @@
   {
     "id": 1283,
     "word": "Schutzschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schutzschalter.mp3",
     "word_type": "Nomen",
@@ -6792,6 +7210,7 @@
   {
     "id": 1284,
     "word": "Signalband",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/signalband.mp3",
     "word_type": "Nomen",
@@ -6807,6 +7226,7 @@
   {
     "id": 1286,
     "word": "Stabschrauber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/stabschrauber.mp3",
     "word_type": "Nomen",
@@ -6822,6 +7242,7 @@
   {
     "id": 1287,
     "word": "Starkstromleitung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/starkstromleitung.mp3",
     "word_type": "Nomen",
@@ -6842,6 +7263,7 @@
   {
     "id": 1288,
     "word": "Steckverbinder",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/steckverbinder.mp3",
     "word_type": "Nomen",
@@ -6862,6 +7284,7 @@
   {
     "id": 1289,
     "word": "Störlichtbogen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/storlichtbogen.mp3",
     "word_type": "Nomen",
@@ -6877,6 +7300,7 @@
   {
     "id": 1290,
     "word": "Strommesszange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/strommesszange.mp3",
     "word_type": "Nomen",
@@ -6892,6 +7316,7 @@
   {
     "id": 1291,
     "word": "Transformator",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/transformator.mp3",
     "word_type": "Nomen",
@@ -6907,6 +7332,7 @@
   {
     "id": 1292,
     "word": "Trockenbauwand",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/trockenbauwand.mp3",
     "word_type": "Nomen",
@@ -6927,6 +7353,7 @@
   {
     "id": 1293,
     "word": "Unterputzdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/unterputzdose.mp3",
     "word_type": "Nomen",
@@ -6942,6 +7369,7 @@
   {
     "id": 1297,
     "word": "Schaltplan",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schaltplan.mp3",
     "word_type": "Nomen",
@@ -6957,6 +7385,7 @@
   {
     "id": 1298,
     "word": "Nut",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/nut.mp3",
     "word_type": "Nomen",
@@ -6977,6 +7406,7 @@
   {
     "id": 1299,
     "word": "Kondensator",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kondensator.mp3",
     "word_type": "Nomen",
@@ -6992,6 +7422,7 @@
   {
     "id": 1300,
     "word": "Atom",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/atom.mp3",
     "word_type": "Nomen",
@@ -7007,6 +7438,7 @@
   {
     "id": 1304,
     "word": "Atomstrom",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/atomstrom.mp3",
     "word_type": "Nomen",
@@ -7022,6 +7454,7 @@
   {
     "id": 1306,
     "word": "Außenleiter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/auenleiter.mp3",
     "word_type": "Nomen",
@@ -7037,6 +7470,7 @@
   {
     "id": 1309,
     "word": "Neutralleiter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/neutralleiter.mp3",
     "word_type": "Nomen",
@@ -7052,6 +7486,7 @@
   {
     "id": 1328,
     "word": "Abfallstrom",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/abfallstrom.mp3",
     "word_type": "Nomen",
@@ -7067,6 +7502,7 @@
   {
     "id": 1329,
     "word": "Amplitude",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/amplitude.mp3",
     "word_type": "Nomen",
@@ -7082,6 +7518,7 @@
   {
     "id": 1330,
     "word": "Dreiphasenwechselstrom",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/dreiphasenwechselstrom.mp3",
     "word_type": "Nomen",
@@ -7097,6 +7534,7 @@
   {
     "id": 1331,
     "word": "Gleichstrom",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gleichstrom.mp3",
     "word_type": "Nomen",
@@ -7112,6 +7550,7 @@
   {
     "id": 1332,
     "word": "Wechselstrom",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/wechselstrom.mp3",
     "word_type": "Nomen",
@@ -7127,6 +7566,7 @@
   {
     "id": 1333,
     "word": "Anode",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/anode.mp3",
     "word_type": "Nomen",
@@ -7142,6 +7582,7 @@
   {
     "id": 1334,
     "word": "Kathode",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kathode.mp3",
     "word_type": "Nomen",
@@ -7157,6 +7598,7 @@
   {
     "id": 1335,
     "word": "Leitung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/leitung.mp3",
     "word_type": "Nomen",
@@ -7172,6 +7614,7 @@
   {
     "id": 1337,
     "word": "Stromkreis",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/stromkreis.mp3",
     "word_type": "Nomen",
@@ -7187,6 +7630,7 @@
   {
     "id": 1339,
     "word": "Verbraucher",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/verbraucher.mp3",
     "word_type": "Nomen",
@@ -7202,6 +7646,7 @@
   {
     "id": 1375,
     "word": "Beipackzettel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/beipackzettel.mp3",
     "word_type": "Nomen",
@@ -7217,6 +7662,7 @@
   {
     "id": 1424,
     "word": "Schwingschleifer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schwingschleifer.mp3",
     "word_type": "Nomen",
@@ -7232,6 +7678,7 @@
   {
     "id": 1426,
     "word": "Sicherung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/sicherung.mp3",
     "word_type": "Nomen",
@@ -7247,6 +7694,7 @@
   {
     "id": 1428,
     "word": "Sondermüll",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/sondermull.mp3",
     "word_type": "Nomen",
@@ -7262,6 +7710,7 @@
   {
     "id": 1446,
     "word": "Ader",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/ader.mp3",
     "word_type": "Nomen",
@@ -7277,6 +7726,7 @@
   {
     "id": 1447,
     "word": "Notausschalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/notausschalter.mp3",
     "word_type": "Nomen",
@@ -7297,6 +7747,7 @@
   {
     "id": 1449,
     "word": "Außengewindeschneider",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/auengewindeschneider.mp3",
     "word_type": "Nomen",
@@ -7312,6 +7763,7 @@
   {
     "id": 1450,
     "word": "Bohrvorrichtung",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/bohrvorrichtung.mp3",
     "word_type": "Nomen",
@@ -7327,6 +7779,7 @@
   {
     "id": 1452,
     "word": "Federscheibe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/federscheibe.mp3",
     "word_type": "Nomen",
@@ -7342,6 +7795,7 @@
   {
     "id": 1453,
     "word": "Flügelmutter",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/flugelmutter.mp3",
     "word_type": "Nomen",
@@ -7357,6 +7811,7 @@
   {
     "id": 1454,
     "word": "Handbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/handbohrer.mp3",
     "word_type": "Nomen",
@@ -7372,6 +7827,7 @@
   {
     "id": 1455,
     "word": "Kegelreibahle",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kegelreibahle.mp3",
     "word_type": "Nomen",
@@ -7387,6 +7843,7 @@
   {
     "id": 1456,
     "word": "Kühlmittelflasche",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kuhlmittelflasche.mp3",
     "word_type": "Nomen",
@@ -7402,6 +7859,7 @@
   {
     "id": 1457,
     "word": "Manometer",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/manometer.mp3",
     "word_type": "Nomen",
@@ -7417,6 +7875,7 @@
   {
     "id": 1458,
     "word": "Maschinengewindebohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/maschinengewindebohrer.mp3",
     "word_type": "Nomen",
@@ -7432,6 +7891,7 @@
   {
     "id": 1459,
     "word": "Ölkanne",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/olkanne.mp3",
     "word_type": "Nomen",
@@ -7452,6 +7912,7 @@
   {
     "id": 1460,
     "word": "Radius",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/radius.mp3",
     "word_type": "Nomen",
@@ -7467,6 +7928,7 @@
   {
     "id": 1461,
     "word": "Rändelschraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/randelschraube.mp3",
     "word_type": "Nomen",
@@ -7482,6 +7944,7 @@
   {
     "id": 1463,
     "word": "Spax-Schraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spax-schraube.mp3",
     "word_type": "Nomen",
@@ -7506,6 +7969,7 @@
   {
     "id": 1464,
     "word": "Unterlegscheibe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/unterlegscheibe.mp3",
     "word_type": "Nomen",
@@ -7521,6 +7985,7 @@
   {
     "id": 1465,
     "word": "Zylinderkopfschraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/zylinderkopfschraube.mp3",
     "word_type": "Nomen",
@@ -7536,6 +8001,7 @@
   {
     "id": 1466,
     "word": "CNC-Fräsmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/cnc-frasmaschine.mp3",
     "word_type": "Nomen",
@@ -7551,6 +8017,7 @@
   {
     "id": 1467,
     "word": "Eckmesserkopf",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/eckmesserkopf.mp3",
     "word_type": "Nomen",
@@ -7566,6 +8033,7 @@
   {
     "id": 1468,
     "word": "Einstellring",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/einstellring.mp3",
     "word_type": "Nomen",
@@ -7581,6 +8049,7 @@
   {
     "id": 1469,
     "word": "Formfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/formfraser.mp3",
     "word_type": "Nomen",
@@ -7596,6 +8065,7 @@
   {
     "id": 1470,
     "word": "Grenzrachenlehre",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/grenzrachenlehre.mp3",
     "word_type": "Nomen",
@@ -7611,6 +8081,7 @@
   {
     "id": 1471,
     "word": "Kantentaster",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kantentaster.mp3",
     "word_type": "Nomen",
@@ -7626,6 +8097,7 @@
   {
     "id": 1472,
     "word": "Messerkopf",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/messerkopf.mp3",
     "word_type": "Nomen",
@@ -7641,6 +8113,7 @@
   {
     "id": 1473,
     "word": "Messuhr",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/messuhr.mp3",
     "word_type": "Nomen",
@@ -7656,6 +8129,7 @@
   {
     "id": 1474,
     "word": "Radienfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/radienfraser.mp3",
     "word_type": "Nomen",
@@ -7671,6 +8145,7 @@
   {
     "id": 1475,
     "word": "Satzfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/satzfraser.mp3",
     "word_type": "Nomen",
@@ -7686,6 +8161,7 @@
   {
     "id": 1476,
     "word": "Schaftfräser mit Radius",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schaftfraser-mit-radius.mp3",
     "word_type": "Nomen",
@@ -7701,6 +8177,7 @@
   {
     "id": 1477,
     "word": "T-Nutenfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/t-nutenfraser.mp3",
     "word_type": "Nomen",
@@ -7716,6 +8193,7 @@
   {
     "id": 1478,
     "word": "T-Nutenstein",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/t-nutenstein.mp3",
     "word_type": "Nomen",
@@ -7731,6 +8209,7 @@
   {
     "id": 1479,
     "word": "Trapezantriebsspindel",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/trapezantriebsspindel.mp3",
     "word_type": "Nomen",
@@ -7746,6 +8225,7 @@
   {
     "id": 1480,
     "word": "Universaltaster",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/universaltaster.mp3",
     "word_type": "Nomen",
@@ -7761,6 +8241,7 @@
   {
     "id": 1481,
     "word": "Walzenfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/walzenfraser.mp3",
     "word_type": "Nomen",
@@ -7776,6 +8257,7 @@
   {
     "id": 1482,
     "word": "Zahnradfräser",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/zahnradfraser.mp3",
     "word_type": "Nomen",
@@ -7791,6 +8273,7 @@
   {
     "id": 1483,
     "word": "Abstechdrehmeißel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/abstechdrehmeiel.mp3",
     "word_type": "Nomen",
@@ -7806,6 +8289,7 @@
   {
     "id": 1485,
     "word": "Bitsatz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bitsatz.mp3",
     "word_type": "Nomen",
@@ -7821,6 +8305,7 @@
   {
     "id": 1487,
     "word": "Bolzenschneider",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bolzenschneider.mp3",
     "word_type": "Nomen",
@@ -7836,6 +8321,7 @@
   {
     "id": 1488,
     "word": "Bügelprisma",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/bugelprisma.mp3",
     "word_type": "Nomen",
@@ -7851,6 +8337,7 @@
   {
     "id": 1489,
     "word": "Doppelkörner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/doppelkorner.mp3",
     "word_type": "Nomen",
@@ -7866,6 +8353,7 @@
   {
     "id": 1491,
     "word": "Druckluftpistole",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/druckluftpistole.mp3",
     "word_type": "Nomen",
@@ -7881,6 +8369,7 @@
   {
     "id": 1493,
     "word": "Einstechdrehmeißel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/einstechdrehmeiel.mp3",
     "word_type": "Nomen",
@@ -7896,6 +8385,7 @@
   {
     "id": 1494,
     "word": "Gegenschlag",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gegenschlag.mp3",
     "word_type": "Nomen",
@@ -7911,6 +8401,7 @@
   {
     "id": 1495,
     "word": "Gewindestange",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/gewindestange.mp3",
     "word_type": "Nomen",
@@ -7926,6 +8417,7 @@
   {
     "id": 1496,
     "word": "Gewindestift",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/gewindestift.mp3",
     "word_type": "Nomen",
@@ -7941,6 +8433,7 @@
   {
     "id": 1501,
     "word": "Innendrehmeißel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/innendrehmeiel.mp3",
     "word_type": "Nomen",
@@ -7956,6 +8449,7 @@
   {
     "id": 1502,
     "word": "Inbus mit Griff",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/inbus-mit-griff.mp3",
     "word_type": "Nomen",
@@ -7984,6 +8478,7 @@
   {
     "id": 1503,
     "word": "Inbussatz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/inbussatz.mp3",
     "word_type": "Nomen",
@@ -8012,6 +8507,7 @@
   {
     "id": 1504,
     "word": "Klebekerze",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/klebekerze.mp3",
     "word_type": "Nomen",
@@ -8032,6 +8528,7 @@
   {
     "id": 1505,
     "word": "Körnerplatte",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kornerplatte.mp3",
     "word_type": "Nomen",
@@ -8047,6 +8544,7 @@
   {
     "id": 1506,
     "word": "Kugellager",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/kugellager.mp3",
     "word_type": "Nomen",
@@ -8062,6 +8560,7 @@
   {
     "id": 1507,
     "word": "Kraftmessdose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kraftmessdose.mp3",
     "word_type": "Nomen",
@@ -8082,6 +8581,7 @@
   {
     "id": 1509,
     "word": "Akku-Ladestation",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/akku-ladestation.mp3",
     "word_type": "Nomen",
@@ -8102,6 +8602,7 @@
   {
     "id": 1510,
     "word": "Lastenkran",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/lastenkran.mp3",
     "word_type": "Nomen",
@@ -8117,6 +8618,7 @@
   {
     "id": 1511,
     "word": "mitlaufende Spitze",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/mitlaufende-spitze.mp3",
     "word_type": "Nomen",
@@ -8132,6 +8634,7 @@
   {
     "id": 1512,
     "word": "O-Ring",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/o-ring.mp3",
     "word_type": "Nomen",
@@ -8147,6 +8650,7 @@
   {
     "id": 1513,
     "word": "Passstift",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/passstift.mp3",
     "word_type": "Nomen",
@@ -8162,6 +8666,7 @@
   {
     "id": 1514,
     "word": "Poliervlies",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/poliervlies.mp3",
     "word_type": "Nomen",
@@ -8177,6 +8682,7 @@
   {
     "id": 1515,
     "word": "Prisma",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/prisma.mp3",
     "word_type": "Nomen",
@@ -8192,6 +8698,7 @@
   {
     "id": 1517,
     "word": "Reduzieröse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/reduzierose.mp3",
     "word_type": "Nomen",
@@ -8207,6 +8714,7 @@
   {
     "id": 1518,
     "word": "Richtbank",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/richtbank.mp3",
     "word_type": "Nomen",
@@ -8222,6 +8730,7 @@
   {
     "id": 1519,
     "word": "Rohrschere",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/rohrschere.mp3",
     "word_type": "Nomen",
@@ -8237,6 +8746,7 @@
   {
     "id": 1520,
     "word": "Säulenbohrmaschine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/saulenbohrmaschine.mp3",
     "word_type": "Nomen",
@@ -8252,6 +8762,7 @@
   {
     "id": 1521,
     "word": "Schlauchschere",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schlauchschere.mp3",
     "word_type": "Nomen",
@@ -8267,6 +8778,7 @@
   {
     "id": 1522,
     "word": "Schleifpapierhalter",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schleifpapierhalter.mp3",
     "word_type": "Nomen",
@@ -8282,6 +8794,7 @@
   {
     "id": 1523,
     "word": "Schnellspanner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schnellspanner.mp3",
     "word_type": "Nomen",
@@ -8297,6 +8810,7 @@
   {
     "id": 1525,
     "word": "Schweißerkabine",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schweierkabine.mp3",
     "word_type": "Nomen",
@@ -8312,6 +8826,7 @@
   {
     "id": 1526,
     "word": "Sicherungsring",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/sicherungsring.mp3",
     "word_type": "Nomen",
@@ -8327,6 +8842,7 @@
   {
     "id": 1527,
     "word": "Spannfeder",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spannfeder.mp3",
     "word_type": "Nomen",
@@ -8347,6 +8863,7 @@
   {
     "id": 1528,
     "word": "Spannfutter",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/spannfutter.mp3",
     "word_type": "Nomen",
@@ -8362,6 +8879,7 @@
   {
     "id": 1529,
     "word": "Spannhülse",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spannhulse.mp3",
     "word_type": "Nomen",
@@ -8377,6 +8895,7 @@
   {
     "id": 1530,
     "word": "Spanntreppe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spanntreppe.mp3",
     "word_type": "Nomen",
@@ -8392,6 +8911,7 @@
   {
     "id": 1531,
     "word": "Tafelschere",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/tafelschere.mp3",
     "word_type": "Nomen",
@@ -8407,6 +8927,7 @@
   {
     "id": 1532,
     "word": "Tiefenmaßstab",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/tiefenmastab.mp3",
     "word_type": "Nomen",
@@ -8422,6 +8943,7 @@
   {
     "id": 1533,
     "word": "Trennstemmer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/trennstemmer.mp3",
     "word_type": "Nomen",
@@ -8437,6 +8959,7 @@
   {
     "id": 1534,
     "word": "Werkzeugwagen",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/werkzeugwagen.mp3",
     "word_type": "Nomen",
@@ -8452,6 +8975,7 @@
   {
     "id": 1536,
     "word": "Austreiber",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/austreiber.mp3",
     "word_type": "Nomen",
@@ -8467,6 +8991,7 @@
   {
     "id": 1537,
     "word": "Feilenbürste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/feilenburste.mp3",
     "word_type": "Nomen",
@@ -8482,6 +9007,7 @@
   {
     "id": 1538,
     "word": "Flachspanner",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/flachspanner.mp3",
     "word_type": "Nomen",
@@ -8497,6 +9023,7 @@
   {
     "id": 1539,
     "word": "Haarwinkel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/haarwinkel.mp3",
     "word_type": "Nomen",
@@ -8512,6 +9039,7 @@
   {
     "id": 1540,
     "word": "Schlichtfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schlichtfeile.mp3",
     "word_type": "Nomen",
@@ -8527,6 +9055,7 @@
   {
     "id": 1541,
     "word": "Schlosserfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schlosserfeile.mp3",
     "word_type": "Nomen",
@@ -8542,6 +9071,7 @@
   {
     "id": 1542,
     "word": "Senkkopfschraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/senkkopfschraube.mp3",
     "word_type": "Nomen",
@@ -8557,6 +9087,7 @@
   {
     "id": 1543,
     "word": "Schruppfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schruppfeile.mp3",
     "word_type": "Nomen",
@@ -8572,6 +9103,7 @@
   {
     "id": 1544,
     "word": "Spannpratze",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/spannpratze.mp3",
     "word_type": "Nomen",
@@ -8587,6 +9119,7 @@
   {
     "id": 1545,
     "word": "Stahlmaßstab",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/stahlmastab.mp3",
     "word_type": "Nomen",
@@ -8602,6 +9135,7 @@
   {
     "id": 1546,
     "word": "Vierkantfeile",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/vierkantfeile.mp3",
     "word_type": "Nomen",
@@ -8617,6 +9151,7 @@
   {
     "id": 1547,
     "word": "Werkbank",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/werkbank.mp3",
     "word_type": "Nomen",
@@ -8632,6 +9167,7 @@
   {
     "id": 1555,
     "word": "Kreide",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/kreide.mp3",
     "word_type": "Nomen",
@@ -8647,6 +9183,7 @@
   {
     "id": 1556,
     "word": "Pinsel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/pinsel.mp3",
     "word_type": "Nomen",
@@ -8662,6 +9199,7 @@
   {
     "id": 1557,
     "word": "Schäferkiste",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schaferkiste.mp3",
     "word_type": "Nomen",
@@ -8677,6 +9215,7 @@
   {
     "id": 1558,
     "word": "Spiritus",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/spiritus.mp3",
     "word_type": "Nomen",
@@ -8692,6 +9231,7 @@
   {
     "id": 1559,
     "word": "Sprühreiniger",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/spruhreiniger.mp3",
     "word_type": "Nomen",
@@ -8707,6 +9247,7 @@
   {
     "id": 1573,
     "word": "Sechskantschraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/sechskantschraube.mp3",
     "word_type": "Nomen",
@@ -8722,6 +9263,7 @@
   {
     "id": 1594,
     "word": "Heftklammern",
+    "article": 4,
     "singular_article": 4,
     "audio": "http://testserver/media/audio/heftklammern.mp3",
     "word_type": "Nomen",
@@ -8737,6 +9279,7 @@
   {
     "id": 1596,
     "word": "Stempel",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/stempel.mp3",
     "word_type": "Nomen",
@@ -8752,6 +9295,7 @@
   {
     "id": 1599,
     "word": "Stempelkissen",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/stempelkissen.mp3",
     "word_type": "Nomen",
@@ -8767,6 +9311,7 @@
   {
     "id": 1623,
     "word": "Dose",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/dose.mp3",
     "word_type": "Nomen",
@@ -8782,6 +9327,7 @@
   {
     "id": 1684,
     "word": "Brandmelder",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/brandmelder.mp3",
     "word_type": "Nomen",
@@ -8797,6 +9343,7 @@
   {
     "id": 1685,
     "word": "Kapselgehörschutz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/kapselgehorschutz.mp3",
     "word_type": "Nomen",
@@ -8812,6 +9359,7 @@
   {
     "id": 1707,
     "word": "Werkzeugkoffer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/werkzeugkoffer.mp3",
     "word_type": "Nomen",
@@ -8827,6 +9375,7 @@
   {
     "id": 1799,
     "word": "Feder",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/feder.mp3",
     "word_type": "Nomen",
@@ -8842,6 +9391,7 @@
   {
     "id": 1852,
     "word": "Mundschutz",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/mundschutz.mp3",
     "word_type": "Nomen",
@@ -8857,6 +9407,7 @@
   {
     "id": 1857,
     "word": "Schleifset",
+    "article": 3,
     "singular_article": 3,
     "audio": "http://testserver/media/audio/schleifset.mp3",
     "word_type": "Nomen",
@@ -8872,6 +9423,7 @@
   {
     "id": 1864,
     "word": "Bandschleifer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/bandschleifer.mp3",
     "word_type": "Nomen",
@@ -8887,6 +9439,7 @@
   {
     "id": 1874,
     "word": "Schleifscheibe",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schleifscheibe.mp3",
     "word_type": "Nomen",
@@ -8902,6 +9455,7 @@
   {
     "id": 1875,
     "word": "Steinbohrer",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/steinbohrer.mp3",
     "word_type": "Nomen",
@@ -8917,6 +9471,7 @@
   {
     "id": 1888,
     "word": "Schleifblock",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/schleifblock.mp3",
     "word_type": "Nomen",
@@ -8932,6 +9487,7 @@
   {
     "id": 1896,
     "word": "D3-Leim",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/d3-leim.mp3",
     "word_type": "Nomen",
@@ -8947,6 +9503,7 @@
   {
     "id": 1897,
     "word": "Einschraubhaken",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/einschraubhaken.mp3",
     "word_type": "Nomen",
@@ -8962,6 +9519,7 @@
   {
     "id": 1900,
     "word": "Schlossschraube",
+    "article": 2,
     "singular_article": 2,
     "audio": "http://testserver/media/audio/schlossschraube.mp3",
     "word_type": "Nomen",
@@ -8977,6 +9535,7 @@
   {
     "id": 1973,
     "word": "Textmarker",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/textmarker.mp3",
     "word_type": "Nomen",
@@ -8992,6 +9551,7 @@
   {
     "id": 2139,
     "word": "Arbeitsschuh",
+    "article": 1,
     "singular_article": 1,
     "audio": "http://testserver/media/audio/arbeitsschuh.mp3",
     "word_type": "Nomen",

--- a/tests/api/expected-results/words_170.json
+++ b/tests/api/expected-results/words_170.json
@@ -1,6 +1,7 @@
 {
   "id": 170,
   "word": "Auto",
+  "article": 3,
   "singular_article": 3,
   "audio": "http://testserver/media/audio/auto.mp3",
   "word_type": "Nomen",

--- a/tests/api/expected-results/words_2.json
+++ b/tests/api/expected-results/words_2.json
@@ -1,6 +1,7 @@
 {
   "id": 2,
   "word": "Schere",
+  "article": 2,
   "singular_article": 2,
   "audio": "http://testserver/media/audio/schere.mp3",
   "word_type": "Nomen",

--- a/tests/api/expected-results/words_by_key.json
+++ b/tests/api/expected-results/words_by_key.json
@@ -1,10992 +1,9572 @@
 [
   {
-      "id": 2,
-      "word": "Schere",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schere.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 2,
-              "image": "http://testserver/media/images/schere.jpg"
-          }
-      ],
-      "example_sentence": "Die Schnur mit einer Schere zerschneiden."
-  },
-  {
-      "id": 3,
-      "word": "Schlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 3,
-              "image": "http://testserver/media/images/schlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 4,
-      "word": "Buch",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/buch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 4,
-              "image": "http://testserver/media/images/buch.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 6,
-      "word": "Akkuschrauber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/akkuschrauber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 6,
-              "image": "http://testserver/media/images/akkuschrauber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 7,
-      "word": "Bohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Metallbohrer",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 7,
-              "image": "http://testserver/media/images/bohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 8,
-      "word": "Bohrmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bohrmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Handbohrmaschine",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 746,
-              "image": "http://testserver/media/images/bohrmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 9,
-      "word": "Dübel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/dubel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 9,
-              "image": "http://testserver/media/images/dubel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 10,
-      "word": "Feile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/feile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 10,
-              "image": "http://testserver/media/images/feile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 11,
-      "word": "Gerüst",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/gerust.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 11,
-              "image": "http://testserver/media/images/gerust.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 12,
-      "word": "Leiter",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/leiter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1274,
-              "image": "http://testserver/media/images/leiter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 13,
-      "word": "Maßband",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/maband.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 290,
-              "image": "http://testserver/media/images/maband.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 14,
-      "word": "Meißel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/meiel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 291,
-              "image": "http://testserver/media/images/meiel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 15,
-      "word": "Messer",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/messer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 513,
-              "image": "http://testserver/media/images/messer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 16,
-      "word": "Schubkarre",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schubkarre.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Schubkarren",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 16,
-              "image": "http://testserver/media/images/schubkarre.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 17,
-      "word": "Zollstock",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zollstock.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Meterstab",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Gliedermaßstab",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 828,
-              "image": "http://testserver/media/images/zollstock.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 18,
-      "word": "Arbeitshandschuh",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/arbeitshandschuh.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Handschuh",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 317,
-              "image": "http://testserver/media/images/arbeitshandschuh.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 20,
-      "word": "Besen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/besen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 20,
-              "image": "http://testserver/media/images/besen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 21,
-      "word": "Eimer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/eimer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 21,
-              "image": "http://testserver/media/images/eimer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 22,
-      "word": "Gehörschutz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gehorschutz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1272,
-              "image": "http://testserver/media/images/gehorschutz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 23,
-      "word": "Hammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/hammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 23,
-              "image": "http://testserver/media/images/hammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 24,
-      "word": "Kabeltrommel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kabeltrommel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 237,
-              "image": "http://testserver/media/images/kabeltrommel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 25,
-      "word": "Klebeband",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/klebeband.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 287,
-              "image": "http://testserver/media/images/klebeband.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 26,
-      "word": "Schraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 299,
-              "image": "http://testserver/media/images/schraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 27,
-      "word": "Schraubenzieher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schraubenzieher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Schraubendreher",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 27,
-              "image": "http://testserver/media/images/schraubenzieher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 28,
-      "word": "Schraubenschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schraubenschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Ring-Maulschlüssel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1423,
-              "image": "http://testserver/media/images/schraubenschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 29,
-      "word": "Schutzbrille",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schutzbrille.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Sicherheitsbrille",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 29,
-              "image": "http://testserver/media/images/schutzbrille.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 30,
-      "word": "Schutzhelm",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schutzhelm.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 30,
-              "image": "http://testserver/media/images/schutzhelm.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 31,
-      "word": "Staubsauger",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/staubsauger.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 31,
-              "image": "http://testserver/media/images/staubsauger.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 32,
-      "word": "Wasserwaage",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/wasserwaage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 32,
-              "image": "http://testserver/media/images/wasserwaage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 33,
-      "word": "Abisolierzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/abisolierzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 807,
-              "image": "http://testserver/media/images/abisolierzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 34,
-      "word": "Bohrkrone",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bohrkrone.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 34,
-              "image": "http://testserver/media/images/bohrkrone.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 35,
-      "word": "Crimpzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/crimpzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Aderendhülsenzange",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 446,
-              "image": "http://testserver/media/images/crimpzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 49,
-      "word": "Gipsbecher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gipsbecher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Gipsbecher",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1612,
-              "image": "http://testserver/media/images/gipsbecher.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 66,
-      "word": "Schleifpapier",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/schleifpapier.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 70,
-              "image": "http://testserver/media/images/schleifpapier.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 116,
-      "word": "Seitenschneider",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/seitenschneider.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 121,
-              "image": "http://testserver/media/images/seitenschneider.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 117,
-      "word": "Spannungsprüfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/spannungsprufer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Duspol",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 122,
-              "image": "http://testserver/media/images/spannungsprufer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 118,
-      "word": "Steckdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/steckdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 123,
-              "image": "http://testserver/media/images/steckdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 119,
-      "word": "Badewanne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/badewanne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 124,
-              "image": "http://testserver/media/images/badewanne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 120,
-      "word": "Doppelmaulschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/doppelmaulschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Maulschlüssel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 125,
-              "image": "http://testserver/media/images/doppelmaulschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 123,
-      "word": "Toilette",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/toilette.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "WC",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 128,
-              "image": "http://testserver/media/images/toilette.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 124,
-      "word": "Waschbecken",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/waschbecken.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 607,
-              "image": "http://testserver/media/images/waschbecken.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 125,
-      "word": "Wasserhahn",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/wasserhahn.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Waschbeckenarmatur",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 130,
-              "image": "http://testserver/media/images/wasserhahn.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 126,
-      "word": "Wasserpumpenzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/wasserpumpenzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 131,
-              "image": "http://testserver/media/images/wasserpumpenzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 132,
-      "word": "Elektrohammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/elektrohammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 137,
-              "image": "http://testserver/media/images/elektrohammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 133,
-      "word": "Spachtel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/spachtel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Spachtel",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Spachtel",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 138,
-              "image": "http://testserver/media/images/spachtel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 135,
-      "word": "Antennendose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/antennendose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 140,
-              "image": "http://testserver/media/images/antennendose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 136,
-      "word": "Kreuzerder",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kreuzerder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 141,
-              "image": "http://testserver/media/images/kreuzerder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 139,
-      "word": "Leuchtmittel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/leuchtmittel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Glühbirne",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 144,
-              "image": "http://testserver/media/images/leuchtmittel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 140,
-      "word": "Arbeitskleidung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/arbeitskleidung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 145,
-              "image": "http://testserver/media/images/arbeitskleidung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 141,
-      "word": "Putzlappen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/putzlappen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Lappen",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Reinigungstuch",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 288,
-              "image": "http://testserver/media/images/putzlappen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 142,
-      "word": "Mülleimer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/mulleimer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Papierkorb",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 255,
-              "image": "http://testserver/media/images/mulleimer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 143,
-      "word": "Bleistift",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bleistift.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 149,
-              "image": "http://testserver/media/images/bleistift.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 144,
-      "word": "Zimmermannsbleistift",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zimmermannsbleistift.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Bleistift",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 150,
-              "image": "http://testserver/media/images/zimmermannsbleistift.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 145,
-      "word": "Werkzeugkiste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/werkzeugkiste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Werkzeugkasten",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1515,
-              "image": "http://testserver/media/images/werkzeugkiste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 146,
-      "word": "Abdeckfolie",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/abdeckfolie.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 449,
-              "image": "http://testserver/media/images/abdeckfolie.png"
-          }
-      ],
-      "example_sentence": "Die Buchsenleiste wurde mit einer Abdeckfolie abgeklebt, um das Beschlagen der Kontakte im Steckbereich während des Lötvorgangs zu vermeiden."
-  },
-  {
-      "id": 151,
-      "word": "Föhn",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/fohn.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Haartrockner",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 655,
-              "image": "http://testserver/media/images/fohn.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 156,
-      "word": "Kamm",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kamm.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 625,
-              "image": "http://testserver/media/images/kamm.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 157,
-      "word": "Spiegel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/spiegel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 164,
-              "image": "http://testserver/media/images/spiegel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 160,
-      "word": "Handbügelsäge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/handbugelsage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Säge",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 167,
-              "image": "http://testserver/media/images/handbugelsage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 161,
-      "word": "Nageleisen",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/nageleisen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Brechstange",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Kuhfuß",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Brecheisen",
-              "singular_article": 3
-          },
-          {
-              "alt_word": "Hebeleisen",
-              "singular_article": 3
-          },
-          {
-              "alt_word": "Ziegenfuß",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 168,
-              "image": "http://testserver/media/images/nageleisen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 167,
-      "word": "Winkel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/winkel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Schreinerwinkel",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Tischlerwinkel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 175,
-              "image": "http://testserver/media/images/winkel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 170,
-      "word": "Auto",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/auto.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 178,
-              "image": "http://testserver/media/images/auto.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 171,
-      "word": "Autobatterie",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/autobatterie.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Autobatterie",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 180,
-              "image": "http://testserver/media/images/autobatterie.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 173,
-      "word": "Hebebühne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/hebebuhne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 182,
-              "image": "http://testserver/media/images/hebebuhne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 175,
-      "word": "Drehmomentschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/drehmomentschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Newtonmeterschlüssel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 184,
-              "image": "http://testserver/media/images/drehmomentschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 177,
-      "word": "Motorbremse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/motorbremse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 186,
-              "image": "http://testserver/media/images/motorbremse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 178,
-      "word": "Ölkanister",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/olkanister.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 187,
-              "image": "http://testserver/media/images/olkanister.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 181,
-      "word": "Ratsche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/ratsche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Knarre",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 190,
-              "image": "http://testserver/media/images/ratsche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 182,
-      "word": "Scheibenwischer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/scheibenwischer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Scheibenwischer",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 191,
-              "image": "http://testserver/media/images/scheibenwischer.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 183,
-      "word": "Schweißgerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/schweigerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 192,
-              "image": "http://testserver/media/images/schweigerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 186,
-      "word": "Schürze",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schurze.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 195,
-              "image": "http://testserver/media/images/schurze.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 187,
-      "word": "Ofenhandschuh",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/ofenhandschuh.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 196,
-              "image": "http://testserver/media/images/ofenhandschuh.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 188,
-      "word": "Kittel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kittel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 197,
-              "image": "http://testserver/media/images/kittel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 189,
-      "word": "Backofen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/backofen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 198,
-              "image": "http://testserver/media/images/backofen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 201,
-      "word": "Cutter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/cutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Cuttermesser",
-              "singular_article": 3
-          },
-          {
-              "alt_word": "Japanmesser",
-              "singular_article": 3
-          },
-          {
-              "alt_word": "Teppichmesser",
-              "singular_article": 0
-          },
-          {
-              "alt_word": "Tapetenmesser",
-              "singular_article": 3
-          },
-          {
-              "alt_word": "Stanley-Messer",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 877,
-              "image": "http://testserver/media/images/cutter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 202,
-      "word": "Betonmischer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/betonmischer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 211,
-              "image": "http://testserver/media/images/betonmischer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 204,
-      "word": "Maurerhammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/maurerhammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 213,
-              "image": "http://testserver/media/images/maurerhammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 208,
-      "word": "Schaufel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schaufel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 217,
-              "image": "http://testserver/media/images/schaufel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 211,
-      "word": "Sackkarre",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sackkarre.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Sackkarren",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1118,
-              "image": "http://testserver/media/images/sackkarre.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 214,
-      "word": "Bügelmessschraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bugelmessschraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 223,
-              "image": "http://testserver/media/images/bugelmessschraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 215,
-      "word": "Drehwerkzeug",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/drehwerkzeug.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 224,
-              "image": "http://testserver/media/images/drehwerkzeug.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 216,
-      "word": "universelle Fräsmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/universelle-frasmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "universelle Fräse",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Universalfräsmaschine",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Universalfräse",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1093,
-              "image": "http://testserver/media/images/universelle-frasmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 217,
-      "word": "Grenzlehrdorn",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/grenzlehrdorn.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 226,
-              "image": "http://testserver/media/images/grenzlehrdorn.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 218,
-      "word": "Körner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/korner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Körner",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 227,
-              "image": "http://testserver/media/images/korner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 219,
-      "word": "Messschieber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/messschieber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 228,
-              "image": "http://testserver/media/images/messschieber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 220,
-      "word": "Schweißgeschirr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/schweigeschirr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 229,
-              "image": "http://testserver/media/images/schweigeschirr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 221,
-      "word": "Dusche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/dusche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 230,
-              "image": "http://testserver/media/images/dusche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 223,
-      "word": "Kreissäge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kreissage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 232,
-              "image": "http://testserver/media/images/kreissage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 224,
-      "word": "Nagel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/nagel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Nägel",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 233,
-              "image": "http://testserver/media/images/nagel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 225,
-      "word": "Pumpenzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/pumpenzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 234,
-              "image": "http://testserver/media/images/pumpenzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 226,
-      "word": "Stichsäge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/stichsage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 235,
-              "image": "http://testserver/media/images/stichsage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 227,
-      "word": "Zange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/zange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kneifzange",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 236,
-              "image": "http://testserver/media/images/zange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 228,
-      "word": "Akku-Winkelschleifer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/akku-winkelschleifer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Akkuflex",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 238,
-              "image": "http://testserver/media/images/akku-winkelschleifer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 231,
-      "word": "Filzstift",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/filzstift.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Edding",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1558,
-              "image": "http://testserver/media/images/filzstift.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 232,
-      "word": "Fäustel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/faustel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Fausthammer",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 242,
-              "image": "http://testserver/media/images/faustel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 237,
-      "word": "Handfeger",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handfeger.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Handbesen",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Kehrbesen",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 247,
-              "image": "http://testserver/media/images/handfeger.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 238,
-      "word": "Isolierband",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/isolierband.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Isolierbänder",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 248,
-              "image": "http://testserver/media/images/isolierband.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 260,
-      "word": "Warnweste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/warnweste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Sicherheitsweste",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 274,
-              "image": "http://testserver/media/images/warnweste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 261,
-      "word": "Arbeitshose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/arbeitshose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 275,
-              "image": "http://testserver/media/images/arbeitshose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 262,
-      "word": "Arbeitsjacke",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/arbeitsjacke.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 276,
-              "image": "http://testserver/media/images/arbeitsjacke.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 263,
-      "word": "Bohrstange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bohrstange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 278,
-              "image": "http://testserver/media/images/bohrstange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 265,
-      "word": "Flachsenker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/flachsenker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 281,
-              "image": "http://testserver/media/images/flachsenker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 266,
-      "word": "Gewindefräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gewindefraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 282,
-              "image": "http://testserver/media/images/gewindefraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 267,
-      "word": "Gewindeschneider",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gewindeschneider.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 283,
-              "image": "http://testserver/media/images/gewindeschneider.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 268,
-      "word": "Handreibahle",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/handreibahle.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Reibahle",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 284,
-              "image": "http://testserver/media/images/handreibahle.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 269,
-      "word": "Industriestaubsauger",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/industriestaubsauger.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Nass-Trockensauger",
-              "singular_article": 0
-          }
-      ],
-      "document_image": [
-          {
-              "id": 285,
-              "image": "http://testserver/media/images/industriestaubsauger.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 270,
-      "word": "Kegelsenker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kegelsenker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 286,
-              "image": "http://testserver/media/images/kegelsenker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 271,
-      "word": "Mülltonne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/mulltonne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 292,
-              "image": "http://testserver/media/images/mulltonne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 272,
-      "word": "Nutenfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/nutenfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1001,
-              "image": "http://testserver/media/images/nutenfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 274,
-      "word": "Rändel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/randel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 295,
-              "image": "http://testserver/media/images/randel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 275,
-      "word": "Rohrzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/rohrzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 296,
-              "image": "http://testserver/media/images/rohrzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 276,
-      "word": "Schaftfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schaftfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 297,
-              "image": "http://testserver/media/images/schaftfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 277,
-      "word": "Scheibenfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/scheibenfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 298,
-              "image": "http://testserver/media/images/scheibenfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 280,
-      "word": "Wendeschneidplatte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/wendeschneidplatte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 303,
-              "image": "http://testserver/media/images/wendeschneidplatte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 281,
-      "word": "Winkelfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/winkelfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1011,
-              "image": "http://testserver/media/images/winkelfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 282,
-      "word": "Zentrierbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zentrierbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 306,
-              "image": "http://testserver/media/images/zentrierbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 284,
-      "word": "zweipolige Phasenprüfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zweipolige-phasenprufer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Phasenprüfer",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 308,
-              "image": "http://testserver/media/images/zweipolige-phasenprufer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 285,
-      "word": "LAN-Tester",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/lan-tester.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "LAN Tester",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 309,
-              "image": "http://testserver/media/images/lan-tester.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 286,
-      "word": "digitale Messschieber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/digitale-messschieber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Messschieber",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 310,
-              "image": "http://testserver/media/images/digitale-messschieber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 287,
-      "word": "Gummihammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gummihammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Simplex-Gummihammer",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Plattenlegehammer",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Pflasterhammer",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 311,
-              "image": "http://testserver/media/images/gummihammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 290,
-      "word": "NC-Anbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/nc-anbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "NC Anbohrer",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 314,
-              "image": "http://testserver/media/images/nc-anbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 292,
-      "word": "Schlagbohrmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schlagbohrmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 318,
-              "image": "http://testserver/media/images/schlagbohrmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 300,
-      "word": "Kreissägeblatt",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kreissageblatt.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 328,
-              "image": "http://testserver/media/images/kreissageblatt.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 301,
-      "word": "Schlangenbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schlangenbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 329,
-              "image": "http://testserver/media/images/schlangenbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 302,
-      "word": "Langbandschleifmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/langbandschleifmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 330,
-              "image": "http://testserver/media/images/langbandschleifmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 303,
-      "word": "Schleifigel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schleifigel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 331,
-              "image": "http://testserver/media/images/schleifigel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 304,
-      "word": "Schraubstock",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schraubstock.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 332,
-              "image": "http://testserver/media/images/schraubstock.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 309,
-      "word": "Kehrblech",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kehrblech.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kehrschaufel",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 337,
-              "image": "http://testserver/media/images/kehrblech.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 311,
-      "word": "Säbelsägeblatt",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/sabelsageblatt.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 339,
-              "image": "http://testserver/media/images/sabelsageblatt.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 315,
-      "word": "Ständerbohrmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/standerbohrmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1571,
-              "image": "http://testserver/media/images/standerbohrmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 320,
-      "word": "Breitbandschleifmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/breitbandschleifmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 348,
-              "image": "http://testserver/media/images/breitbandschleifmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 322,
-      "word": "Winkelschleifer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/winkelschleifer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Flex",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1446,
-              "image": "http://testserver/media/images/winkelschleifer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 323,
-      "word": "Bithalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bithalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Bitaufnahme",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 351,
-              "image": "http://testserver/media/images/bithalter.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 324,
-      "word": "Bit",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bit.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Bit",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 352,
-              "image": "http://testserver/media/images/bit.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 335,
-      "word": "Exzenterschleifer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/exzenterschleifer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1444,
-              "image": "http://testserver/media/images/exzenterschleifer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 337,
-      "word": "Inbus",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/inbus.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Inbusschlüssel",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Innensechskantschlüssel",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Stiftschlüssel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1482,
-              "image": "http://testserver/media/images/inbus.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 343,
-      "word": "Locher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/locher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 385,
-              "image": "http://testserver/media/images/locher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 350,
-      "word": "Desinfektionsmittel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/desinfektionsmittel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Hand-Desinfektionsmittel",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1027,
-              "image": "http://testserver/media/images/desinfektionsmittel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 360,
-      "word": "Einweghandschuh",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/einweghandschuh.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Einmalhandschuh",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1213,
-              "image": "http://testserver/media/images/einweghandschuh.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 361,
-      "word": "Mund-Nase-Schutz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/mund-nase-schutz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Mund-Nase-Bedeckung",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Mundschutz",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1164,
-              "image": "http://testserver/media/images/mund-nase-schutz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 401,
-      "word": "Kabelentmantler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kabelentmantler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Abmantelwerkzeug",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 723,
-              "image": "http://testserver/media/images/kabelentmantler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 402,
-      "word": "Kabelmesser",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kabelmesser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 782,
-              "image": "http://testserver/media/images/kabelmesser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 403,
-      "word": "Kabelschere",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kabelschere.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 783,
-              "image": "http://testserver/media/images/kabelschere.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 409,
-      "word": "Gabelstapler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gabelstapler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1108,
-              "image": "http://testserver/media/images/gabelstapler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 415,
-      "word": "Ordner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/ordner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 384,
-              "image": "http://testserver/media/images/ordner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 418,
-      "word": "Tacker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/tacker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 386,
-              "image": "http://testserver/media/images/tacker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 419,
-      "word": "Telefon",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/telefon.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 383,
-              "image": "http://testserver/media/images/telefon.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 425,
-      "word": "Kugelschreiber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kugelschreiber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 379,
-              "image": "http://testserver/media/images/kugelschreiber.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 436,
-      "word": "Halbrundfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/halbrundfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1076,
-              "image": "http://testserver/media/images/halbrundfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 438,
-      "word": "Metall-Bügelsäge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/metall-bugelsage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "PUK-Säge",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 812,
-              "image": "http://testserver/media/images/metall-bugelsage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 441,
-      "word": "Rundfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/rundfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1077,
-              "image": "http://testserver/media/images/rundfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 473,
-      "word": "Dreikantfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/dreikantfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1072,
-              "image": "http://testserver/media/images/dreikantfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 474,
-      "word": "Flachstumpffeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/flachstumpffeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1586,
-              "image": "http://testserver/media/images/flachstumpffeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 476,
-      "word": "Kombinationszange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kombinationszange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kombizange",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 441,
-              "image": "http://testserver/media/images/kombinationszange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 477,
-      "word": "Kraft-Seitenschneider",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kraft-seitenschneider.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 785,
-              "image": "http://testserver/media/images/kraft-seitenschneider.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 484,
-      "word": "Schlosserhammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schlosserhammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 814,
-              "image": "http://testserver/media/images/schlosserhammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 495,
-      "word": "Handhubwagen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handhubwagen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Hubwagen",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1111,
-              "image": "http://testserver/media/images/handhubwagen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 499,
-      "word": "Hochregallager",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/hochregallager.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1124,
-              "image": "http://testserver/media/images/hochregallager.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 500,
-      "word": "Verladerampe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/verladerampe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1130,
-              "image": "http://testserver/media/images/verladerampe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 502,
-      "word": "Kleinteilelager",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kleinteilelager.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1125,
-              "image": "http://testserver/media/images/kleinteilelager.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 508,
-      "word": "Schwamm",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schwamm.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 800,
-              "image": "http://testserver/media/images/schwamm.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 509,
-      "word": "Spülmittel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/spulmittel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1209,
-              "image": "http://testserver/media/images/spulmittel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 510,
-      "word": "Küchentuch",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kuchentuch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1224,
-              "image": "http://testserver/media/images/kuchentuch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 511,
-      "word": "Geschirrtuch",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/geschirrtuch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Geschirrtücher",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 529,
-              "image": "http://testserver/media/images/geschirrtuch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 512,
-      "word": "Spülbürste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spulburste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1211,
-              "image": "http://testserver/media/images/spulburste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 513,
-      "word": "Spülbecken",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/spulbecken.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1212,
-              "image": "http://testserver/media/images/spulbecken.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 514,
-      "word": "Elektroherd",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/elektroherd.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Herd",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1287,
-              "image": "http://testserver/media/images/elektroherd.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 515,
-      "word": "Herdplatte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/herdplatte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1288,
-              "image": "http://testserver/media/images/herdplatte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 516,
-      "word": "Suppe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/suppe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 668,
-              "image": "http://testserver/media/images/suppe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 518,
-      "word": "Butter",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/butter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 678,
-              "image": "http://testserver/media/images/butter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 522,
-      "word": "Schüssel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 510,
-              "image": "http://testserver/media/images/schussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 523,
-      "word": "Sieb",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/sieb.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 526,
-              "image": "http://testserver/media/images/sieb.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 524,
-      "word": "Topf",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/topf.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 797,
-              "image": "http://testserver/media/images/topf.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 525,
-      "word": "Pfanne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/pfanne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 537,
-              "image": "http://testserver/media/images/pfanne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 528,
-      "word": "Platte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/platte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1308,
-              "image": "http://testserver/media/images/platte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 529,
-      "word": "Salatbesteck",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/salatbesteck.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1281,
-              "image": "http://testserver/media/images/salatbesteck.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 530,
-      "word": "Schale",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schale.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1289,
-              "image": "http://testserver/media/images/schale.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 531,
-      "word": "Flaschenöffner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/flaschenoffner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1282,
-              "image": "http://testserver/media/images/flaschenoffner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 532,
-      "word": "Besteck",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/besteck.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 402,
-              "image": "http://testserver/media/images/besteck.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 533,
-      "word": "Löffel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/loffel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 403,
-              "image": "http://testserver/media/images/loffel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 534,
-      "word": "Gabel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/gabel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 404,
-              "image": "http://testserver/media/images/gabel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 535,
-      "word": "Geschirr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/geschirr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 405,
-              "image": "http://testserver/media/images/geschirr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 536,
-      "word": "Tasse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/tasse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 471,
-              "image": "http://testserver/media/images/tasse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 537,
-      "word": "Teller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/teller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 407,
-              "image": "http://testserver/media/images/teller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 538,
-      "word": "Gedeck",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/gedeck.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1611,
-              "image": "http://testserver/media/images/gedeck.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 539,
-      "word": "Unterteller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/unterteller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Untertasse",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 520,
-              "image": "http://testserver/media/images/unterteller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 540,
-      "word": "Flasche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/flasche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 685,
-              "image": "http://testserver/media/images/flasche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 541,
-      "word": "Glas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/glas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 485,
-              "image": "http://testserver/media/images/glas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 542,
-      "word": "Bierglas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bierglas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1596,
-              "image": "http://testserver/media/images/bierglas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 543,
-      "word": "Weinglas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/weinglas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 521,
-              "image": "http://testserver/media/images/weinglas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 544,
-      "word": "Sektglas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/sektglas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 516,
-              "image": "http://testserver/media/images/sektglas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 545,
-      "word": "Schnapsglas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/schnapsglas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 713,
-              "image": "http://testserver/media/images/schnapsglas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 546,
-      "word": "Eierbecher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/eierbecher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 875,
-              "image": "http://testserver/media/images/eierbecher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 547,
-      "word": "Kanne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kanne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1310,
-              "image": "http://testserver/media/images/kanne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 548,
-      "word": "Krug",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/krug.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Karaffe",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 509,
-              "image": "http://testserver/media/images/krug.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 549,
-      "word": "Serviette",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/serviette.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 514,
-              "image": "http://testserver/media/images/serviette.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 553,
-      "word": "Gewindebohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gewindebohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 978,
-              "image": "http://testserver/media/images/gewindebohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 559,
-      "word": "Kreisschneider",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kreisschneider.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1039,
-              "image": "http://testserver/media/images/kreisschneider.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 567,
-      "word": "Spiralbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/spiralbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1587,
-              "image": "http://testserver/media/images/spiralbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 568,
-      "word": "Walzenstirnfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/walzenstirnfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1010,
-              "image": "http://testserver/media/images/walzenstirnfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 589,
-      "word": "Auflaufform",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/auflaufform.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 494,
-              "image": "http://testserver/media/images/auflaufform.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 595,
-      "word": "Tischdecke",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/tischdecke.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1295,
-              "image": "http://testserver/media/images/tischdecke.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 596,
-      "word": "Vase",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/vase.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1249,
-              "image": "http://testserver/media/images/vase.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 599,
-      "word": "Backblech",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/backblech.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 496,
-              "image": "http://testserver/media/images/backblech.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 613,
-      "word": "Schneebesen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schneebesen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Schaumschläger",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 463,
-              "image": "http://testserver/media/images/schneebesen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 617,
-      "word": "Teigschaber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/teigschaber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 454,
-              "image": "http://testserver/media/images/teigschaber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 636,
-      "word": "Butterdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/butterdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1290,
-              "image": "http://testserver/media/images/butterdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 638,
-      "word": "Zuckerspender",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zuckerspender.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 522,
-              "image": "http://testserver/media/images/zuckerspender.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 641,
-      "word": "GN-Behälter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gn-behalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 410,
-              "image": "http://testserver/media/images/gn-behalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 646,
-      "word": "Teeglas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/teeglas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 414,
-              "image": "http://testserver/media/images/teeglas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 649,
-      "word": "Dosenöffner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/dosenoffner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 457,
-              "image": "http://testserver/media/images/dosenoffner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 651,
-      "word": "Pinsel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/pinsel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 719,
-              "image": "http://testserver/media/images/pinsel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 654,
-      "word": "Backpapier",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/backpapier.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 466,
-              "image": "http://testserver/media/images/backpapier.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 656,
-      "word": "Dunstabzugshaube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/dunstabzugshaube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Abzugshaube",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 493,
-              "image": "http://testserver/media/images/dunstabzugshaube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 667,
-      "word": "Kaffeemaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kaffeemaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kaffeebereiter",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 503,
-              "image": "http://testserver/media/images/kaffeemaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 668,
-      "word": "Kühlschrank",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kuhlschrank.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 535,
-              "image": "http://testserver/media/images/kuhlschrank.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 670,
-      "word": "Thermoskanne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/thermoskanne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 544,
-              "image": "http://testserver/media/images/thermoskanne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 671,
-      "word": "Omelett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/omelett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 666,
-              "image": "http://testserver/media/images/omelett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 673,
-      "word": "Spiegelei",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/spiegelei.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 667,
-              "image": "http://testserver/media/images/spiegelei.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 674,
-      "word": "Haferflocken",
-      "singular_article": 4,
-      "audio": "http://testserver/media/audio/haferflocken.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 664,
-              "image": "http://testserver/media/images/haferflocken.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 675,
-      "word": "Rotwein",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/rotwein.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 675,
-              "image": "http://testserver/media/images/rotwein.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 676,
-      "word": "Weißwein",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/weiwein.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 677,
-              "image": "http://testserver/media/images/weiwein.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 678,
-      "word": "Bier",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bier.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 670,
-              "image": "http://testserver/media/images/bier.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 679,
-      "word": "Eistee",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/eistee.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 671,
-              "image": "http://testserver/media/images/eistee.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 680,
-      "word": "Saft",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/saft.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 676,
-              "image": "http://testserver/media/images/saft.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 681,
-      "word": "Eiswürfel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/eiswurfel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 672,
-              "image": "http://testserver/media/images/eiswurfel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 682,
-      "word": "Honig",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/honig.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 679,
-              "image": "http://testserver/media/images/honig.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 683,
-      "word": "Marmelade",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/marmelade.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 681,
-              "image": "http://testserver/media/images/marmelade.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 685,
-      "word": "Tee",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/tee.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 682,
-              "image": "http://testserver/media/images/tee.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 686,
-      "word": "Teebeutel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/teebeutel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 683,
-              "image": "http://testserver/media/images/teebeutel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 687,
-      "word": "Kaffee",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kaffee.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 680,
-              "image": "http://testserver/media/images/kaffee.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 688,
-      "word": "Kaffeefilter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kaffeefilter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 504,
-              "image": "http://testserver/media/images/kaffeefilter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 689,
-      "word": "Milch",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/milch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 674,
-              "image": "http://testserver/media/images/milch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 691,
-      "word": "Öl",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/ol.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 673,
-              "image": "http://testserver/media/images/ol.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 692,
-      "word": "Müsli",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/musli.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 665,
-              "image": "http://testserver/media/images/musli.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 693,
-      "word": "Zahnstocher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zahnstocher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1390,
-              "image": "http://testserver/media/images/zahnstocher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 698,
-      "word": "Korkenzieher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/korkenzieher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 798,
-              "image": "http://testserver/media/images/korkenzieher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 700,
-      "word": "Chafing-Dish",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/chafing-dish.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 499,
-              "image": "http://testserver/media/images/chafing-dish.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 701,
-      "word": "Cocktailglas",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/cocktailglas.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 500,
-              "image": "http://testserver/media/images/cocktailglas.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 702,
-      "word": "Espressotasse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/espressotasse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 501,
-              "image": "http://testserver/media/images/espressotasse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 703,
-      "word": "Kaffeelöffel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kaffeeloffel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 505,
-              "image": "http://testserver/media/images/kaffeeloffel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 704,
-      "word": "Kuchengabel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kuchengabel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 511,
-              "image": "http://testserver/media/images/kuchengabel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 705,
-      "word": "Kaffeeportionierer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kaffeeportionierer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 506,
-              "image": "http://testserver/media/images/kaffeeportionierer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 706,
-      "word": "Kuchenteller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kuchenteller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 832,
-              "image": "http://testserver/media/images/kuchenteller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 707,
-      "word": "Schieferplatte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schieferplatte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Schieferplatten",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 515,
-              "image": "http://testserver/media/images/schieferplatte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 709,
-      "word": "Suppenteller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/suppenteller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 518,
-              "image": "http://testserver/media/images/suppenteller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 710,
-      "word": "Kaffeetasse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kaffeetasse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 507,
-              "image": "http://testserver/media/images/kaffeetasse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 713,
-      "word": "Bodenwischgerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bodenwischgerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1854,
-              "image": "http://testserver/media/images/bodenwischgerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 714,
-      "word": "Papierhandtuch",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/papierhandtuch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 583,
-              "image": "http://testserver/media/images/papierhandtuch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 715,
-      "word": "Papierhandtuchspender",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/papierhandtuchspender.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 584,
-              "image": "http://testserver/media/images/papierhandtuchspender.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 716,
-      "word": "Reinigungsbürste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/reinigungsburste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 801,
-              "image": "http://testserver/media/images/reinigungsburste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 717,
-      "word": "Reinigungshandschuh",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/reinigungshandschuh.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Spülhandschuh",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1240,
-              "image": "http://testserver/media/images/reinigungshandschuh.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 718,
-      "word": "Reinigungsmittel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/reinigungsmittel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1214,
-              "image": "http://testserver/media/images/reinigungsmittel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 719,
-      "word": "Reinigungswagen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/reinigungswagen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1263,
-              "image": "http://testserver/media/images/reinigungswagen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 720,
-      "word": "Seifenspender",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/seifenspender.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 587,
-              "image": "http://testserver/media/images/seifenspender.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 721,
-      "word": "Sprühflasche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spruhflasche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 650,
-              "image": "http://testserver/media/images/spruhflasche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 723,
-      "word": "Staubsaugerbeutel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/staubsaugerbeutel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1219,
-              "image": "http://testserver/media/images/staubsaugerbeutel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 724,
-      "word": "Wischbezug",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/wischbezug.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1220,
-              "image": "http://testserver/media/images/wischbezug.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 726,
-      "word": "Bademantel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bademantel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1279,
-              "image": "http://testserver/media/images/bademantel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 727,
-      "word": "Badezimmer",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/badezimmer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 569,
-              "image": "http://testserver/media/images/badezimmer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 728,
-      "word": "Balkon",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/balkon.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1237,
-              "image": "http://testserver/media/images/balkon.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 729,
-      "word": "Bettdecke",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bettdecke.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 565,
-              "image": "http://testserver/media/images/bettdecke.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 730,
-      "word": "Bettwäsche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bettwasche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 714,
-              "image": "http://testserver/media/images/bettwasche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 731,
-      "word": "Doppelbett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/doppelbett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 566,
-              "image": "http://testserver/media/images/doppelbett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 732,
-      "word": "Duschkopf",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/duschkopf.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 567,
-              "image": "http://testserver/media/images/duschkopf.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 733,
-      "word": "Einzelbett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/einzelbett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 568,
-              "image": "http://testserver/media/images/einzelbett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 734,
-      "word": "Fenster",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/fenster.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 434,
-              "image": "http://testserver/media/images/fenster.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 735,
-      "word": "Fernbedienung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/fernbedienung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 715,
-              "image": "http://testserver/media/images/fernbedienung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 736,
-      "word": "Fernseher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/fernseher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 580,
-              "image": "http://testserver/media/images/fernseher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 738,
-      "word": "Garderobe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/garderobe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 572,
-              "image": "http://testserver/media/images/garderobe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 739,
-      "word": "Gardine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/gardine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1254,
-              "image": "http://testserver/media/images/gardine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 740,
-      "word": "Handtuch",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/handtuch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 796,
-              "image": "http://testserver/media/images/handtuch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 741,
-      "word": "Handtuchhalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handtuchhalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 574,
-              "image": "http://testserver/media/images/handtuchhalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 742,
-      "word": "Handtuchstange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/handtuchstange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 575,
-              "image": "http://testserver/media/images/handtuchstange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 743,
-      "word": "Hoteltresor",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/hoteltresor.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Hotelsafe",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Zimmersafe",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Zimmertresor",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 592,
-              "image": "http://testserver/media/images/hoteltresor.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 745,
-      "word": "Kleiderbügel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kleiderbugel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1216,
-              "image": "http://testserver/media/images/kleiderbugel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 746,
-      "word": "Kleiderschrank",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kleiderschrank.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 576,
-              "image": "http://testserver/media/images/kleiderschrank.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 747,
-      "word": "Klimaanlagenregler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/klimaanlagenregler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 577,
-              "image": "http://testserver/media/images/klimaanlagenregler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 748,
-      "word": "Kopfkissen",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kopfkissen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 578,
-              "image": "http://testserver/media/images/kopfkissen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 749,
-      "word": "Minibar",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/minibar.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 581,
-              "image": "http://testserver/media/images/minibar.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 750,
-      "word": "Nachttisch",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/nachttisch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Nachtkästchen",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 582,
-              "image": "http://testserver/media/images/nachttisch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 751,
-      "word": "Rasierapparat",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/rasierapparat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1217,
-              "image": "http://testserver/media/images/rasierapparat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 753,
-      "word": "Toilettenbürste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/toilettenburste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 589,
-              "image": "http://testserver/media/images/toilettenburste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 754,
-      "word": "Toilettenpapier",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/toilettenpapier.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 716,
-              "image": "http://testserver/media/images/toilettenpapier.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 755,
-      "word": "Toilettenpapierhalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/toilettenpapierhalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 590,
-              "image": "http://testserver/media/images/toilettenpapierhalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 756,
-      "word": "Wasserkocher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/wasserkocher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1228,
-              "image": "http://testserver/media/images/wasserkocher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 757,
-      "word": "Zahnbürste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/zahnburste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 651,
-              "image": "http://testserver/media/images/zahnburste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 758,
-      "word": "Zahnpasta",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/zahnpasta.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 718,
-              "image": "http://testserver/media/images/zahnpasta.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 759,
-      "word": "EC-Karte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/ec-karte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "EC-Karten",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 436,
-              "image": "http://testserver/media/images/ec-karte.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 761,
-      "word": "Gepäck",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/gepack.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1396,
-              "image": "http://testserver/media/images/gepack.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 762,
-      "word": "Gepäckwagen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gepackwagen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 558,
-              "image": "http://testserver/media/images/gepackwagen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 764,
-      "word": "Koffer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/koffer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1397,
-              "image": "http://testserver/media/images/koffer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 765,
-      "word": "Kreditkarte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kreditkarte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kreditkarten",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 437,
-              "image": "http://testserver/media/images/kreditkarte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 766,
-      "word": "Parkplatz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/parkplatz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1236,
-              "image": "http://testserver/media/images/parkplatz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 767,
-      "word": "Rezeption",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/rezeption.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 551,
-              "image": "http://testserver/media/images/rezeption.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 768,
-      "word": "Rezeptionsglocke",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/rezeptionsglocke.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1395,
-              "image": "http://testserver/media/images/rezeptionsglocke.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 769,
-      "word": "Sicherheitsnadel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sicherheitsnadel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1283,
-              "image": "http://testserver/media/images/sicherheitsnadel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 771,
-      "word": "Streichholz",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/streichholz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1284,
-              "image": "http://testserver/media/images/streichholz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 772,
-      "word": "Tasche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/tasche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1234,
-              "image": "http://testserver/media/images/tasche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 773,
-      "word": "Trolley",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/trolley.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 432,
-              "image": "http://testserver/media/images/trolley.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 776,
-      "word": "Waschmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/waschmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1153,
-              "image": "http://testserver/media/images/waschmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 778,
-      "word": "Waschmittel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/waschmittel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1242,
-              "image": "http://testserver/media/images/waschmittel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 779,
-      "word": "Wäscheständer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/waschestander.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1842,
-              "image": "http://testserver/media/images/waschestander.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 780,
-      "word": "Wäscheklammer",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/wascheklammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1243,
-              "image": "http://testserver/media/images/wascheklammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 782,
-      "word": "Waschgang",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/waschgang.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1244,
-              "image": "http://testserver/media/images/waschgang.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 783,
-      "word": "Schleuderzahl",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schleuderzahl.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1245,
-              "image": "http://testserver/media/images/schleuderzahl.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 784,
-      "word": "Pflegeetikett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/pflegeetikett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1246,
-              "image": "http://testserver/media/images/pflegeetikett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 786,
-      "word": "Seife",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/seife.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1225,
-              "image": "http://testserver/media/images/seife.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 797,
-      "word": "Seitenscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/seitenscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Seitenfenster",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1719,
-              "image": "http://testserver/media/images/seitenscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 798,
-      "word": "Heckscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/heckscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1375,
-              "image": "http://testserver/media/images/heckscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 799,
-      "word": "Bremspedal",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bremspedal.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1624,
-              "image": "http://testserver/media/images/bremspedal.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 800,
-      "word": "Gaspedal",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/gaspedal.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1717,
-              "image": "http://testserver/media/images/gaspedal.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 801,
-      "word": "Kupplung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kupplung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1424,
-              "image": "http://testserver/media/images/kupplung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 803,
-      "word": "Motoröl",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/motorol.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1436,
-              "image": "http://testserver/media/images/motorol.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 805,
-      "word": "Lenkrad",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/lenkrad.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1718,
-              "image": "http://testserver/media/images/lenkrad.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 807,
-      "word": "Reifen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/reifen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1452,
-              "image": "http://testserver/media/images/reifen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 808,
-      "word": "Fahrersitz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/fahrersitz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1716,
-              "image": "http://testserver/media/images/fahrersitz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 818,
-      "word": "Lkw",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/lkw.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "LKW",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Lastkraftwagen",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1116,
-              "image": "http://testserver/media/images/lkw.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 832,
-      "word": "Sicherheitsgurt",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/sicherheitsgurt.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1804,
-              "image": "http://testserver/media/images/sicherheitsgurt.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 908,
-      "word": "Handtacker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handtacker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 439,
-              "image": "http://testserver/media/images/handtacker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 909,
-      "word": "Winkelmesser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/winkelmesser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 990,
-              "image": "http://testserver/media/images/winkelmesser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 912,
-      "word": "Vorhängeschloss",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/vorhangeschloss.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 417,
-              "image": "http://testserver/media/images/vorhangeschloss.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 914,
-      "word": "Zimmermannshammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zimmermannshammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1514,
-              "image": "http://testserver/media/images/zimmermannshammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 924,
-      "word": "Reibebrett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/reibebrett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1270,
-              "image": "http://testserver/media/images/reibebrett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 932,
-      "word": "Bogenzirkel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bogenzirkel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Zirkel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 991,
-              "image": "http://testserver/media/images/bogenzirkel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 937,
-      "word": "Flachzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/flachzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 771,
-              "image": "http://testserver/media/images/flachzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 938,
-      "word": "Gripzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/gripzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1031,
-              "image": "http://testserver/media/images/gripzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 945,
-      "word": "Schlagschnur",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schlagschnur.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 945,
-              "image": "http://testserver/media/images/schlagschnur.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 953,
-      "word": "Schraubenziehersatz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schraubenziehersatz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 419,
-              "image": "http://testserver/media/images/schraubenziehersatz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 954,
-      "word": "Holzbock",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/holzbock.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1607,
-              "image": "http://testserver/media/images/holzbock.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 955,
-      "word": "Spitzzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spitzzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 418,
-              "image": "http://testserver/media/images/spitzzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 958,
-      "word": "Staubsaugerfilter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/staubsaugerfilter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Filter",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Lamellenfilter",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1840,
-              "image": "http://testserver/media/images/staubsaugerfilter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 959,
-      "word": "Schlauch",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schlauch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1573,
-              "image": "http://testserver/media/images/schlauch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 961,
-      "word": "Anschlagwinkel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/anschlagwinkel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 443,
-              "image": "http://testserver/media/images/anschlagwinkel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 964,
-      "word": "Drehmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/drehmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "konventionelle Drehmaschine",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1037,
-              "image": "http://testserver/media/images/drehmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 980,
-      "word": "Bargeld",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bargeld.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 435,
-              "image": "http://testserver/media/images/bargeld.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1005,
-      "word": "Erste-Hilfe-Koffer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/erste-hilfe-koffer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 547,
-              "image": "http://testserver/media/images/erste-hilfe-koffer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1006,
-      "word": "Feuerlöscher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/feuerloscher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 488,
-              "image": "http://testserver/media/images/feuerloscher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1010,
-      "word": "Container-Kran",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/container-kran.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Container-Brücke",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1106,
-              "image": "http://testserver/media/images/container-kran.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1012,
-      "word": "Förderband",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/forderband.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Fließband",
-              "singular_article": 3
-          },
-          {
-              "alt_word": "Bandförderer",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Transportband",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1107,
-              "image": "http://testserver/media/images/forderband.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1019,
-      "word": "Rolltor",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/rolltor.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1117,
-              "image": "http://testserver/media/images/rolltor.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1020,
-      "word": "Sattelzug",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/sattelzug.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1119,
-              "image": "http://testserver/media/images/sattelzug.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1021,
-      "word": "Transportroller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/transportroller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1120,
-              "image": "http://testserver/media/images/transportroller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1022,
-      "word": "Transportwagen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/transportwagen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1121,
-              "image": "http://testserver/media/images/transportwagen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1023,
-      "word": "Bett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1256,
-              "image": "http://testserver/media/images/bett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1034,
-      "word": "Lichtschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/lichtschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 803,
-              "image": "http://testserver/media/images/lichtschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1049,
-      "word": "Geldschein",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/geldschein.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 687,
-              "image": "http://testserver/media/images/geldschein.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1050,
-      "word": "Münze",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/munze.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 688,
-              "image": "http://testserver/media/images/munze.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1111,
-      "word": "Backrost",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/backrost.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Rost",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 497,
-              "image": "http://testserver/media/images/backrost.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1113,
-      "word": "Kaffeevollautomat",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kaffeevollautomat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kaffeemaschine",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 508,
-              "image": "http://testserver/media/images/kaffeevollautomat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1115,
-      "word": "Servierteller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/servierteller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 517,
-              "image": "http://testserver/media/images/servierteller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1116,
-      "word": "Tumbler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/tumbler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 519,
-              "image": "http://testserver/media/images/tumbler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1117,
-      "word": "Warmhalterost",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/warmhalterost.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 523,
-              "image": "http://testserver/media/images/warmhalterost.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1118,
-      "word": "Desinfektionsmittelspender",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/desinfektionsmittelspender.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 524,
-              "image": "http://testserver/media/images/desinfektionsmittelspender.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1119,
-      "word": "Käsebrett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kasebrett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 531,
-              "image": "http://testserver/media/images/kasebrett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1122,
-      "word": "Rührschüssel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/ruhrschussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 539,
-              "image": "http://testserver/media/images/ruhrschussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1123,
-      "word": "Ceranfeldschaber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/ceranfeldschaber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 540,
-              "image": "http://testserver/media/images/ceranfeldschaber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1126,
-      "word": "Topflappen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/topflappen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1280,
-              "image": "http://testserver/media/images/topflappen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1127,
-      "word": "Defibrillator",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/defibrillator.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 548,
-              "image": "http://testserver/media/images/defibrillator.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1128,
-      "word": "Notfallplan",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/notfallplan.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 549,
-              "image": "http://testserver/media/images/notfallplan.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1129,
-      "word": "Notausgang",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/notausgang.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 550,
-              "image": "http://testserver/media/images/notausgang.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1136,
-      "word": "Garderobenständer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/garderobenstander.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 559,
-              "image": "http://testserver/media/images/garderobenstander.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1138,
-      "word": "Telefonanlage",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/telefonanlage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 561,
-              "image": "http://testserver/media/images/telefonanlage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1139,
-      "word": "Sitzgruppe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sitzgruppe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 562,
-              "image": "http://testserver/media/images/sitzgruppe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1142,
-      "word": "Fliese",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/fliese.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 570,
-              "image": "http://testserver/media/images/fliese.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1143,
-      "word": "Flurschild",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/flurschild.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 571,
-              "image": "http://testserver/media/images/flurschild.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1144,
-      "word": "Kosmetikmülleimer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kosmetikmulleimer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 579,
-              "image": "http://testserver/media/images/kosmetikmulleimer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1145,
-      "word": "Schließzylinder",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schliezylinder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 586,
-              "image": "http://testserver/media/images/schliezylinder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1146,
-      "word": "Sicherheitssteckdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sicherheitssteckdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 588,
-              "image": "http://testserver/media/images/sicherheitssteckdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1147,
-      "word": "Waschtisch",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/waschtisch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1569,
-              "image": "http://testserver/media/images/waschtisch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1148,
-      "word": "Türschild",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/turschild.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 591,
-              "image": "http://testserver/media/images/turschild.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1149,
-      "word": "Badregal",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/badregal.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1570,
-              "image": "http://testserver/media/images/badregal.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1197,
-      "word": "Mikrowelle",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/mikrowelle.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 663,
-              "image": "http://testserver/media/images/mikrowelle.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1198,
-      "word": "Küchenmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kuchenmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 661,
-              "image": "http://testserver/media/images/kuchenmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1199,
-      "word": "Gasherd",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gasherd.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 662,
-              "image": "http://testserver/media/images/gasherd.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1200,
-      "word": "Bierkrug",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bierkrug.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 669,
-              "image": "http://testserver/media/images/bierkrug.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1203,
-      "word": "Abstandschelle",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/abstandschelle.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 724,
-              "image": "http://testserver/media/images/abstandschelle.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1204,
-      "word": "Abzweigdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/abzweigdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 725,
-              "image": "http://testserver/media/images/abzweigdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1205,
-      "word": "Aderendhülse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/aderendhulse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Aderendhülsen",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 726,
-              "image": "http://testserver/media/images/aderendhulse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1206,
-      "word": "Aderleitung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/aderleitung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 727,
-              "image": "http://testserver/media/images/aderleitung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1207,
-      "word": "Alarmleuchte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/alarmleuchte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 728,
-              "image": "http://testserver/media/images/alarmleuchte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1208,
-      "word": "Analogmessgerät",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/analogmessgerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 729,
-              "image": "http://testserver/media/images/analogmessgerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1209,
-      "word": "Anlagenmessgerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/anlagenmessgerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 730,
-              "image": "http://testserver/media/images/anlagenmessgerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1210,
-      "word": "Anschlussdatenbezeichnung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/anschlussdatenbezeichnung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 731,
-              "image": "http://testserver/media/images/anschlussdatenbezeichnung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1211,
-      "word": "Baustrahler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/baustrahler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 732,
-              "image": "http://testserver/media/images/baustrahler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1212,
-      "word": "Aufputzinstallation",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/aufputzinstallation.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 733,
-              "image": "http://testserver/media/images/aufputzinstallation.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1213,
-      "word": "Aufputzinstallationsrohr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/aufputzinstallationsrohr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 734,
-              "image": "http://testserver/media/images/aufputzinstallationsrohr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1214,
-      "word": "Audiosignal",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/audiosignal.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 735,
-              "image": "http://testserver/media/images/audiosignal.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1215,
-      "word": "Außengewinde",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/auengewinde.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 737,
-              "image": "http://testserver/media/images/auengewinde.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1216,
-      "word": "Bananenstecker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bananenstecker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 738,
-              "image": "http://testserver/media/images/bananenstecker.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1217,
-      "word": "Batterie",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/batterie.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 739,
-              "image": "http://testserver/media/images/batterie.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1218,
-      "word": "Baustromverteiler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/baustromverteiler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 740,
-              "image": "http://testserver/media/images/baustromverteiler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1219,
-      "word": "Bedienfeld",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bedienfeld.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 741,
-              "image": "http://testserver/media/images/bedienfeld.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1220,
-      "word": "Betoninstallationsrohr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/betoninstallationsrohr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 742,
-              "image": "http://testserver/media/images/betoninstallationsrohr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1221,
-      "word": "Bohrfutter",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bohrfutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 743,
-              "image": "http://testserver/media/images/bohrfutter.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1222,
-      "word": "Bohrfutterschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bohrfutterschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 744,
-              "image": "http://testserver/media/images/bohrfutterschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1223,
-      "word": "Bohrloch",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bohrloch.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Bohrlöcher",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 745,
-              "image": "http://testserver/media/images/bohrloch.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1224,
-      "word": "Brandschutzschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/brandschutzschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 747,
-              "image": "http://testserver/media/images/brandschutzschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1225,
-      "word": "Brüstungskanal",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/brustungskanal.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 748,
-              "image": "http://testserver/media/images/brustungskanal.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1226,
-      "word": "Bügelgehörschutz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bugelgehorschutz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 749,
-              "image": "http://testserver/media/images/bugelgehorschutz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1227,
-      "word": "Dämmerungsschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/dammerungsschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 750,
-              "image": "http://testserver/media/images/dammerungsschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1228,
-      "word": "Deckenleuchte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/deckenleuchte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 751,
-              "image": "http://testserver/media/images/deckenleuchte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1229,
-      "word": "Dimmer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/dimmer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 752,
-              "image": "http://testserver/media/images/dimmer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1230,
-      "word": "Dosenklemme",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/dosenklemme.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Dosenklemmen",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 753,
-              "image": "http://testserver/media/images/dosenklemme.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1231,
-      "word": "Draht",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/draht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 754,
-              "image": "http://testserver/media/images/draht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1232,
-      "word": "Dreheisenmessgerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/dreheisenmessgerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 755,
-              "image": "http://testserver/media/images/dreheisenmessgerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1233,
-      "word": "Drehfeldmessgerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/drehfeldmessgerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 756,
-              "image": "http://testserver/media/images/drehfeldmessgerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1234,
-      "word": "Drehschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/drehschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 757,
-              "image": "http://testserver/media/images/drehschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1236,
-      "word": "Druckschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/druckschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 758,
-              "image": "http://testserver/media/images/druckschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1237,
-      "word": "Durchbruchbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/durchbruchbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 759,
-              "image": "http://testserver/media/images/durchbruchbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1238,
-      "word": "Durchgangsprüfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/durchgangsprufer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 760,
-              "image": "http://testserver/media/images/durchgangsprufer.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1239,
-      "word": "E-Check",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/e-check.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Elektro-Check",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "elektrische Sicherheitsprüfung",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 761,
-              "image": "http://testserver/media/images/e-check.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1240,
-      "word": "Elektrikergips",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/elektrikergips.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Elektriker-Gips",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 762,
-              "image": "http://testserver/media/images/elektrikergips.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1241,
-      "word": "elektrische Verteiler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/elektrische-verteiler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Verteilung",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Sicherungskasten",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Verteilerkasten",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 763,
-              "image": "http://testserver/media/images/elektrische-verteiler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1242,
-      "word": "Elektroinstallation",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/elektroinstallation.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 764,
-              "image": "http://testserver/media/images/elektroinstallation.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1243,
-      "word": "Elektrosäge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/elektrosage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 765,
-              "image": "http://testserver/media/images/elektrosage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1244,
-      "word": "Elektroschere",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/elektroschere.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 766,
-              "image": "http://testserver/media/images/elektroschere.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1246,
-      "word": "Entlötpumpe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/entlotpumpe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 768,
-              "image": "http://testserver/media/images/entlotpumpe.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1247,
-      "word": "Eurostecker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/eurostecker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 769,
-              "image": "http://testserver/media/images/eurostecker.jpg"
-          }
-      ],
-      "example_sentence": "Das Netzteil ist versehen mit einem Eurostecker für den direkten Anschluss an eine Schuko-Steckdose und verfügt über eine 3m lange Zuleitung."
-  },
-  {
-      "id": 1249,
-      "word": "Flachmeißel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/flachmeiel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1574,
-              "image": "http://testserver/media/images/flachmeiel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1250,
-      "word": "Flachrundzange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/flachrundzange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 770,
-              "image": "http://testserver/media/images/flachrundzange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1252,
-      "word": "Gehörstöpsel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gehorstopsel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Gehörschutzstöpsel",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Ohrenstöpsel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 772,
-              "image": "http://testserver/media/images/gehorstopsel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1253,
-      "word": "Heißklebepistole",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/heiklebepistole.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 773,
-              "image": "http://testserver/media/images/heiklebepistole.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1254,
-      "word": "Heißluftgebläse",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/heiluftgeblase.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 774,
-              "image": "http://testserver/media/images/heiluftgeblase.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1255,
-      "word": "Hygrometer",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/hygrometer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 775,
-              "image": "http://testserver/media/images/hygrometer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1256,
-      "word": "Infrarotstrahler",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/infrarotstrahler.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 776,
-              "image": "http://testserver/media/images/infrarotstrahler.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1257,
-      "word": "Innengewinde",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/innengewinde.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 777,
-              "image": "http://testserver/media/images/innengewinde.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1258,
-      "word": "inverte Stromerzeuger",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/inverte-stromerzeuger.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 778,
-              "image": "http://testserver/media/images/inverte-stromerzeuger.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1259,
-      "word": "Kabel",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kabel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 779,
-              "image": "http://testserver/media/images/kabel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1260,
-      "word": "Kabelbinder",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kabelbinder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 780,
-              "image": "http://testserver/media/images/kabelbinder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1261,
-      "word": "Kabeleinziehsystem",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kabeleinziehsystem.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 781,
-              "image": "http://testserver/media/images/kabeleinziehsystem.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1263,
-      "word": "Kraftstromsteckdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kraftstromsteckdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 786,
-              "image": "http://testserver/media/images/kraftstromsteckdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1264,
-      "word": "Kuparohr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kuparohr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kuparohre",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 787,
-              "image": "http://testserver/media/images/kuparohr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1265,
-      "word": "Litzenleitung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/litzenleitung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 788,
-              "image": "http://testserver/media/images/litzenleitung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1266,
-      "word": "Lochsäge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/lochsage.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 789,
-              "image": "http://testserver/media/images/lochsage.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1267,
-      "word": "Lötkolben",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/lotkolben.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1278,
-              "image": "http://testserver/media/images/lotkolben.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1268,
-      "word": "Lötset",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/lotset.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 790,
-              "image": "http://testserver/media/images/lotset.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1270,
-      "word": "Lötstation",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/lotstation.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 791,
-              "image": "http://testserver/media/images/lotstation.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1271,
-      "word": "Lötstelle",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/lotstelle.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Lötstellen",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 792,
-              "image": "http://testserver/media/images/lotstelle.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1272,
-      "word": "Lötzinn",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/lotzinn.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 793,
-              "image": "http://testserver/media/images/lotzinn.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1273,
-      "word": "LSA-Plus-Auflegewerkzeug",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/lsa-plus-auflegewerkzeug.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "LSA-Plus-Anlegewerkzeug",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 794,
-              "image": "http://testserver/media/images/lsa-plus-auflegewerkzeug.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1274,
-      "word": "Mauernutfräse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/mauernutfrase.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 808,
-              "image": "http://testserver/media/images/mauernutfrase.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1275,
-      "word": "Metalldetektor",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/metalldetektor.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 809,
-              "image": "http://testserver/media/images/metalldetektor.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1276,
-      "word": "Netzteil",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/netzteil.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 810,
-              "image": "http://testserver/media/images/netzteil.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1277,
-      "word": "Phasenprüfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/phasenprufer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 811,
-              "image": "http://testserver/media/images/phasenprufer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1278,
-      "word": "Doppelringschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/doppelringschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1575,
-              "image": "http://testserver/media/images/doppelringschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1279,
-      "word": "Ringmaulschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/ringmaulschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Maulringschlüssel",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1576,
-              "image": "http://testserver/media/images/ringmaulschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1280,
-      "word": "Schleifenimpedanzmessgerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/schleifenimpedanzmessgerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 813,
-              "image": "http://testserver/media/images/schleifenimpedanzmessgerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1281,
-      "word": "Schraubenkopf",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schraubenkopf.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 815,
-              "image": "http://testserver/media/images/schraubenkopf.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1282,
-      "word": "Schraubenmutter",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schraubenmutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Mutter",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 816,
-              "image": "http://testserver/media/images/schraubenmutter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1283,
-      "word": "Schutzschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schutzschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 817,
-              "image": "http://testserver/media/images/schutzschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1284,
-      "word": "Signalband",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/signalband.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 818,
-              "image": "http://testserver/media/images/signalband.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1286,
-      "word": "Stabschrauber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/stabschrauber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 819,
-              "image": "http://testserver/media/images/stabschrauber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1287,
-      "word": "Starkstromleitung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/starkstromleitung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Starkstromleitungen",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 820,
-              "image": "http://testserver/media/images/starkstromleitung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1288,
-      "word": "Steckverbinder",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/steckverbinder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Steckverbinder",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 821,
-              "image": "http://testserver/media/images/steckverbinder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1289,
-      "word": "Störlichtbogen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/storlichtbogen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 822,
-              "image": "http://testserver/media/images/storlichtbogen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1290,
-      "word": "Strommesszange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/strommesszange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 823,
-              "image": "http://testserver/media/images/strommesszange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1291,
-      "word": "Transformator",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/transformator.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 824,
-              "image": "http://testserver/media/images/transformator.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1292,
-      "word": "Trockenbauwand",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/trockenbauwand.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Unterputzinstallation",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 825,
-              "image": "http://testserver/media/images/trockenbauwand.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1293,
-      "word": "Unterputzdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/unterputzdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 826,
-              "image": "http://testserver/media/images/unterputzdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1297,
-      "word": "Schaltplan",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schaltplan.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 829,
-              "image": "http://testserver/media/images/schaltplan.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1298,
-      "word": "Nut",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/nut.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Nute",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 830,
-              "image": "http://testserver/media/images/nut.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1299,
-      "word": "Kondensator",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kondensator.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 831,
-              "image": "http://testserver/media/images/kondensator.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1300,
-      "word": "Atom",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/atom.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 833,
-              "image": "http://testserver/media/images/atom.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1304,
-      "word": "Atomstrom",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/atomstrom.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 837,
-              "image": "http://testserver/media/images/atomstrom.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1306,
-      "word": "Außenleiter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/auenleiter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 839,
-              "image": "http://testserver/media/images/auenleiter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1309,
-      "word": "Neutralleiter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/neutralleiter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 842,
-              "image": "http://testserver/media/images/neutralleiter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1328,
-      "word": "Abfallstrom",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/abfallstrom.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 861,
-              "image": "http://testserver/media/images/abfallstrom.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1329,
-      "word": "Amplitude",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/amplitude.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 862,
-              "image": "http://testserver/media/images/amplitude.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1330,
-      "word": "Dreiphasenwechselstrom",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/dreiphasenwechselstrom.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 863,
-              "image": "http://testserver/media/images/dreiphasenwechselstrom.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1331,
-      "word": "Gleichstrom",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gleichstrom.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 864,
-              "image": "http://testserver/media/images/gleichstrom.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1332,
-      "word": "Wechselstrom",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/wechselstrom.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 865,
-              "image": "http://testserver/media/images/wechselstrom.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1333,
-      "word": "Anode",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/anode.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 866,
-              "image": "http://testserver/media/images/anode.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1334,
-      "word": "Kathode",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kathode.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 867,
-              "image": "http://testserver/media/images/kathode.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1335,
-      "word": "Leitung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/leitung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 868,
-              "image": "http://testserver/media/images/leitung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1337,
-      "word": "Stromkreis",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/stromkreis.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 870,
-              "image": "http://testserver/media/images/stromkreis.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1339,
-      "word": "Verbraucher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/verbraucher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 872,
-              "image": "http://testserver/media/images/verbraucher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1375,
-      "word": "Beipackzettel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/beipackzettel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 891,
-              "image": "http://testserver/media/images/beipackzettel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1377,
-      "word": "Bordbrett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bordbrett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 894,
-              "image": "http://testserver/media/images/bordbrett.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1403,
-      "word": "Ladegerät",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/ladegerat.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Batterieladegerät",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1855,
-              "image": "http://testserver/media/images/ladegerat.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1424,
-      "word": "Schwingschleifer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schwingschleifer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 947,
-              "image": "http://testserver/media/images/schwingschleifer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1426,
-      "word": "Sicherung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sicherung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 949,
-              "image": "http://testserver/media/images/sicherung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1428,
-      "word": "Sondermüll",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/sondermull.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 951,
-              "image": "http://testserver/media/images/sondermull.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1446,
-      "word": "Ader",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/ader.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 971,
-              "image": "http://testserver/media/images/ader.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1447,
-      "word": "Notausschalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/notausschalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Notausschaltknopf",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 972,
-              "image": "http://testserver/media/images/notausschalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1449,
-      "word": "Außengewindeschneider",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/auengewindeschneider.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 973,
-              "image": "http://testserver/media/images/auengewindeschneider.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1450,
-      "word": "Bohrvorrichtung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bohrvorrichtung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 974,
-              "image": "http://testserver/media/images/bohrvorrichtung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1452,
-      "word": "Federscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/federscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 976,
-              "image": "http://testserver/media/images/federscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1453,
-      "word": "Flügelmutter",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/flugelmutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 977,
-              "image": "http://testserver/media/images/flugelmutter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1454,
-      "word": "Handbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 979,
-              "image": "http://testserver/media/images/handbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1455,
-      "word": "Kegelreibahle",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kegelreibahle.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 980,
-              "image": "http://testserver/media/images/kegelreibahle.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1456,
-      "word": "Kühlmittelflasche",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kuhlmittelflasche.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 981,
-              "image": "http://testserver/media/images/kuhlmittelflasche.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1457,
-      "word": "Manometer",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/manometer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 982,
-              "image": "http://testserver/media/images/manometer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1458,
-      "word": "Maschinengewindebohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/maschinengewindebohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 983,
-              "image": "http://testserver/media/images/maschinengewindebohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1459,
-      "word": "Ölkanne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/olkanne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Ölkännchen",
-              "singular_article": 3
-          }
-      ],
-      "document_image": [
-          {
-              "id": 984,
-              "image": "http://testserver/media/images/olkanne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1460,
-      "word": "Radius",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/radius.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 985,
-              "image": "http://testserver/media/images/radius.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1461,
-      "word": "Rändelschraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/randelschraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 986,
-              "image": "http://testserver/media/images/randelschraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1463,
-      "word": "Spax-Schraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spax-schraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Universalschraube",
-              "singular_article": 2
-          },
-          {
-              "alt_word": "Spax",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 988,
-              "image": "http://testserver/media/images/spax-schraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1464,
-      "word": "Unterlegscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/unterlegscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 989,
-              "image": "http://testserver/media/images/unterlegscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1465,
-      "word": "Zylinderkopfschraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/zylinderkopfschraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 992,
-              "image": "http://testserver/media/images/zylinderkopfschraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1466,
-      "word": "CNC-Fräsmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/cnc-frasmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 993,
-              "image": "http://testserver/media/images/cnc-frasmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1467,
-      "word": "Eckmesserkopf",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/eckmesserkopf.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 994,
-              "image": "http://testserver/media/images/eckmesserkopf.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1468,
-      "word": "Einstellring",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/einstellring.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 995,
-              "image": "http://testserver/media/images/einstellring.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1469,
-      "word": "Formfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/formfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 996,
-              "image": "http://testserver/media/images/formfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1470,
-      "word": "Grenzrachenlehre",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/grenzrachenlehre.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 997,
-              "image": "http://testserver/media/images/grenzrachenlehre.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1471,
-      "word": "Kantentaster",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kantentaster.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 998,
-              "image": "http://testserver/media/images/kantentaster.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1472,
-      "word": "Messerkopf",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/messerkopf.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 999,
-              "image": "http://testserver/media/images/messerkopf.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1473,
-      "word": "Messuhr",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/messuhr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1000,
-              "image": "http://testserver/media/images/messuhr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1474,
-      "word": "Radienfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/radienfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1002,
-              "image": "http://testserver/media/images/radienfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1475,
-      "word": "Satzfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/satzfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1003,
-              "image": "http://testserver/media/images/satzfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1476,
-      "word": "Schaftfräser mit Radius",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schaftfraser-mit-radius.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1004,
-              "image": "http://testserver/media/images/schaftfraser-mit-radius.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1477,
-      "word": "T-Nutenfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/t-nutenfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1005,
-              "image": "http://testserver/media/images/t-nutenfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1478,
-      "word": "T-Nutenstein",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/t-nutenstein.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1006,
-              "image": "http://testserver/media/images/t-nutenstein.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1479,
-      "word": "Trapezantriebsspindel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/trapezantriebsspindel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1007,
-              "image": "http://testserver/media/images/trapezantriebsspindel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1480,
-      "word": "Universaltaster",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/universaltaster.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1008,
-              "image": "http://testserver/media/images/universaltaster.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1481,
-      "word": "Walzenfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/walzenfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1009,
-              "image": "http://testserver/media/images/walzenfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1482,
-      "word": "Zahnradfräser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zahnradfraser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1012,
-              "image": "http://testserver/media/images/zahnradfraser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1483,
-      "word": "Abstechdrehmeißel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/abstechdrehmeiel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1013,
-              "image": "http://testserver/media/images/abstechdrehmeiel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1485,
-      "word": "Bitsatz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bitsatz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1015,
-              "image": "http://testserver/media/images/bitsatz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1487,
-      "word": "Bolzenschneider",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bolzenschneider.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1016,
-              "image": "http://testserver/media/images/bolzenschneider.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1488,
-      "word": "Bügelprisma",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bugelprisma.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1017,
-              "image": "http://testserver/media/images/bugelprisma.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1489,
-      "word": "Doppelkörner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/doppelkorner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1018,
-              "image": "http://testserver/media/images/doppelkorner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1491,
-      "word": "Druckluftpistole",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/druckluftpistole.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1020,
-              "image": "http://testserver/media/images/druckluftpistole.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1492,
-      "word": "E-Motor",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/e-motor.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1021,
-              "image": "http://testserver/media/images/e-motor.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1493,
-      "word": "Einstechdrehmeißel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/einstechdrehmeiel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1022,
-              "image": "http://testserver/media/images/einstechdrehmeiel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1494,
-      "word": "Gegenschlag",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gegenschlag.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1023,
-              "image": "http://testserver/media/images/gegenschlag.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1495,
-      "word": "Gewindestange",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/gewindestange.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1024,
-              "image": "http://testserver/media/images/gewindestange.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1496,
-      "word": "Gewindestift",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/gewindestift.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1025,
-              "image": "http://testserver/media/images/gewindestift.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1501,
-      "word": "Innendrehmeißel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/innendrehmeiel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1033,
-              "image": "http://testserver/media/images/innendrehmeiel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1502,
-      "word": "Inbus mit Griff",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/inbus-mit-griff.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Inbusschlüssel mit Griff",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Stiftschlüssel mit Griff",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Innensechskantschlüssel mit Griff",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1034,
-              "image": "http://testserver/media/images/inbus-mit-griff.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1503,
-      "word": "Inbussatz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/inbussatz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Innensechskantschlüsselsatz",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Inbusschlüsselsatz",
-              "singular_article": 1
-          },
-          {
-              "alt_word": "Stiftschlüsselsatz",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1035,
-              "image": "http://testserver/media/images/inbussatz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1504,
-      "word": "Klebekerze",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/klebekerze.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Klebekerzen",
-              "singular_article": 4
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1036,
-              "image": "http://testserver/media/images/klebekerze.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1505,
-      "word": "Körnerplatte",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kornerplatte.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1038,
-              "image": "http://testserver/media/images/kornerplatte.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1506,
-      "word": "Kugellager",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kugellager.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1040,
-              "image": "http://testserver/media/images/kugellager.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1507,
-      "word": "Kraftmessdose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kraftmessdose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Kraftaufnehmer",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1041,
-              "image": "http://testserver/media/images/kraftmessdose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1509,
-      "word": "Akku-Ladestation",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/akku-ladestation.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Ladestation",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1043,
-              "image": "http://testserver/media/images/akku-ladestation.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1510,
-      "word": "Lastenkran",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/lastenkran.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1044,
-              "image": "http://testserver/media/images/lastenkran.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1511,
-      "word": "mitlaufende Spitze",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/mitlaufende-spitze.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1045,
-              "image": "http://testserver/media/images/mitlaufende-spitze.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1512,
-      "word": "O-Ring",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/o-ring.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1046,
-              "image": "http://testserver/media/images/o-ring.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1513,
-      "word": "Passstift",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/passstift.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1047,
-              "image": "http://testserver/media/images/passstift.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1514,
-      "word": "Poliervlies",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/poliervlies.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1048,
-              "image": "http://testserver/media/images/poliervlies.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1515,
-      "word": "Prisma",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/prisma.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1049,
-              "image": "http://testserver/media/images/prisma.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1517,
-      "word": "Reduzieröse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/reduzierose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1051,
-              "image": "http://testserver/media/images/reduzierose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1518,
-      "word": "Richtbank",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/richtbank.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1052,
-              "image": "http://testserver/media/images/richtbank.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1519,
-      "word": "Rohrschere",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/rohrschere.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1053,
-              "image": "http://testserver/media/images/rohrschere.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1520,
-      "word": "Säulenbohrmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/saulenbohrmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1054,
-              "image": "http://testserver/media/images/saulenbohrmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1521,
-      "word": "Schlauchschere",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schlauchschere.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1055,
-              "image": "http://testserver/media/images/schlauchschere.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1522,
-      "word": "Schleifpapierhalter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schleifpapierhalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1056,
-              "image": "http://testserver/media/images/schleifpapierhalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1523,
-      "word": "Schnellspanner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schnellspanner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1057,
-              "image": "http://testserver/media/images/schnellspanner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1525,
-      "word": "Schweißerkabine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schweierkabine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1060,
-              "image": "http://testserver/media/images/schweierkabine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1526,
-      "word": "Sicherungsring",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/sicherungsring.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1061,
-              "image": "http://testserver/media/images/sicherungsring.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1527,
-      "word": "Spannfeder",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spannfeder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Feder",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1062,
-              "image": "http://testserver/media/images/spannfeder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1528,
-      "word": "Spannfutter",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/spannfutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1063,
-              "image": "http://testserver/media/images/spannfutter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1529,
-      "word": "Spannhülse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spannhulse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1064,
-              "image": "http://testserver/media/images/spannhulse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1530,
-      "word": "Spanntreppe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spanntreppe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1065,
-              "image": "http://testserver/media/images/spanntreppe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1531,
-      "word": "Tafelschere",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/tafelschere.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1066,
-              "image": "http://testserver/media/images/tafelschere.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1532,
-      "word": "Tiefenmaßstab",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/tiefenmastab.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1067,
-              "image": "http://testserver/media/images/tiefenmastab.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1533,
-      "word": "Trennstemmer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/trennstemmer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1068,
-              "image": "http://testserver/media/images/trennstemmer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1534,
-      "word": "Werkzeugwagen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/werkzeugwagen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1069,
-              "image": "http://testserver/media/images/werkzeugwagen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1536,
-      "word": "Austreiber",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/austreiber.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1071,
-              "image": "http://testserver/media/images/austreiber.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1537,
-      "word": "Feilenbürste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/feilenburste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1073,
-              "image": "http://testserver/media/images/feilenburste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1538,
-      "word": "Flachspanner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/flachspanner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1074,
-              "image": "http://testserver/media/images/flachspanner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1539,
-      "word": "Haarwinkel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/haarwinkel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1075,
-              "image": "http://testserver/media/images/haarwinkel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1540,
-      "word": "Schlichtfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schlichtfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1078,
-              "image": "http://testserver/media/images/schlichtfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1541,
-      "word": "Schlosserfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schlosserfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1079,
-              "image": "http://testserver/media/images/schlosserfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1542,
-      "word": "Senkkopfschraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/senkkopfschraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1080,
-              "image": "http://testserver/media/images/senkkopfschraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1543,
-      "word": "Schruppfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schruppfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1081,
-              "image": "http://testserver/media/images/schruppfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1544,
-      "word": "Spannpratze",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/spannpratze.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1082,
-              "image": "http://testserver/media/images/spannpratze.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1545,
-      "word": "Stahlmaßstab",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/stahlmastab.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1083,
-              "image": "http://testserver/media/images/stahlmastab.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1546,
-      "word": "Vierkantfeile",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/vierkantfeile.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1084,
-              "image": "http://testserver/media/images/vierkantfeile.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1547,
-      "word": "Werkbank",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/werkbank.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1085,
-              "image": "http://testserver/media/images/werkbank.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1555,
-      "word": "Kreide",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kreide.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1087,
-              "image": "http://testserver/media/images/kreide.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1556,
-      "word": "Pinsel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/pinsel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1088,
-              "image": "http://testserver/media/images/pinsel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1557,
-      "word": "Schäferkiste",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schaferkiste.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1089,
-              "image": "http://testserver/media/images/schaferkiste.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1558,
-      "word": "Spiritus",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/spiritus.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1090,
-              "image": "http://testserver/media/images/spiritus.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1559,
-      "word": "Sprühreiniger",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/spruhreiniger.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1091,
-              "image": "http://testserver/media/images/spruhreiniger.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1573,
-      "word": "Sechskantschraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sechskantschraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1599,
-              "image": "http://testserver/media/images/sechskantschraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1594,
-      "word": "Heftklammern",
-      "singular_article": 4,
-      "audio": "http://testserver/media/audio/heftklammern.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1126,
-              "image": "http://testserver/media/images/heftklammern.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1595,
-      "word": "Lagerplatzetikett",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/lagerplatzetikett.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1127,
-              "image": "http://testserver/media/images/lagerplatzetikett.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1596,
-      "word": "Stempel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/stempel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1128,
-              "image": "http://testserver/media/images/stempel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1599,
-      "word": "Stempelkissen",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/stempelkissen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1852,
-              "image": "http://testserver/media/images/stempelkissen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1623,
-      "word": "Dose",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/dose.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1296,
-              "image": "http://testserver/media/images/dose.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1684,
-      "word": "Brandmelder",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/brandmelder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1324,
-              "image": "http://testserver/media/images/brandmelder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1685,
-      "word": "Kapselgehörschutz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kapselgehorschutz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1325,
-              "image": "http://testserver/media/images/kapselgehorschutz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1699,
-      "word": "KFZ-Werkstatt",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kfz-werkstatt.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1346,
-              "image": "http://testserver/media/images/kfz-werkstatt.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1701,
-      "word": "Prüfwerkstatt",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/prufwerkstatt.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1348,
-              "image": "http://testserver/media/images/prufwerkstatt.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1707,
-      "word": "Werkzeugkoffer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/werkzeugkoffer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1584,
-              "image": "http://testserver/media/images/werkzeugkoffer.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1709,
-      "word": "Fahrzeugbrief",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/fahrzeugbrief.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1350,
-              "image": "http://testserver/media/images/fahrzeugbrief.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1711,
-      "word": "Fahrzeugschein",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/fahrzeugschein.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1351,
-              "image": "http://testserver/media/images/fahrzeugschein.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1713,
-      "word": "Feinstaubplakette",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/feinstaubplakette.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1352,
-              "image": "http://testserver/media/images/feinstaubplakette.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1716,
-      "word": "Prüfplakette",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/prufplakette.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1354,
-              "image": "http://testserver/media/images/prufplakette.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1717,
-      "word": "Serviceheft",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/serviceheft.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1355,
-              "image": "http://testserver/media/images/serviceheft.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1718,
-      "word": "Typenschild",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/typenschild.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1356,
-              "image": "http://testserver/media/images/typenschild.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1732,
-      "word": "Beifahrertür",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/beifahrertur.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1369,
-              "image": "http://testserver/media/images/beifahrertur.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1733,
-      "word": "Dachreling",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/dachreling.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1370,
-              "image": "http://testserver/media/images/dachreling.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1734,
-      "word": "Fahrertür",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/fahrertur.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1371,
-              "image": "http://testserver/media/images/fahrertur.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1735,
-      "word": "Fahrzeugfront",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/fahrzeugfront.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1372,
-              "image": "http://testserver/media/images/fahrzeugfront.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1736,
-      "word": "Fahrzeugheck",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/fahrzeugheck.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1373,
-              "image": "http://testserver/media/images/fahrzeugheck.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1737,
-      "word": "Frontscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/frontscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1374,
-              "image": "http://testserver/media/images/frontscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1738,
-      "word": "Kofferraum",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kofferraum.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1376,
-              "image": "http://testserver/media/images/kofferraum.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1739,
-      "word": "Kotflügel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kotflugel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1377,
-              "image": "http://testserver/media/images/kotflugel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1740,
-      "word": "Kühlergrill",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kuhlergrill.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1378,
-              "image": "http://testserver/media/images/kuhlergrill.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1741,
-      "word": "Ladeanschluss",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/ladeanschluss.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1379,
-              "image": "http://testserver/media/images/ladeanschluss.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1742,
-      "word": "Motorhaube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/motorhaube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1380,
-              "image": "http://testserver/media/images/motorhaube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1743,
-      "word": "Motorhaubenschloss",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/motorhaubenschloss.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1381,
-              "image": "http://testserver/media/images/motorhaubenschloss.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1744,
-      "word": "Schweller",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schweller.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1382,
-              "image": "http://testserver/media/images/schweller.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1747,
-      "word": "Türgriff",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/turgriff.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1386,
-              "image": "http://testserver/media/images/turgriff.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1748,
-      "word": "Türschloss",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/turschloss.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1387,
-              "image": "http://testserver/media/images/turschloss.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1754,
-      "word": "Ablagefach",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/ablagefach.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1400,
-              "image": "http://testserver/media/images/ablagefach.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1755,
-      "word": "Airbag",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/airbag.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1398,
-              "image": "http://testserver/media/images/airbag.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1757,
-      "word": "Aschenbecher",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/aschenbecher.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1399,
-              "image": "http://testserver/media/images/aschenbecher.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1758,
-      "word": "Mittelarmlehne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/mittelarmlehne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Armlehne",
-              "singular_article": 2
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1401,
-              "image": "http://testserver/media/images/mittelarmlehne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1761,
-      "word": "Handbremshebel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handbremshebel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1402,
-              "image": "http://testserver/media/images/handbremshebel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1762,
-      "word": "Gurtschloss",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/gurtschloss.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1403,
-              "image": "http://testserver/media/images/gurtschloss.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1763,
-      "word": "Fußraum",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/furaum.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1404,
-              "image": "http://testserver/media/images/furaum.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1767,
-      "word": "Handgriff",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/handgriff.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1408,
-              "image": "http://testserver/media/images/handgriff.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1768,
-      "word": "Handschuhfach",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/handschuhfach.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1409,
-              "image": "http://testserver/media/images/handschuhfach.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1770,
-      "word": "Instrumententafel",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/instrumententafel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1411,
-              "image": "http://testserver/media/images/instrumententafel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1771,
-      "word": "Kofferraumabdeckung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kofferraumabdeckung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1412,
-              "image": "http://testserver/media/images/kofferraumabdeckung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1773,
-      "word": "Kupplungspedal",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kupplungspedal.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1414,
-              "image": "http://testserver/media/images/kupplungspedal.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1776,
-      "word": "Rücksitz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/rucksitz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1417,
-              "image": "http://testserver/media/images/rucksitz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1777,
-      "word": "Schalthebel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schalthebel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1418,
-              "image": "http://testserver/media/images/schalthebel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1779,
-      "word": "Sicherungskasten",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/sicherungskasten.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1420,
-              "image": "http://testserver/media/images/sicherungskasten.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1780,
-      "word": "Sonnenblende",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/sonnenblende.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1421,
-              "image": "http://testserver/media/images/sonnenblende.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1781,
-      "word": "Türöffner",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/turoffner.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1422,
-              "image": "http://testserver/media/images/turoffner.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1783,
-      "word": "Anlasser",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/anlasser.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1426,
-              "image": "http://testserver/media/images/anlasser.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1784,
-      "word": "Batterieklemme",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/batterieklemme.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1427,
-              "image": "http://testserver/media/images/batterieklemme.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1785,
-      "word": "Bremsflüssigkeit",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bremsflussigkeit.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1428,
-              "image": "http://testserver/media/images/bremsflussigkeit.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1786,
-      "word": "Keilriemen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/keilriemen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1429,
-              "image": "http://testserver/media/images/keilriemen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1788,
-      "word": "Kühlflüssigkeit",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/kuhlflussigkeit.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1431,
-              "image": "http://testserver/media/images/kuhlflussigkeit.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1789,
-      "word": "Lichtmaschine",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/lichtmaschine.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1432,
-              "image": "http://testserver/media/images/lichtmaschine.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1792,
-      "word": "Motorabdeckung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/motorabdeckung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1435,
-              "image": "http://testserver/media/images/motorabdeckung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1793,
-      "word": "Ölfilter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/olfilter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1437,
-              "image": "http://testserver/media/images/olfilter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1797,
-      "word": "Waschwasserbehälter",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/waschwasserbehalter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1440,
-              "image": "http://testserver/media/images/waschwasserbehalter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1798,
-      "word": "Zahnriemen",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zahnriemen.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1441,
-              "image": "http://testserver/media/images/zahnriemen.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1799,
-      "word": "Feder",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/feder.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1597,
-              "image": "http://testserver/media/images/feder.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1804,
-      "word": "Abgasendrohr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/abgasendrohr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1453,
-              "image": "http://testserver/media/images/abgasendrohr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1805,
-      "word": "Abgasrohr",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/abgasrohr.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1454,
-              "image": "http://testserver/media/images/abgasrohr.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1807,
-      "word": "Auspuffblende",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/auspuffblende.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1455,
-              "image": "http://testserver/media/images/auspuffblende.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1808,
-      "word": "Auswuchtgewicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/auswuchtgewicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1456,
-              "image": "http://testserver/media/images/auswuchtgewicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1809,
-      "word": "Bremsbelag",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bremsbelag.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1457,
-              "image": "http://testserver/media/images/bremsbelag.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1810,
-      "word": "Bremsleitung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bremsleitung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1458,
-              "image": "http://testserver/media/images/bremsleitung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1811,
-      "word": "Bremssattel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bremssattel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1459,
-              "image": "http://testserver/media/images/bremssattel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1812,
-      "word": "Bremsscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/bremsscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1460,
-              "image": "http://testserver/media/images/bremsscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1813,
-      "word": "Federbein",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/federbein.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1461,
-              "image": "http://testserver/media/images/federbein.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1814,
-      "word": "Felge",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/felge.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1462,
-              "image": "http://testserver/media/images/felge.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1815,
-      "word": "Führungslenker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/fuhrungslenker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1463,
-              "image": "http://testserver/media/images/fuhrungslenker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1818,
-      "word": "Kugelgelenk",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kugelgelenk.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1465,
-              "image": "http://testserver/media/images/kugelgelenk.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1819,
-      "word": "Lambdasonde",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/lambdasonde.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1466,
-              "image": "http://testserver/media/images/lambdasonde.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1820,
-      "word": "Mittelschalldämpfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/mittelschalldampfer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1467,
-              "image": "http://testserver/media/images/mittelschalldampfer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1821,
-      "word": "Ölwanne",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/olwanne.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1468,
-              "image": "http://testserver/media/images/olwanne.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1822,
-      "word": "Radaufhängung",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/radaufhangung.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1469,
-              "image": "http://testserver/media/images/radaufhangung.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1823,
-      "word": "Radmutter",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/radmutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1470,
-              "image": "http://testserver/media/images/radmutter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1824,
-      "word": "Reifenprofil",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/reifenprofil.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1471,
-              "image": "http://testserver/media/images/reifenprofil.png"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1825,
-      "word": "Scheibenbremse",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/scheibenbremse.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1472,
-              "image": "http://testserver/media/images/scheibenbremse.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1826,
-      "word": "Stabilisator",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/stabilisator.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1480,
-              "image": "http://testserver/media/images/stabilisator.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1827,
-      "word": "Stoßdämpfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/stodampfer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1473,
-              "image": "http://testserver/media/images/stodampfer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1830,
-      "word": "Ringschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/ringschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1476,
-              "image": "http://testserver/media/images/ringschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1831,
-      "word": "Kunststoffhammer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/kunststoffhammer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1477,
-              "image": "http://testserver/media/images/kunststoffhammer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1833,
-      "word": "Zündkerzenschlüssel",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/zundkerzenschlussel.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1479,
-              "image": "http://testserver/media/images/zundkerzenschlussel.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1834,
-      "word": "Abblendlicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/abblendlicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1483,
-              "image": "http://testserver/media/images/abblendlicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1835,
-      "word": "Blinklicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/blinklicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1484,
-              "image": "http://testserver/media/images/blinklicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1836,
-      "word": "Bremslicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/bremslicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1485,
-              "image": "http://testserver/media/images/bremslicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1837,
-      "word": "Fernlicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/fernlicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1486,
-              "image": "http://testserver/media/images/fernlicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1839,
-      "word": "Kennzeichenlicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/kennzeichenlicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1488,
-              "image": "http://testserver/media/images/kennzeichenlicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1840,
-      "word": "Rückfahrlicht",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/ruckfahrlicht.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1489,
-              "image": "http://testserver/media/images/ruckfahrlicht.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1841,
-      "word": "Scheinwerfer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/scheinwerfer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1490,
-              "image": "http://testserver/media/images/scheinwerfer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1844,
-      "word": "Bordcomputer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bordcomputer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1491,
-              "image": "http://testserver/media/images/bordcomputer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1845,
-      "word": "Einparkhilfe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/einparkhilfe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1492,
-              "image": "http://testserver/media/images/einparkhilfe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1846,
-      "word": "Hupe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/hupe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1493,
-              "image": "http://testserver/media/images/hupe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1848,
-      "word": "Scheibenwischintervall",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/scheibenwischintervall.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1495,
-              "image": "http://testserver/media/images/scheibenwischintervall.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1850,
-      "word": "Wischautomatik",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/wischautomatik.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1497,
-              "image": "http://testserver/media/images/wischautomatik.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1851,
-      "word": "Gefahrenstofflager",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/gefahrenstofflager.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1498,
-              "image": "http://testserver/media/images/gefahrenstofflager.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1852,
-      "word": "Mundschutz",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/mundschutz.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1499,
-              "image": "http://testserver/media/images/mundschutz.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1857,
-      "word": "Schleifset",
-      "singular_article": 3,
-      "audio": "http://testserver/media/audio/schleifset.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1504,
-              "image": "http://testserver/media/images/schleifset.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1864,
-      "word": "Bandschleifer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/bandschleifer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1516,
-              "image": "http://testserver/media/images/bandschleifer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1874,
-      "word": "Schleifscheibe",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schleifscheibe.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1526,
-              "image": "http://testserver/media/images/schleifscheibe.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1875,
-      "word": "Steinbohrer",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/steinbohrer.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1527,
-              "image": "http://testserver/media/images/steinbohrer.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1887,
-      "word": "Maschinenschraubstock",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/maschinenschraubstock.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1533,
-              "image": "http://testserver/media/images/maschinenschraubstock.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1888,
-      "word": "Schleifblock",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/schleifblock.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1534,
-              "image": "http://testserver/media/images/schleifblock.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1889,
-      "word": "Starkstromstecker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/starkstromstecker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1535,
-              "image": "http://testserver/media/images/starkstromstecker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1896,
-      "word": "D3-Leim",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/d3-leim.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1539,
-              "image": "http://testserver/media/images/d3-leim.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1897,
-      "word": "Einschraubhaken",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/einschraubhaken.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1540,
-              "image": "http://testserver/media/images/einschraubhaken.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1898,
-      "word": "Hutmutter",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/hutmutter.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1541,
-              "image": "http://testserver/media/images/hutmutter.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1900,
-      "word": "Schlossschraube",
-      "singular_article": 2,
-      "audio": "http://testserver/media/audio/schlossschraube.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1543,
-              "image": "http://testserver/media/images/schlossschraube.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 1973,
-      "word": "Textmarker",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/textmarker.mp3",
-      "word_type": "Nomen",
-      "alternatives": [],
-      "document_image": [
-          {
-              "id": 1627,
-              "image": "http://testserver/media/images/textmarker.jpg"
-          }
-      ],
-      "example_sentence": ""
-  },
-  {
-      "id": 2139,
-      "word": "Arbeitsschuh",
-      "singular_article": 1,
-      "audio": "http://testserver/media/audio/arbeitsschuh.mp3",
-      "word_type": "Nomen",
-      "alternatives": [
-          {
-              "alt_word": "Sicherheitsschuh",
-              "singular_article": 1
-          }
-      ],
-      "document_image": [
-          {
-              "id": 1849,
-              "image": "http://testserver/media/images/arbeitsschuh.jpg"
-          }
-      ],
-      "example_sentence": ""
+    "id": 2,
+    "word": "Schere",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schere.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 2,
+        "image": "http://testserver/media/images/schere.jpg"
+      }
+    ],
+    "example_sentence": "Die Schnur mit einer Schere zerschneiden."
+  },
+  {
+    "id": 3,
+    "word": "Schlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 3,
+        "image": "http://testserver/media/images/schlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 4,
+    "word": "Buch",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/buch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 4,
+        "image": "http://testserver/media/images/buch.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 6,
+    "word": "Akkuschrauber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/akkuschrauber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 6,
+        "image": "http://testserver/media/images/akkuschrauber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 7,
+    "word": "Bohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Metallbohrer",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 7,
+        "image": "http://testserver/media/images/bohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 8,
+    "word": "Bohrmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bohrmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Handbohrmaschine",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 746,
+        "image": "http://testserver/media/images/bohrmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 9,
+    "word": "Dübel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/dubel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 9,
+        "image": "http://testserver/media/images/dubel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 10,
+    "word": "Feile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/feile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 10,
+        "image": "http://testserver/media/images/feile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 11,
+    "word": "Gerüst",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/gerust.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 11,
+        "image": "http://testserver/media/images/gerust.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 12,
+    "word": "Leiter",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/leiter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1274,
+        "image": "http://testserver/media/images/leiter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 13,
+    "word": "Maßband",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/maband.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 290,
+        "image": "http://testserver/media/images/maband.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 14,
+    "word": "Meißel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/meiel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 291,
+        "image": "http://testserver/media/images/meiel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 15,
+    "word": "Messer",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/messer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 513,
+        "image": "http://testserver/media/images/messer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 16,
+    "word": "Schubkarre",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schubkarre.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Schubkarren",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 16,
+        "image": "http://testserver/media/images/schubkarre.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 17,
+    "word": "Zollstock",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zollstock.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Meterstab",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Gliedermaßstab",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 828,
+        "image": "http://testserver/media/images/zollstock.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 18,
+    "word": "Arbeitshandschuh",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/arbeitshandschuh.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Handschuh",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 317,
+        "image": "http://testserver/media/images/arbeitshandschuh.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 20,
+    "word": "Besen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/besen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 20,
+        "image": "http://testserver/media/images/besen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 21,
+    "word": "Eimer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/eimer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 21,
+        "image": "http://testserver/media/images/eimer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 22,
+    "word": "Gehörschutz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gehorschutz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1272,
+        "image": "http://testserver/media/images/gehorschutz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 23,
+    "word": "Hammer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/hammer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 23,
+        "image": "http://testserver/media/images/hammer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 24,
+    "word": "Kabeltrommel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kabeltrommel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 237,
+        "image": "http://testserver/media/images/kabeltrommel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 25,
+    "word": "Klebeband",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/klebeband.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 287,
+        "image": "http://testserver/media/images/klebeband.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 26,
+    "word": "Schraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 299,
+        "image": "http://testserver/media/images/schraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 27,
+    "word": "Schraubenzieher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schraubenzieher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Schraubendreher",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 27,
+        "image": "http://testserver/media/images/schraubenzieher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 28,
+    "word": "Schraubenschlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schraubenschlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Ring-Maulschlüssel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1423,
+        "image": "http://testserver/media/images/schraubenschlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 29,
+    "word": "Schutzbrille",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schutzbrille.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Sicherheitsbrille",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 29,
+        "image": "http://testserver/media/images/schutzbrille.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 30,
+    "word": "Schutzhelm",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schutzhelm.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 30,
+        "image": "http://testserver/media/images/schutzhelm.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 31,
+    "word": "Staubsauger",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/staubsauger.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 31,
+        "image": "http://testserver/media/images/staubsauger.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 32,
+    "word": "Wasserwaage",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/wasserwaage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 32,
+        "image": "http://testserver/media/images/wasserwaage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 33,
+    "word": "Abisolierzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/abisolierzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 807,
+        "image": "http://testserver/media/images/abisolierzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 34,
+    "word": "Bohrkrone",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bohrkrone.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 34,
+        "image": "http://testserver/media/images/bohrkrone.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 35,
+    "word": "Crimpzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/crimpzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Aderendhülsenzange",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 446,
+        "image": "http://testserver/media/images/crimpzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 49,
+    "word": "Gipsbecher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gipsbecher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Gipsbecher",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1612,
+        "image": "http://testserver/media/images/gipsbecher.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 66,
+    "word": "Schleifpapier",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/schleifpapier.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 70,
+        "image": "http://testserver/media/images/schleifpapier.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 116,
+    "word": "Seitenschneider",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/seitenschneider.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 121,
+        "image": "http://testserver/media/images/seitenschneider.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 117,
+    "word": "Spannungsprüfer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/spannungsprufer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Duspol",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 122,
+        "image": "http://testserver/media/images/spannungsprufer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 118,
+    "word": "Steckdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/steckdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 123,
+        "image": "http://testserver/media/images/steckdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 119,
+    "word": "Badewanne",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/badewanne.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 124,
+        "image": "http://testserver/media/images/badewanne.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 120,
+    "word": "Doppelmaulschlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/doppelmaulschlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Maulschlüssel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 125,
+        "image": "http://testserver/media/images/doppelmaulschlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 123,
+    "word": "Toilette",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/toilette.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "WC",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 128,
+        "image": "http://testserver/media/images/toilette.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 124,
+    "word": "Waschbecken",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/waschbecken.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 607,
+        "image": "http://testserver/media/images/waschbecken.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 125,
+    "word": "Wasserhahn",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/wasserhahn.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Waschbeckenarmatur",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 130,
+        "image": "http://testserver/media/images/wasserhahn.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 126,
+    "word": "Wasserpumpenzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/wasserpumpenzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 131,
+        "image": "http://testserver/media/images/wasserpumpenzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 132,
+    "word": "Elektrohammer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/elektrohammer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 137,
+        "image": "http://testserver/media/images/elektrohammer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 133,
+    "word": "Spachtel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/spachtel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Spachtel",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Spachtel",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 138,
+        "image": "http://testserver/media/images/spachtel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 135,
+    "word": "Antennendose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/antennendose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 140,
+        "image": "http://testserver/media/images/antennendose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 136,
+    "word": "Kreuzerder",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kreuzerder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 141,
+        "image": "http://testserver/media/images/kreuzerder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 139,
+    "word": "Leuchtmittel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/leuchtmittel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Glühbirne",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 144,
+        "image": "http://testserver/media/images/leuchtmittel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 140,
+    "word": "Arbeitskleidung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/arbeitskleidung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 145,
+        "image": "http://testserver/media/images/arbeitskleidung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 141,
+    "word": "Putzlappen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/putzlappen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Lappen",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Reinigungstuch",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 288,
+        "image": "http://testserver/media/images/putzlappen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 142,
+    "word": "Mülleimer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/mulleimer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Papierkorb",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 255,
+        "image": "http://testserver/media/images/mulleimer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 143,
+    "word": "Bleistift",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bleistift.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 149,
+        "image": "http://testserver/media/images/bleistift.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 144,
+    "word": "Zimmermannsbleistift",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zimmermannsbleistift.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Bleistift",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 150,
+        "image": "http://testserver/media/images/zimmermannsbleistift.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 145,
+    "word": "Werkzeugkiste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/werkzeugkiste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Werkzeugkasten",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1515,
+        "image": "http://testserver/media/images/werkzeugkiste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 146,
+    "word": "Abdeckfolie",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/abdeckfolie.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 449,
+        "image": "http://testserver/media/images/abdeckfolie.png"
+      }
+    ],
+    "example_sentence": "Die Buchsenleiste wurde mit einer Abdeckfolie abgeklebt, um das Beschlagen der Kontakte im Steckbereich während des Lötvorgangs zu vermeiden."
+  },
+  {
+    "id": 151,
+    "word": "Föhn",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/fohn.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Haartrockner",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 655,
+        "image": "http://testserver/media/images/fohn.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 156,
+    "word": "Kamm",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kamm.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 625,
+        "image": "http://testserver/media/images/kamm.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 157,
+    "word": "Spiegel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/spiegel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 164,
+        "image": "http://testserver/media/images/spiegel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 160,
+    "word": "Handbügelsäge",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/handbugelsage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Säge",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 167,
+        "image": "http://testserver/media/images/handbugelsage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 161,
+    "word": "Nageleisen",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/nageleisen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Brechstange",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Kuhfuß",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Brecheisen",
+        "singular_article": 3
+      },
+      {
+        "alt_word": "Hebeleisen",
+        "singular_article": 3
+      },
+      {
+        "alt_word": "Ziegenfuß",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 168,
+        "image": "http://testserver/media/images/nageleisen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 167,
+    "word": "Winkel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/winkel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Schreinerwinkel",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Tischlerwinkel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 175,
+        "image": "http://testserver/media/images/winkel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 175,
+    "word": "Drehmomentschlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/drehmomentschlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Newtonmeterschlüssel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 184,
+        "image": "http://testserver/media/images/drehmomentschlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 181,
+    "word": "Ratsche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/ratsche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Knarre",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 190,
+        "image": "http://testserver/media/images/ratsche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 183,
+    "word": "Schweißgerät",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/schweigerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 192,
+        "image": "http://testserver/media/images/schweigerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 186,
+    "word": "Schürze",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schurze.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 195,
+        "image": "http://testserver/media/images/schurze.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 187,
+    "word": "Ofenhandschuh",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/ofenhandschuh.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 196,
+        "image": "http://testserver/media/images/ofenhandschuh.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 188,
+    "word": "Kittel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kittel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 197,
+        "image": "http://testserver/media/images/kittel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 189,
+    "word": "Backofen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/backofen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 198,
+        "image": "http://testserver/media/images/backofen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 201,
+    "word": "Cutter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/cutter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Cuttermesser",
+        "singular_article": 3
+      },
+      {
+        "alt_word": "Japanmesser",
+        "singular_article": 3
+      },
+      {
+        "alt_word": "Teppichmesser",
+        "singular_article": 0
+      },
+      {
+        "alt_word": "Tapetenmesser",
+        "singular_article": 3
+      },
+      {
+        "alt_word": "Stanley-Messer",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 877,
+        "image": "http://testserver/media/images/cutter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 202,
+    "word": "Betonmischer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/betonmischer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 211,
+        "image": "http://testserver/media/images/betonmischer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 208,
+    "word": "Schaufel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schaufel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 217,
+        "image": "http://testserver/media/images/schaufel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 211,
+    "word": "Sackkarre",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/sackkarre.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Sackkarren",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1118,
+        "image": "http://testserver/media/images/sackkarre.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 214,
+    "word": "Bügelmessschraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bugelmessschraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 223,
+        "image": "http://testserver/media/images/bugelmessschraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 215,
+    "word": "Drehwerkzeug",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/drehwerkzeug.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 224,
+        "image": "http://testserver/media/images/drehwerkzeug.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 216,
+    "word": "universelle Fräsmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/universelle-frasmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "universelle Fräse",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Universalfräsmaschine",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Universalfräse",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1093,
+        "image": "http://testserver/media/images/universelle-frasmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 217,
+    "word": "Grenzlehrdorn",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/grenzlehrdorn.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 226,
+        "image": "http://testserver/media/images/grenzlehrdorn.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 218,
+    "word": "Körner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/korner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Körner",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 227,
+        "image": "http://testserver/media/images/korner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 219,
+    "word": "Messschieber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/messschieber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 228,
+        "image": "http://testserver/media/images/messschieber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 220,
+    "word": "Schweißgeschirr",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/schweigeschirr.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 229,
+        "image": "http://testserver/media/images/schweigeschirr.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 221,
+    "word": "Dusche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/dusche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 230,
+        "image": "http://testserver/media/images/dusche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 223,
+    "word": "Kreissäge",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kreissage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 232,
+        "image": "http://testserver/media/images/kreissage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 224,
+    "word": "Nagel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/nagel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Nägel",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 233,
+        "image": "http://testserver/media/images/nagel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 225,
+    "word": "Pumpenzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/pumpenzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 234,
+        "image": "http://testserver/media/images/pumpenzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 226,
+    "word": "Stichsäge",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/stichsage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 235,
+        "image": "http://testserver/media/images/stichsage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 227,
+    "word": "Zange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/zange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kneifzange",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 236,
+        "image": "http://testserver/media/images/zange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 228,
+    "word": "Akku-Winkelschleifer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/akku-winkelschleifer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Akkuflex",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 238,
+        "image": "http://testserver/media/images/akku-winkelschleifer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 231,
+    "word": "Filzstift",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/filzstift.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Edding",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1558,
+        "image": "http://testserver/media/images/filzstift.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 237,
+    "word": "Handfeger",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/handfeger.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Handbesen",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Kehrbesen",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 247,
+        "image": "http://testserver/media/images/handfeger.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 238,
+    "word": "Isolierband",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/isolierband.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Isolierbänder",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 248,
+        "image": "http://testserver/media/images/isolierband.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 260,
+    "word": "Warnweste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/warnweste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Sicherheitsweste",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 274,
+        "image": "http://testserver/media/images/warnweste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 261,
+    "word": "Arbeitshose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/arbeitshose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 275,
+        "image": "http://testserver/media/images/arbeitshose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 262,
+    "word": "Arbeitsjacke",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/arbeitsjacke.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 276,
+        "image": "http://testserver/media/images/arbeitsjacke.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 263,
+    "word": "Bohrstange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bohrstange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 278,
+        "image": "http://testserver/media/images/bohrstange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 265,
+    "word": "Flachsenker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/flachsenker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 281,
+        "image": "http://testserver/media/images/flachsenker.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 266,
+    "word": "Gewindefräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gewindefraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 282,
+        "image": "http://testserver/media/images/gewindefraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 267,
+    "word": "Gewindeschneider",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gewindeschneider.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 283,
+        "image": "http://testserver/media/images/gewindeschneider.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 268,
+    "word": "Handreibahle",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/handreibahle.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Reibahle",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 284,
+        "image": "http://testserver/media/images/handreibahle.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 269,
+    "word": "Industriestaubsauger",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/industriestaubsauger.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Nass-Trockensauger",
+        "singular_article": 0
+      }
+    ],
+    "document_image": [
+      {
+        "id": 285,
+        "image": "http://testserver/media/images/industriestaubsauger.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 270,
+    "word": "Kegelsenker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kegelsenker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 286,
+        "image": "http://testserver/media/images/kegelsenker.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 271,
+    "word": "Mülltonne",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/mulltonne.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 292,
+        "image": "http://testserver/media/images/mulltonne.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 272,
+    "word": "Nutenfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/nutenfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1001,
+        "image": "http://testserver/media/images/nutenfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 274,
+    "word": "Rändel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/randel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 295,
+        "image": "http://testserver/media/images/randel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 275,
+    "word": "Rohrzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/rohrzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 296,
+        "image": "http://testserver/media/images/rohrzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 276,
+    "word": "Schaftfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schaftfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 297,
+        "image": "http://testserver/media/images/schaftfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 277,
+    "word": "Scheibenfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/scheibenfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 298,
+        "image": "http://testserver/media/images/scheibenfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 280,
+    "word": "Wendeschneidplatte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/wendeschneidplatte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 303,
+        "image": "http://testserver/media/images/wendeschneidplatte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 281,
+    "word": "Winkelfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/winkelfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1011,
+        "image": "http://testserver/media/images/winkelfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 282,
+    "word": "Zentrierbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zentrierbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 306,
+        "image": "http://testserver/media/images/zentrierbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 284,
+    "word": "zweipolige Phasenprüfer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zweipolige-phasenprufer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Phasenprüfer",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 308,
+        "image": "http://testserver/media/images/zweipolige-phasenprufer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 285,
+    "word": "LAN-Tester",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/lan-tester.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "LAN Tester",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 309,
+        "image": "http://testserver/media/images/lan-tester.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 286,
+    "word": "digitale Messschieber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/digitale-messschieber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Messschieber",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 310,
+        "image": "http://testserver/media/images/digitale-messschieber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 290,
+    "word": "NC-Anbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/nc-anbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "NC Anbohrer",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 314,
+        "image": "http://testserver/media/images/nc-anbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 292,
+    "word": "Schlagbohrmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schlagbohrmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 318,
+        "image": "http://testserver/media/images/schlagbohrmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 300,
+    "word": "Kreissägeblatt",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kreissageblatt.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 328,
+        "image": "http://testserver/media/images/kreissageblatt.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 301,
+    "word": "Schlangenbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schlangenbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 329,
+        "image": "http://testserver/media/images/schlangenbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 302,
+    "word": "Langbandschleifmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/langbandschleifmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 330,
+        "image": "http://testserver/media/images/langbandschleifmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 303,
+    "word": "Schleifigel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schleifigel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 331,
+        "image": "http://testserver/media/images/schleifigel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 304,
+    "word": "Schraubstock",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schraubstock.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 332,
+        "image": "http://testserver/media/images/schraubstock.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 309,
+    "word": "Kehrblech",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kehrblech.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kehrschaufel",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 337,
+        "image": "http://testserver/media/images/kehrblech.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 311,
+    "word": "Säbelsägeblatt",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/sabelsageblatt.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 339,
+        "image": "http://testserver/media/images/sabelsageblatt.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 315,
+    "word": "Ständerbohrmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/standerbohrmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1571,
+        "image": "http://testserver/media/images/standerbohrmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 320,
+    "word": "Breitbandschleifmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/breitbandschleifmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 348,
+        "image": "http://testserver/media/images/breitbandschleifmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 322,
+    "word": "Winkelschleifer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/winkelschleifer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Flex",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1446,
+        "image": "http://testserver/media/images/winkelschleifer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 323,
+    "word": "Bithalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bithalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Bitaufnahme",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 351,
+        "image": "http://testserver/media/images/bithalter.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 324,
+    "word": "Bit",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bit.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Bit",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 352,
+        "image": "http://testserver/media/images/bit.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 335,
+    "word": "Exzenterschleifer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/exzenterschleifer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1444,
+        "image": "http://testserver/media/images/exzenterschleifer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 337,
+    "word": "Inbus",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/inbus.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Inbusschlüssel",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Innensechskantschlüssel",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Stiftschlüssel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1482,
+        "image": "http://testserver/media/images/inbus.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 343,
+    "word": "Locher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/locher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 385,
+        "image": "http://testserver/media/images/locher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 350,
+    "word": "Desinfektionsmittel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/desinfektionsmittel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Hand-Desinfektionsmittel",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1027,
+        "image": "http://testserver/media/images/desinfektionsmittel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 360,
+    "word": "Einweghandschuh",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/einweghandschuh.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Einmalhandschuh",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1213,
+        "image": "http://testserver/media/images/einweghandschuh.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 361,
+    "word": "Mund-Nase-Schutz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/mund-nase-schutz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Mund-Nase-Bedeckung",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Mundschutz",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1164,
+        "image": "http://testserver/media/images/mund-nase-schutz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 401,
+    "word": "Kabelentmantler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kabelentmantler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Abmantelwerkzeug",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 723,
+        "image": "http://testserver/media/images/kabelentmantler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 402,
+    "word": "Kabelmesser",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kabelmesser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 782,
+        "image": "http://testserver/media/images/kabelmesser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 403,
+    "word": "Kabelschere",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kabelschere.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 783,
+        "image": "http://testserver/media/images/kabelschere.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 415,
+    "word": "Ordner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/ordner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 384,
+        "image": "http://testserver/media/images/ordner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 418,
+    "word": "Tacker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/tacker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 386,
+        "image": "http://testserver/media/images/tacker.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 419,
+    "word": "Telefon",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/telefon.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 383,
+        "image": "http://testserver/media/images/telefon.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 425,
+    "word": "Kugelschreiber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kugelschreiber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 379,
+        "image": "http://testserver/media/images/kugelschreiber.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 436,
+    "word": "Halbrundfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/halbrundfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1076,
+        "image": "http://testserver/media/images/halbrundfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 438,
+    "word": "Metall-Bügelsäge",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/metall-bugelsage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "PUK-Säge",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 812,
+        "image": "http://testserver/media/images/metall-bugelsage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 441,
+    "word": "Rundfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/rundfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1077,
+        "image": "http://testserver/media/images/rundfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 473,
+    "word": "Dreikantfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/dreikantfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1072,
+        "image": "http://testserver/media/images/dreikantfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 474,
+    "word": "Flachstumpffeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/flachstumpffeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1586,
+        "image": "http://testserver/media/images/flachstumpffeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 476,
+    "word": "Kombinationszange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kombinationszange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kombizange",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 441,
+        "image": "http://testserver/media/images/kombinationszange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 477,
+    "word": "Kraft-Seitenschneider",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kraft-seitenschneider.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 785,
+        "image": "http://testserver/media/images/kraft-seitenschneider.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 484,
+    "word": "Schlosserhammer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schlosserhammer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 814,
+        "image": "http://testserver/media/images/schlosserhammer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 508,
+    "word": "Schwamm",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schwamm.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 800,
+        "image": "http://testserver/media/images/schwamm.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 509,
+    "word": "Spülmittel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/spulmittel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1209,
+        "image": "http://testserver/media/images/spulmittel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 510,
+    "word": "Küchentuch",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kuchentuch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1224,
+        "image": "http://testserver/media/images/kuchentuch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 511,
+    "word": "Geschirrtuch",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/geschirrtuch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Geschirrtücher",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 529,
+        "image": "http://testserver/media/images/geschirrtuch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 512,
+    "word": "Spülbürste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spulburste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1211,
+        "image": "http://testserver/media/images/spulburste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 513,
+    "word": "Spülbecken",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/spulbecken.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1212,
+        "image": "http://testserver/media/images/spulbecken.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 514,
+    "word": "Elektroherd",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/elektroherd.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Herd",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1287,
+        "image": "http://testserver/media/images/elektroherd.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 515,
+    "word": "Herdplatte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/herdplatte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1288,
+        "image": "http://testserver/media/images/herdplatte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 516,
+    "word": "Suppe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/suppe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 668,
+        "image": "http://testserver/media/images/suppe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 518,
+    "word": "Butter",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/butter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 678,
+        "image": "http://testserver/media/images/butter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 522,
+    "word": "Schüssel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 510,
+        "image": "http://testserver/media/images/schussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 523,
+    "word": "Sieb",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/sieb.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 526,
+        "image": "http://testserver/media/images/sieb.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 524,
+    "word": "Topf",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/topf.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 797,
+        "image": "http://testserver/media/images/topf.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 525,
+    "word": "Pfanne",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/pfanne.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 537,
+        "image": "http://testserver/media/images/pfanne.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 528,
+    "word": "Platte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/platte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1308,
+        "image": "http://testserver/media/images/platte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 529,
+    "word": "Salatbesteck",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/salatbesteck.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1281,
+        "image": "http://testserver/media/images/salatbesteck.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 530,
+    "word": "Schale",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schale.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1289,
+        "image": "http://testserver/media/images/schale.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 531,
+    "word": "Flaschenöffner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/flaschenoffner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1282,
+        "image": "http://testserver/media/images/flaschenoffner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 532,
+    "word": "Besteck",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/besteck.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 402,
+        "image": "http://testserver/media/images/besteck.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 533,
+    "word": "Löffel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/loffel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 403,
+        "image": "http://testserver/media/images/loffel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 534,
+    "word": "Gabel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/gabel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 404,
+        "image": "http://testserver/media/images/gabel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 535,
+    "word": "Geschirr",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/geschirr.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 405,
+        "image": "http://testserver/media/images/geschirr.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 536,
+    "word": "Tasse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/tasse.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 471,
+        "image": "http://testserver/media/images/tasse.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 537,
+    "word": "Teller",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/teller.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 407,
+        "image": "http://testserver/media/images/teller.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 538,
+    "word": "Gedeck",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/gedeck.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1611,
+        "image": "http://testserver/media/images/gedeck.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 539,
+    "word": "Unterteller",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/unterteller.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Untertasse",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 520,
+        "image": "http://testserver/media/images/unterteller.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 540,
+    "word": "Flasche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/flasche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 685,
+        "image": "http://testserver/media/images/flasche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 541,
+    "word": "Glas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/glas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 485,
+        "image": "http://testserver/media/images/glas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 542,
+    "word": "Bierglas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bierglas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1596,
+        "image": "http://testserver/media/images/bierglas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 543,
+    "word": "Weinglas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/weinglas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 521,
+        "image": "http://testserver/media/images/weinglas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 544,
+    "word": "Sektglas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/sektglas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 516,
+        "image": "http://testserver/media/images/sektglas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 545,
+    "word": "Schnapsglas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/schnapsglas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 713,
+        "image": "http://testserver/media/images/schnapsglas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 546,
+    "word": "Eierbecher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/eierbecher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 875,
+        "image": "http://testserver/media/images/eierbecher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 547,
+    "word": "Kanne",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kanne.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1310,
+        "image": "http://testserver/media/images/kanne.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 548,
+    "word": "Krug",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/krug.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Karaffe",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 509,
+        "image": "http://testserver/media/images/krug.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 549,
+    "word": "Serviette",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/serviette.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 514,
+        "image": "http://testserver/media/images/serviette.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 553,
+    "word": "Gewindebohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gewindebohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 978,
+        "image": "http://testserver/media/images/gewindebohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 559,
+    "word": "Kreisschneider",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kreisschneider.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1039,
+        "image": "http://testserver/media/images/kreisschneider.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 567,
+    "word": "Spiralbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/spiralbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1587,
+        "image": "http://testserver/media/images/spiralbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 568,
+    "word": "Walzenstirnfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/walzenstirnfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1010,
+        "image": "http://testserver/media/images/walzenstirnfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 589,
+    "word": "Auflaufform",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/auflaufform.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 494,
+        "image": "http://testserver/media/images/auflaufform.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 595,
+    "word": "Tischdecke",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/tischdecke.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1295,
+        "image": "http://testserver/media/images/tischdecke.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 596,
+    "word": "Vase",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/vase.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1249,
+        "image": "http://testserver/media/images/vase.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 599,
+    "word": "Backblech",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/backblech.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 496,
+        "image": "http://testserver/media/images/backblech.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 613,
+    "word": "Schneebesen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schneebesen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Schaumschläger",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 463,
+        "image": "http://testserver/media/images/schneebesen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 617,
+    "word": "Teigschaber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/teigschaber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 454,
+        "image": "http://testserver/media/images/teigschaber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 636,
+    "word": "Butterdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/butterdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1290,
+        "image": "http://testserver/media/images/butterdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 638,
+    "word": "Zuckerspender",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zuckerspender.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 522,
+        "image": "http://testserver/media/images/zuckerspender.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 641,
+    "word": "GN-Behälter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gn-behalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 410,
+        "image": "http://testserver/media/images/gn-behalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 646,
+    "word": "Teeglas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/teeglas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 414,
+        "image": "http://testserver/media/images/teeglas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 649,
+    "word": "Dosenöffner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/dosenoffner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 457,
+        "image": "http://testserver/media/images/dosenoffner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 651,
+    "word": "Pinsel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/pinsel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 719,
+        "image": "http://testserver/media/images/pinsel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 654,
+    "word": "Backpapier",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/backpapier.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 466,
+        "image": "http://testserver/media/images/backpapier.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 656,
+    "word": "Dunstabzugshaube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/dunstabzugshaube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Abzugshaube",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 493,
+        "image": "http://testserver/media/images/dunstabzugshaube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 667,
+    "word": "Kaffeemaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kaffeemaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kaffeebereiter",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 503,
+        "image": "http://testserver/media/images/kaffeemaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 668,
+    "word": "Kühlschrank",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kuhlschrank.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 535,
+        "image": "http://testserver/media/images/kuhlschrank.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 670,
+    "word": "Thermoskanne",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/thermoskanne.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 544,
+        "image": "http://testserver/media/images/thermoskanne.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 671,
+    "word": "Omelett",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/omelett.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 666,
+        "image": "http://testserver/media/images/omelett.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 673,
+    "word": "Spiegelei",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/spiegelei.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 667,
+        "image": "http://testserver/media/images/spiegelei.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 674,
+    "word": "Haferflocken",
+    "article": 4,
+    "singular_article": 4,
+    "audio": "http://testserver/media/audio/haferflocken.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 664,
+        "image": "http://testserver/media/images/haferflocken.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 675,
+    "word": "Rotwein",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/rotwein.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 675,
+        "image": "http://testserver/media/images/rotwein.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 676,
+    "word": "Weißwein",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/weiwein.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 677,
+        "image": "http://testserver/media/images/weiwein.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 678,
+    "word": "Bier",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bier.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 670,
+        "image": "http://testserver/media/images/bier.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 679,
+    "word": "Eistee",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/eistee.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 671,
+        "image": "http://testserver/media/images/eistee.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 680,
+    "word": "Saft",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/saft.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 676,
+        "image": "http://testserver/media/images/saft.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 681,
+    "word": "Eiswürfel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/eiswurfel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 672,
+        "image": "http://testserver/media/images/eiswurfel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 682,
+    "word": "Honig",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/honig.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 679,
+        "image": "http://testserver/media/images/honig.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 683,
+    "word": "Marmelade",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/marmelade.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 681,
+        "image": "http://testserver/media/images/marmelade.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 685,
+    "word": "Tee",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/tee.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 682,
+        "image": "http://testserver/media/images/tee.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 686,
+    "word": "Teebeutel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/teebeutel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 683,
+        "image": "http://testserver/media/images/teebeutel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 687,
+    "word": "Kaffee",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kaffee.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 680,
+        "image": "http://testserver/media/images/kaffee.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 688,
+    "word": "Kaffeefilter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kaffeefilter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 504,
+        "image": "http://testserver/media/images/kaffeefilter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 689,
+    "word": "Milch",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/milch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 674,
+        "image": "http://testserver/media/images/milch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 691,
+    "word": "Öl",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/ol.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 673,
+        "image": "http://testserver/media/images/ol.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 692,
+    "word": "Müsli",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/musli.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 665,
+        "image": "http://testserver/media/images/musli.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 693,
+    "word": "Zahnstocher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zahnstocher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1390,
+        "image": "http://testserver/media/images/zahnstocher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 698,
+    "word": "Korkenzieher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/korkenzieher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 798,
+        "image": "http://testserver/media/images/korkenzieher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 700,
+    "word": "Chafing-Dish",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/chafing-dish.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 499,
+        "image": "http://testserver/media/images/chafing-dish.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 701,
+    "word": "Cocktailglas",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/cocktailglas.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 500,
+        "image": "http://testserver/media/images/cocktailglas.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 702,
+    "word": "Espressotasse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/espressotasse.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 501,
+        "image": "http://testserver/media/images/espressotasse.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 703,
+    "word": "Kaffeelöffel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kaffeeloffel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 505,
+        "image": "http://testserver/media/images/kaffeeloffel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 704,
+    "word": "Kuchengabel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kuchengabel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 511,
+        "image": "http://testserver/media/images/kuchengabel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 705,
+    "word": "Kaffeeportionierer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kaffeeportionierer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 506,
+        "image": "http://testserver/media/images/kaffeeportionierer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 706,
+    "word": "Kuchenteller",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kuchenteller.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 832,
+        "image": "http://testserver/media/images/kuchenteller.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 707,
+    "word": "Schieferplatte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schieferplatte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Schieferplatten",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 515,
+        "image": "http://testserver/media/images/schieferplatte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 709,
+    "word": "Suppenteller",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/suppenteller.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 518,
+        "image": "http://testserver/media/images/suppenteller.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 710,
+    "word": "Kaffeetasse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kaffeetasse.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 507,
+        "image": "http://testserver/media/images/kaffeetasse.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 713,
+    "word": "Bodenwischgerät",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bodenwischgerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1854,
+        "image": "http://testserver/media/images/bodenwischgerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 714,
+    "word": "Papierhandtuch",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/papierhandtuch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 583,
+        "image": "http://testserver/media/images/papierhandtuch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 715,
+    "word": "Papierhandtuchspender",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/papierhandtuchspender.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 584,
+        "image": "http://testserver/media/images/papierhandtuchspender.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 716,
+    "word": "Reinigungsbürste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/reinigungsburste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 801,
+        "image": "http://testserver/media/images/reinigungsburste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 717,
+    "word": "Reinigungshandschuh",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/reinigungshandschuh.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Spülhandschuh",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1240,
+        "image": "http://testserver/media/images/reinigungshandschuh.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 718,
+    "word": "Reinigungsmittel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/reinigungsmittel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1214,
+        "image": "http://testserver/media/images/reinigungsmittel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 719,
+    "word": "Reinigungswagen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/reinigungswagen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1263,
+        "image": "http://testserver/media/images/reinigungswagen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 720,
+    "word": "Seifenspender",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/seifenspender.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 587,
+        "image": "http://testserver/media/images/seifenspender.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 721,
+    "word": "Sprühflasche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spruhflasche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 650,
+        "image": "http://testserver/media/images/spruhflasche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 723,
+    "word": "Staubsaugerbeutel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/staubsaugerbeutel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1219,
+        "image": "http://testserver/media/images/staubsaugerbeutel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 724,
+    "word": "Wischbezug",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/wischbezug.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1220,
+        "image": "http://testserver/media/images/wischbezug.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 726,
+    "word": "Bademantel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bademantel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1279,
+        "image": "http://testserver/media/images/bademantel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 727,
+    "word": "Badezimmer",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/badezimmer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 569,
+        "image": "http://testserver/media/images/badezimmer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 728,
+    "word": "Balkon",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/balkon.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1237,
+        "image": "http://testserver/media/images/balkon.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 729,
+    "word": "Bettdecke",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bettdecke.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 565,
+        "image": "http://testserver/media/images/bettdecke.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 730,
+    "word": "Bettwäsche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bettwasche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 714,
+        "image": "http://testserver/media/images/bettwasche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 731,
+    "word": "Doppelbett",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/doppelbett.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 566,
+        "image": "http://testserver/media/images/doppelbett.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 732,
+    "word": "Duschkopf",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/duschkopf.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 567,
+        "image": "http://testserver/media/images/duschkopf.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 733,
+    "word": "Einzelbett",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/einzelbett.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 568,
+        "image": "http://testserver/media/images/einzelbett.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 734,
+    "word": "Fenster",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/fenster.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 434,
+        "image": "http://testserver/media/images/fenster.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 735,
+    "word": "Fernbedienung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/fernbedienung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 715,
+        "image": "http://testserver/media/images/fernbedienung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 736,
+    "word": "Fernseher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/fernseher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 580,
+        "image": "http://testserver/media/images/fernseher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 738,
+    "word": "Garderobe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/garderobe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 572,
+        "image": "http://testserver/media/images/garderobe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 739,
+    "word": "Gardine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/gardine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1254,
+        "image": "http://testserver/media/images/gardine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 740,
+    "word": "Handtuch",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/handtuch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 796,
+        "image": "http://testserver/media/images/handtuch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 741,
+    "word": "Handtuchhalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/handtuchhalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 574,
+        "image": "http://testserver/media/images/handtuchhalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 742,
+    "word": "Handtuchstange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/handtuchstange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 575,
+        "image": "http://testserver/media/images/handtuchstange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 743,
+    "word": "Hoteltresor",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/hoteltresor.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Hotelsafe",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Zimmersafe",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Zimmertresor",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 592,
+        "image": "http://testserver/media/images/hoteltresor.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 745,
+    "word": "Kleiderbügel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kleiderbugel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1216,
+        "image": "http://testserver/media/images/kleiderbugel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 746,
+    "word": "Kleiderschrank",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kleiderschrank.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 576,
+        "image": "http://testserver/media/images/kleiderschrank.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 747,
+    "word": "Klimaanlagenregler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/klimaanlagenregler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 577,
+        "image": "http://testserver/media/images/klimaanlagenregler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 748,
+    "word": "Kopfkissen",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kopfkissen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 578,
+        "image": "http://testserver/media/images/kopfkissen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 749,
+    "word": "Minibar",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/minibar.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 581,
+        "image": "http://testserver/media/images/minibar.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 750,
+    "word": "Nachttisch",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/nachttisch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Nachtkästchen",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 582,
+        "image": "http://testserver/media/images/nachttisch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 751,
+    "word": "Rasierapparat",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/rasierapparat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1217,
+        "image": "http://testserver/media/images/rasierapparat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 753,
+    "word": "Toilettenbürste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/toilettenburste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 589,
+        "image": "http://testserver/media/images/toilettenburste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 754,
+    "word": "Toilettenpapier",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/toilettenpapier.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 716,
+        "image": "http://testserver/media/images/toilettenpapier.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 755,
+    "word": "Toilettenpapierhalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/toilettenpapierhalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 590,
+        "image": "http://testserver/media/images/toilettenpapierhalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 756,
+    "word": "Wasserkocher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/wasserkocher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1228,
+        "image": "http://testserver/media/images/wasserkocher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 757,
+    "word": "Zahnbürste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/zahnburste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 651,
+        "image": "http://testserver/media/images/zahnburste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 758,
+    "word": "Zahnpasta",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/zahnpasta.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 718,
+        "image": "http://testserver/media/images/zahnpasta.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 759,
+    "word": "EC-Karte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/ec-karte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "EC-Karten",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 436,
+        "image": "http://testserver/media/images/ec-karte.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 761,
+    "word": "Gepäck",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/gepack.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1396,
+        "image": "http://testserver/media/images/gepack.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 762,
+    "word": "Gepäckwagen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gepackwagen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 558,
+        "image": "http://testserver/media/images/gepackwagen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 764,
+    "word": "Koffer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/koffer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1397,
+        "image": "http://testserver/media/images/koffer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 765,
+    "word": "Kreditkarte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kreditkarte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kreditkarten",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 437,
+        "image": "http://testserver/media/images/kreditkarte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 766,
+    "word": "Parkplatz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/parkplatz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1236,
+        "image": "http://testserver/media/images/parkplatz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 767,
+    "word": "Rezeption",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/rezeption.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 551,
+        "image": "http://testserver/media/images/rezeption.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 768,
+    "word": "Rezeptionsglocke",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/rezeptionsglocke.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1395,
+        "image": "http://testserver/media/images/rezeptionsglocke.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 769,
+    "word": "Sicherheitsnadel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/sicherheitsnadel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1283,
+        "image": "http://testserver/media/images/sicherheitsnadel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 771,
+    "word": "Streichholz",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/streichholz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1284,
+        "image": "http://testserver/media/images/streichholz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 772,
+    "word": "Tasche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/tasche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1234,
+        "image": "http://testserver/media/images/tasche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 773,
+    "word": "Trolley",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/trolley.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 432,
+        "image": "http://testserver/media/images/trolley.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 776,
+    "word": "Waschmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/waschmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1153,
+        "image": "http://testserver/media/images/waschmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 778,
+    "word": "Waschmittel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/waschmittel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1242,
+        "image": "http://testserver/media/images/waschmittel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 779,
+    "word": "Wäscheständer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/waschestander.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1842,
+        "image": "http://testserver/media/images/waschestander.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 780,
+    "word": "Wäscheklammer",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/wascheklammer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1243,
+        "image": "http://testserver/media/images/wascheklammer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 782,
+    "word": "Waschgang",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/waschgang.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1244,
+        "image": "http://testserver/media/images/waschgang.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 783,
+    "word": "Schleuderzahl",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schleuderzahl.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1245,
+        "image": "http://testserver/media/images/schleuderzahl.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 784,
+    "word": "Pflegeetikett",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/pflegeetikett.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1246,
+        "image": "http://testserver/media/images/pflegeetikett.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 786,
+    "word": "Seife",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/seife.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1225,
+        "image": "http://testserver/media/images/seife.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 908,
+    "word": "Handtacker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/handtacker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 439,
+        "image": "http://testserver/media/images/handtacker.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 909,
+    "word": "Winkelmesser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/winkelmesser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 990,
+        "image": "http://testserver/media/images/winkelmesser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 912,
+    "word": "Vorhängeschloss",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/vorhangeschloss.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 417,
+        "image": "http://testserver/media/images/vorhangeschloss.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 932,
+    "word": "Bogenzirkel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bogenzirkel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Zirkel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 991,
+        "image": "http://testserver/media/images/bogenzirkel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 937,
+    "word": "Flachzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/flachzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 771,
+        "image": "http://testserver/media/images/flachzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 938,
+    "word": "Gripzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/gripzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1031,
+        "image": "http://testserver/media/images/gripzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 945,
+    "word": "Schlagschnur",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schlagschnur.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 945,
+        "image": "http://testserver/media/images/schlagschnur.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 953,
+    "word": "Schraubenziehersatz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schraubenziehersatz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 419,
+        "image": "http://testserver/media/images/schraubenziehersatz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 954,
+    "word": "Holzbock",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/holzbock.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1607,
+        "image": "http://testserver/media/images/holzbock.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 955,
+    "word": "Spitzzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spitzzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 418,
+        "image": "http://testserver/media/images/spitzzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 958,
+    "word": "Staubsaugerfilter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/staubsaugerfilter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Filter",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Lamellenfilter",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1840,
+        "image": "http://testserver/media/images/staubsaugerfilter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 959,
+    "word": "Schlauch",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schlauch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1573,
+        "image": "http://testserver/media/images/schlauch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 961,
+    "word": "Anschlagwinkel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/anschlagwinkel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 443,
+        "image": "http://testserver/media/images/anschlagwinkel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 964,
+    "word": "Drehmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/drehmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "konventionelle Drehmaschine",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1037,
+        "image": "http://testserver/media/images/drehmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 980,
+    "word": "Bargeld",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bargeld.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 435,
+        "image": "http://testserver/media/images/bargeld.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1005,
+    "word": "Erste-Hilfe-Koffer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/erste-hilfe-koffer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 547,
+        "image": "http://testserver/media/images/erste-hilfe-koffer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1006,
+    "word": "Feuerlöscher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/feuerloscher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 488,
+        "image": "http://testserver/media/images/feuerloscher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1023,
+    "word": "Bett",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bett.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1256,
+        "image": "http://testserver/media/images/bett.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1034,
+    "word": "Lichtschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/lichtschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 803,
+        "image": "http://testserver/media/images/lichtschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1049,
+    "word": "Geldschein",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/geldschein.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 687,
+        "image": "http://testserver/media/images/geldschein.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1050,
+    "word": "Münze",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/munze.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 688,
+        "image": "http://testserver/media/images/munze.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1111,
+    "word": "Backrost",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/backrost.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Rost",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 497,
+        "image": "http://testserver/media/images/backrost.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1113,
+    "word": "Kaffeevollautomat",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kaffeevollautomat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kaffeemaschine",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 508,
+        "image": "http://testserver/media/images/kaffeevollautomat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1115,
+    "word": "Servierteller",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/servierteller.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 517,
+        "image": "http://testserver/media/images/servierteller.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1116,
+    "word": "Tumbler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/tumbler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 519,
+        "image": "http://testserver/media/images/tumbler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1117,
+    "word": "Warmhalterost",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/warmhalterost.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 523,
+        "image": "http://testserver/media/images/warmhalterost.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1118,
+    "word": "Desinfektionsmittelspender",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/desinfektionsmittelspender.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 524,
+        "image": "http://testserver/media/images/desinfektionsmittelspender.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1119,
+    "word": "Käsebrett",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kasebrett.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 531,
+        "image": "http://testserver/media/images/kasebrett.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1122,
+    "word": "Rührschüssel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/ruhrschussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 539,
+        "image": "http://testserver/media/images/ruhrschussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1123,
+    "word": "Ceranfeldschaber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/ceranfeldschaber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 540,
+        "image": "http://testserver/media/images/ceranfeldschaber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1126,
+    "word": "Topflappen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/topflappen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1280,
+        "image": "http://testserver/media/images/topflappen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1127,
+    "word": "Defibrillator",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/defibrillator.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 548,
+        "image": "http://testserver/media/images/defibrillator.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1128,
+    "word": "Notfallplan",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/notfallplan.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 549,
+        "image": "http://testserver/media/images/notfallplan.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1129,
+    "word": "Notausgang",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/notausgang.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 550,
+        "image": "http://testserver/media/images/notausgang.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1136,
+    "word": "Garderobenständer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/garderobenstander.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 559,
+        "image": "http://testserver/media/images/garderobenstander.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1138,
+    "word": "Telefonanlage",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/telefonanlage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 561,
+        "image": "http://testserver/media/images/telefonanlage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1139,
+    "word": "Sitzgruppe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/sitzgruppe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 562,
+        "image": "http://testserver/media/images/sitzgruppe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1142,
+    "word": "Fliese",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/fliese.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 570,
+        "image": "http://testserver/media/images/fliese.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1143,
+    "word": "Flurschild",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/flurschild.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 571,
+        "image": "http://testserver/media/images/flurschild.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1144,
+    "word": "Kosmetikmülleimer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kosmetikmulleimer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 579,
+        "image": "http://testserver/media/images/kosmetikmulleimer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1145,
+    "word": "Schließzylinder",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schliezylinder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 586,
+        "image": "http://testserver/media/images/schliezylinder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1146,
+    "word": "Sicherheitssteckdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/sicherheitssteckdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 588,
+        "image": "http://testserver/media/images/sicherheitssteckdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1147,
+    "word": "Waschtisch",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/waschtisch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1569,
+        "image": "http://testserver/media/images/waschtisch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1148,
+    "word": "Türschild",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/turschild.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 591,
+        "image": "http://testserver/media/images/turschild.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1149,
+    "word": "Badregal",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/badregal.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1570,
+        "image": "http://testserver/media/images/badregal.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1197,
+    "word": "Mikrowelle",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/mikrowelle.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 663,
+        "image": "http://testserver/media/images/mikrowelle.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1198,
+    "word": "Küchenmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kuchenmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 661,
+        "image": "http://testserver/media/images/kuchenmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1199,
+    "word": "Gasherd",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gasherd.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 662,
+        "image": "http://testserver/media/images/gasherd.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1200,
+    "word": "Bierkrug",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bierkrug.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 669,
+        "image": "http://testserver/media/images/bierkrug.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1203,
+    "word": "Abstandschelle",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/abstandschelle.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 724,
+        "image": "http://testserver/media/images/abstandschelle.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1204,
+    "word": "Abzweigdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/abzweigdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 725,
+        "image": "http://testserver/media/images/abzweigdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1205,
+    "word": "Aderendhülse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/aderendhulse.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Aderendhülsen",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 726,
+        "image": "http://testserver/media/images/aderendhulse.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1206,
+    "word": "Aderleitung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/aderleitung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 727,
+        "image": "http://testserver/media/images/aderleitung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1207,
+    "word": "Alarmleuchte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/alarmleuchte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 728,
+        "image": "http://testserver/media/images/alarmleuchte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1208,
+    "word": "Analogmessgerät",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/analogmessgerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 729,
+        "image": "http://testserver/media/images/analogmessgerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1209,
+    "word": "Anlagenmessgerät",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/anlagenmessgerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 730,
+        "image": "http://testserver/media/images/anlagenmessgerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1210,
+    "word": "Anschlussdatenbezeichnung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/anschlussdatenbezeichnung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 731,
+        "image": "http://testserver/media/images/anschlussdatenbezeichnung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1211,
+    "word": "Baustrahler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/baustrahler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 732,
+        "image": "http://testserver/media/images/baustrahler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1212,
+    "word": "Aufputzinstallation",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/aufputzinstallation.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 733,
+        "image": "http://testserver/media/images/aufputzinstallation.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1213,
+    "word": "Aufputzinstallationsrohr",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/aufputzinstallationsrohr.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 734,
+        "image": "http://testserver/media/images/aufputzinstallationsrohr.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1214,
+    "word": "Audiosignal",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/audiosignal.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 735,
+        "image": "http://testserver/media/images/audiosignal.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1215,
+    "word": "Außengewinde",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/auengewinde.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 737,
+        "image": "http://testserver/media/images/auengewinde.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1216,
+    "word": "Bananenstecker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bananenstecker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 738,
+        "image": "http://testserver/media/images/bananenstecker.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1217,
+    "word": "Batterie",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/batterie.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 739,
+        "image": "http://testserver/media/images/batterie.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1218,
+    "word": "Baustromverteiler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/baustromverteiler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 740,
+        "image": "http://testserver/media/images/baustromverteiler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1219,
+    "word": "Bedienfeld",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bedienfeld.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 741,
+        "image": "http://testserver/media/images/bedienfeld.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1220,
+    "word": "Betoninstallationsrohr",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/betoninstallationsrohr.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 742,
+        "image": "http://testserver/media/images/betoninstallationsrohr.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1221,
+    "word": "Bohrfutter",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bohrfutter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 743,
+        "image": "http://testserver/media/images/bohrfutter.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1222,
+    "word": "Bohrfutterschlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bohrfutterschlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 744,
+        "image": "http://testserver/media/images/bohrfutterschlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1223,
+    "word": "Bohrloch",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bohrloch.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Bohrlöcher",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 745,
+        "image": "http://testserver/media/images/bohrloch.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1224,
+    "word": "Brandschutzschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/brandschutzschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 747,
+        "image": "http://testserver/media/images/brandschutzschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1225,
+    "word": "Brüstungskanal",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/brustungskanal.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 748,
+        "image": "http://testserver/media/images/brustungskanal.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1226,
+    "word": "Bügelgehörschutz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bugelgehorschutz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 749,
+        "image": "http://testserver/media/images/bugelgehorschutz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1227,
+    "word": "Dämmerungsschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/dammerungsschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 750,
+        "image": "http://testserver/media/images/dammerungsschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1228,
+    "word": "Deckenleuchte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/deckenleuchte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 751,
+        "image": "http://testserver/media/images/deckenleuchte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1229,
+    "word": "Dimmer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/dimmer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 752,
+        "image": "http://testserver/media/images/dimmer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1230,
+    "word": "Dosenklemme",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/dosenklemme.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Dosenklemmen",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 753,
+        "image": "http://testserver/media/images/dosenklemme.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1231,
+    "word": "Draht",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/draht.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 754,
+        "image": "http://testserver/media/images/draht.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1232,
+    "word": "Dreheisenmessgerät",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/dreheisenmessgerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 755,
+        "image": "http://testserver/media/images/dreheisenmessgerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1233,
+    "word": "Drehfeldmessgerät",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/drehfeldmessgerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 756,
+        "image": "http://testserver/media/images/drehfeldmessgerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1234,
+    "word": "Drehschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/drehschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 757,
+        "image": "http://testserver/media/images/drehschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1236,
+    "word": "Druckschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/druckschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 758,
+        "image": "http://testserver/media/images/druckschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1237,
+    "word": "Durchbruchbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/durchbruchbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 759,
+        "image": "http://testserver/media/images/durchbruchbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1238,
+    "word": "Durchgangsprüfer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/durchgangsprufer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 760,
+        "image": "http://testserver/media/images/durchgangsprufer.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1239,
+    "word": "E-Check",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/e-check.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Elektro-Check",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "elektrische Sicherheitsprüfung",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 761,
+        "image": "http://testserver/media/images/e-check.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1240,
+    "word": "Elektrikergips",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/elektrikergips.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Elektriker-Gips",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 762,
+        "image": "http://testserver/media/images/elektrikergips.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1241,
+    "word": "elektrische Verteiler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/elektrische-verteiler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Verteilung",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Sicherungskasten",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Verteilerkasten",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 763,
+        "image": "http://testserver/media/images/elektrische-verteiler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1242,
+    "word": "Elektroinstallation",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/elektroinstallation.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 764,
+        "image": "http://testserver/media/images/elektroinstallation.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1243,
+    "word": "Elektrosäge",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/elektrosage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 765,
+        "image": "http://testserver/media/images/elektrosage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1244,
+    "word": "Elektroschere",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/elektroschere.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 766,
+        "image": "http://testserver/media/images/elektroschere.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1246,
+    "word": "Entlötpumpe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/entlotpumpe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 768,
+        "image": "http://testserver/media/images/entlotpumpe.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1247,
+    "word": "Eurostecker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/eurostecker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 769,
+        "image": "http://testserver/media/images/eurostecker.jpg"
+      }
+    ],
+    "example_sentence": "Das Netzteil ist versehen mit einem Eurostecker für den direkten Anschluss an eine Schuko-Steckdose und verfügt über eine 3m lange Zuleitung."
+  },
+  {
+    "id": 1249,
+    "word": "Flachmeißel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/flachmeiel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1574,
+        "image": "http://testserver/media/images/flachmeiel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1250,
+    "word": "Flachrundzange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/flachrundzange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 770,
+        "image": "http://testserver/media/images/flachrundzange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1252,
+    "word": "Gehörstöpsel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gehorstopsel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Gehörschutzstöpsel",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Ohrenstöpsel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 772,
+        "image": "http://testserver/media/images/gehorstopsel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1253,
+    "word": "Heißklebepistole",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/heiklebepistole.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 773,
+        "image": "http://testserver/media/images/heiklebepistole.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1254,
+    "word": "Heißluftgebläse",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/heiluftgeblase.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 774,
+        "image": "http://testserver/media/images/heiluftgeblase.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1255,
+    "word": "Hygrometer",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/hygrometer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 775,
+        "image": "http://testserver/media/images/hygrometer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1256,
+    "word": "Infrarotstrahler",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/infrarotstrahler.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 776,
+        "image": "http://testserver/media/images/infrarotstrahler.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1257,
+    "word": "Innengewinde",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/innengewinde.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 777,
+        "image": "http://testserver/media/images/innengewinde.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1258,
+    "word": "inverte Stromerzeuger",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/inverte-stromerzeuger.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 778,
+        "image": "http://testserver/media/images/inverte-stromerzeuger.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1259,
+    "word": "Kabel",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kabel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 779,
+        "image": "http://testserver/media/images/kabel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1260,
+    "word": "Kabelbinder",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kabelbinder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 780,
+        "image": "http://testserver/media/images/kabelbinder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1261,
+    "word": "Kabeleinziehsystem",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kabeleinziehsystem.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 781,
+        "image": "http://testserver/media/images/kabeleinziehsystem.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1263,
+    "word": "Kraftstromsteckdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kraftstromsteckdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 786,
+        "image": "http://testserver/media/images/kraftstromsteckdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1264,
+    "word": "Kuparohr",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kuparohr.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kuparohre",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 787,
+        "image": "http://testserver/media/images/kuparohr.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1265,
+    "word": "Litzenleitung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/litzenleitung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 788,
+        "image": "http://testserver/media/images/litzenleitung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1266,
+    "word": "Lochsäge",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/lochsage.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 789,
+        "image": "http://testserver/media/images/lochsage.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1267,
+    "word": "Lötkolben",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/lotkolben.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1278,
+        "image": "http://testserver/media/images/lotkolben.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1268,
+    "word": "Lötset",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/lotset.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 790,
+        "image": "http://testserver/media/images/lotset.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1270,
+    "word": "Lötstation",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/lotstation.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 791,
+        "image": "http://testserver/media/images/lotstation.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1271,
+    "word": "Lötstelle",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/lotstelle.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Lötstellen",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 792,
+        "image": "http://testserver/media/images/lotstelle.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1272,
+    "word": "Lötzinn",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/lotzinn.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 793,
+        "image": "http://testserver/media/images/lotzinn.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1273,
+    "word": "LSA-Plus-Auflegewerkzeug",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/lsa-plus-auflegewerkzeug.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "LSA-Plus-Anlegewerkzeug",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 794,
+        "image": "http://testserver/media/images/lsa-plus-auflegewerkzeug.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1274,
+    "word": "Mauernutfräse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/mauernutfrase.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 808,
+        "image": "http://testserver/media/images/mauernutfrase.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1275,
+    "word": "Metalldetektor",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/metalldetektor.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 809,
+        "image": "http://testserver/media/images/metalldetektor.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1276,
+    "word": "Netzteil",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/netzteil.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 810,
+        "image": "http://testserver/media/images/netzteil.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1277,
+    "word": "Phasenprüfer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/phasenprufer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 811,
+        "image": "http://testserver/media/images/phasenprufer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1278,
+    "word": "Doppelringschlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/doppelringschlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1575,
+        "image": "http://testserver/media/images/doppelringschlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1279,
+    "word": "Ringmaulschlüssel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/ringmaulschlussel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Maulringschlüssel",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1576,
+        "image": "http://testserver/media/images/ringmaulschlussel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1280,
+    "word": "Schleifenimpedanzmessgerät",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/schleifenimpedanzmessgerat.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 813,
+        "image": "http://testserver/media/images/schleifenimpedanzmessgerat.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1281,
+    "word": "Schraubenkopf",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schraubenkopf.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 815,
+        "image": "http://testserver/media/images/schraubenkopf.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1282,
+    "word": "Schraubenmutter",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schraubenmutter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Mutter",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 816,
+        "image": "http://testserver/media/images/schraubenmutter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1283,
+    "word": "Schutzschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schutzschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 817,
+        "image": "http://testserver/media/images/schutzschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1284,
+    "word": "Signalband",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/signalband.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 818,
+        "image": "http://testserver/media/images/signalband.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1286,
+    "word": "Stabschrauber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/stabschrauber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 819,
+        "image": "http://testserver/media/images/stabschrauber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1287,
+    "word": "Starkstromleitung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/starkstromleitung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Starkstromleitungen",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 820,
+        "image": "http://testserver/media/images/starkstromleitung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1288,
+    "word": "Steckverbinder",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/steckverbinder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Steckverbinder",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 821,
+        "image": "http://testserver/media/images/steckverbinder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1289,
+    "word": "Störlichtbogen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/storlichtbogen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 822,
+        "image": "http://testserver/media/images/storlichtbogen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1290,
+    "word": "Strommesszange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/strommesszange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 823,
+        "image": "http://testserver/media/images/strommesszange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1291,
+    "word": "Transformator",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/transformator.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 824,
+        "image": "http://testserver/media/images/transformator.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1292,
+    "word": "Trockenbauwand",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/trockenbauwand.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Unterputzinstallation",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 825,
+        "image": "http://testserver/media/images/trockenbauwand.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1293,
+    "word": "Unterputzdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/unterputzdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 826,
+        "image": "http://testserver/media/images/unterputzdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1297,
+    "word": "Schaltplan",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schaltplan.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 829,
+        "image": "http://testserver/media/images/schaltplan.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1298,
+    "word": "Nut",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/nut.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Nute",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 830,
+        "image": "http://testserver/media/images/nut.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1299,
+    "word": "Kondensator",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kondensator.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 831,
+        "image": "http://testserver/media/images/kondensator.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1300,
+    "word": "Atom",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/atom.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 833,
+        "image": "http://testserver/media/images/atom.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1304,
+    "word": "Atomstrom",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/atomstrom.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 837,
+        "image": "http://testserver/media/images/atomstrom.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1306,
+    "word": "Außenleiter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/auenleiter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 839,
+        "image": "http://testserver/media/images/auenleiter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1309,
+    "word": "Neutralleiter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/neutralleiter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 842,
+        "image": "http://testserver/media/images/neutralleiter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1328,
+    "word": "Abfallstrom",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/abfallstrom.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 861,
+        "image": "http://testserver/media/images/abfallstrom.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1329,
+    "word": "Amplitude",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/amplitude.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 862,
+        "image": "http://testserver/media/images/amplitude.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1330,
+    "word": "Dreiphasenwechselstrom",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/dreiphasenwechselstrom.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 863,
+        "image": "http://testserver/media/images/dreiphasenwechselstrom.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1331,
+    "word": "Gleichstrom",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gleichstrom.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 864,
+        "image": "http://testserver/media/images/gleichstrom.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1332,
+    "word": "Wechselstrom",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/wechselstrom.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 865,
+        "image": "http://testserver/media/images/wechselstrom.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1333,
+    "word": "Anode",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/anode.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 866,
+        "image": "http://testserver/media/images/anode.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1334,
+    "word": "Kathode",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kathode.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 867,
+        "image": "http://testserver/media/images/kathode.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1335,
+    "word": "Leitung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/leitung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 868,
+        "image": "http://testserver/media/images/leitung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1337,
+    "word": "Stromkreis",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/stromkreis.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 870,
+        "image": "http://testserver/media/images/stromkreis.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1339,
+    "word": "Verbraucher",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/verbraucher.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 872,
+        "image": "http://testserver/media/images/verbraucher.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1375,
+    "word": "Beipackzettel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/beipackzettel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 891,
+        "image": "http://testserver/media/images/beipackzettel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1424,
+    "word": "Schwingschleifer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schwingschleifer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 947,
+        "image": "http://testserver/media/images/schwingschleifer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1426,
+    "word": "Sicherung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/sicherung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 949,
+        "image": "http://testserver/media/images/sicherung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1428,
+    "word": "Sondermüll",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/sondermull.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 951,
+        "image": "http://testserver/media/images/sondermull.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1446,
+    "word": "Ader",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/ader.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 971,
+        "image": "http://testserver/media/images/ader.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1447,
+    "word": "Notausschalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/notausschalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Notausschaltknopf",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 972,
+        "image": "http://testserver/media/images/notausschalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1449,
+    "word": "Außengewindeschneider",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/auengewindeschneider.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 973,
+        "image": "http://testserver/media/images/auengewindeschneider.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1450,
+    "word": "Bohrvorrichtung",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/bohrvorrichtung.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 974,
+        "image": "http://testserver/media/images/bohrvorrichtung.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1452,
+    "word": "Federscheibe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/federscheibe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 976,
+        "image": "http://testserver/media/images/federscheibe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1453,
+    "word": "Flügelmutter",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/flugelmutter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 977,
+        "image": "http://testserver/media/images/flugelmutter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1454,
+    "word": "Handbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/handbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 979,
+        "image": "http://testserver/media/images/handbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1455,
+    "word": "Kegelreibahle",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kegelreibahle.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 980,
+        "image": "http://testserver/media/images/kegelreibahle.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1456,
+    "word": "Kühlmittelflasche",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kuhlmittelflasche.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 981,
+        "image": "http://testserver/media/images/kuhlmittelflasche.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1457,
+    "word": "Manometer",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/manometer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 982,
+        "image": "http://testserver/media/images/manometer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1458,
+    "word": "Maschinengewindebohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/maschinengewindebohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 983,
+        "image": "http://testserver/media/images/maschinengewindebohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1459,
+    "word": "Ölkanne",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/olkanne.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Ölkännchen",
+        "singular_article": 3
+      }
+    ],
+    "document_image": [
+      {
+        "id": 984,
+        "image": "http://testserver/media/images/olkanne.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1460,
+    "word": "Radius",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/radius.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 985,
+        "image": "http://testserver/media/images/radius.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1461,
+    "word": "Rändelschraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/randelschraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 986,
+        "image": "http://testserver/media/images/randelschraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1463,
+    "word": "Spax-Schraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spax-schraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Universalschraube",
+        "singular_article": 2
+      },
+      {
+        "alt_word": "Spax",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 988,
+        "image": "http://testserver/media/images/spax-schraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1464,
+    "word": "Unterlegscheibe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/unterlegscheibe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 989,
+        "image": "http://testserver/media/images/unterlegscheibe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1465,
+    "word": "Zylinderkopfschraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/zylinderkopfschraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 992,
+        "image": "http://testserver/media/images/zylinderkopfschraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1466,
+    "word": "CNC-Fräsmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/cnc-frasmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 993,
+        "image": "http://testserver/media/images/cnc-frasmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1467,
+    "word": "Eckmesserkopf",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/eckmesserkopf.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 994,
+        "image": "http://testserver/media/images/eckmesserkopf.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1468,
+    "word": "Einstellring",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/einstellring.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 995,
+        "image": "http://testserver/media/images/einstellring.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1469,
+    "word": "Formfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/formfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 996,
+        "image": "http://testserver/media/images/formfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1470,
+    "word": "Grenzrachenlehre",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/grenzrachenlehre.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 997,
+        "image": "http://testserver/media/images/grenzrachenlehre.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1471,
+    "word": "Kantentaster",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kantentaster.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 998,
+        "image": "http://testserver/media/images/kantentaster.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1472,
+    "word": "Messerkopf",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/messerkopf.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 999,
+        "image": "http://testserver/media/images/messerkopf.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1473,
+    "word": "Messuhr",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/messuhr.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1000,
+        "image": "http://testserver/media/images/messuhr.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1474,
+    "word": "Radienfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/radienfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1002,
+        "image": "http://testserver/media/images/radienfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1475,
+    "word": "Satzfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/satzfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1003,
+        "image": "http://testserver/media/images/satzfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1476,
+    "word": "Schaftfräser mit Radius",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schaftfraser-mit-radius.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1004,
+        "image": "http://testserver/media/images/schaftfraser-mit-radius.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1477,
+    "word": "T-Nutenfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/t-nutenfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1005,
+        "image": "http://testserver/media/images/t-nutenfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1478,
+    "word": "T-Nutenstein",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/t-nutenstein.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1006,
+        "image": "http://testserver/media/images/t-nutenstein.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1479,
+    "word": "Trapezantriebsspindel",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/trapezantriebsspindel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1007,
+        "image": "http://testserver/media/images/trapezantriebsspindel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1480,
+    "word": "Universaltaster",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/universaltaster.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1008,
+        "image": "http://testserver/media/images/universaltaster.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1481,
+    "word": "Walzenfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/walzenfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1009,
+        "image": "http://testserver/media/images/walzenfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1482,
+    "word": "Zahnradfräser",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/zahnradfraser.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1012,
+        "image": "http://testserver/media/images/zahnradfraser.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1483,
+    "word": "Abstechdrehmeißel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/abstechdrehmeiel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1013,
+        "image": "http://testserver/media/images/abstechdrehmeiel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1485,
+    "word": "Bitsatz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bitsatz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1015,
+        "image": "http://testserver/media/images/bitsatz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1487,
+    "word": "Bolzenschneider",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bolzenschneider.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1016,
+        "image": "http://testserver/media/images/bolzenschneider.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1488,
+    "word": "Bügelprisma",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/bugelprisma.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1017,
+        "image": "http://testserver/media/images/bugelprisma.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1489,
+    "word": "Doppelkörner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/doppelkorner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1018,
+        "image": "http://testserver/media/images/doppelkorner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1491,
+    "word": "Druckluftpistole",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/druckluftpistole.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1020,
+        "image": "http://testserver/media/images/druckluftpistole.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1493,
+    "word": "Einstechdrehmeißel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/einstechdrehmeiel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1022,
+        "image": "http://testserver/media/images/einstechdrehmeiel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1494,
+    "word": "Gegenschlag",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gegenschlag.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1023,
+        "image": "http://testserver/media/images/gegenschlag.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1495,
+    "word": "Gewindestange",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/gewindestange.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1024,
+        "image": "http://testserver/media/images/gewindestange.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1496,
+    "word": "Gewindestift",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/gewindestift.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1025,
+        "image": "http://testserver/media/images/gewindestift.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1501,
+    "word": "Innendrehmeißel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/innendrehmeiel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1033,
+        "image": "http://testserver/media/images/innendrehmeiel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1502,
+    "word": "Inbus mit Griff",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/inbus-mit-griff.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Inbusschlüssel mit Griff",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Stiftschlüssel mit Griff",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Innensechskantschlüssel mit Griff",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1034,
+        "image": "http://testserver/media/images/inbus-mit-griff.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1503,
+    "word": "Inbussatz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/inbussatz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Innensechskantschlüsselsatz",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Inbusschlüsselsatz",
+        "singular_article": 1
+      },
+      {
+        "alt_word": "Stiftschlüsselsatz",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1035,
+        "image": "http://testserver/media/images/inbussatz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1504,
+    "word": "Klebekerze",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/klebekerze.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Klebekerzen",
+        "singular_article": 4
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1036,
+        "image": "http://testserver/media/images/klebekerze.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1505,
+    "word": "Körnerplatte",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kornerplatte.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1038,
+        "image": "http://testserver/media/images/kornerplatte.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1506,
+    "word": "Kugellager",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/kugellager.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1040,
+        "image": "http://testserver/media/images/kugellager.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1507,
+    "word": "Kraftmessdose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kraftmessdose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Kraftaufnehmer",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1041,
+        "image": "http://testserver/media/images/kraftmessdose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1509,
+    "word": "Akku-Ladestation",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/akku-ladestation.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Ladestation",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1043,
+        "image": "http://testserver/media/images/akku-ladestation.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1510,
+    "word": "Lastenkran",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/lastenkran.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1044,
+        "image": "http://testserver/media/images/lastenkran.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1511,
+    "word": "mitlaufende Spitze",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/mitlaufende-spitze.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1045,
+        "image": "http://testserver/media/images/mitlaufende-spitze.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1512,
+    "word": "O-Ring",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/o-ring.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1046,
+        "image": "http://testserver/media/images/o-ring.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1513,
+    "word": "Passstift",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/passstift.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1047,
+        "image": "http://testserver/media/images/passstift.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1514,
+    "word": "Poliervlies",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/poliervlies.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1048,
+        "image": "http://testserver/media/images/poliervlies.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1515,
+    "word": "Prisma",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/prisma.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1049,
+        "image": "http://testserver/media/images/prisma.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1517,
+    "word": "Reduzieröse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/reduzierose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1051,
+        "image": "http://testserver/media/images/reduzierose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1518,
+    "word": "Richtbank",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/richtbank.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1052,
+        "image": "http://testserver/media/images/richtbank.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1519,
+    "word": "Rohrschere",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/rohrschere.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1053,
+        "image": "http://testserver/media/images/rohrschere.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1520,
+    "word": "Säulenbohrmaschine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/saulenbohrmaschine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1054,
+        "image": "http://testserver/media/images/saulenbohrmaschine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1521,
+    "word": "Schlauchschere",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schlauchschere.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1055,
+        "image": "http://testserver/media/images/schlauchschere.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1522,
+    "word": "Schleifpapierhalter",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schleifpapierhalter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1056,
+        "image": "http://testserver/media/images/schleifpapierhalter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1523,
+    "word": "Schnellspanner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schnellspanner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1057,
+        "image": "http://testserver/media/images/schnellspanner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1525,
+    "word": "Schweißerkabine",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schweierkabine.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1060,
+        "image": "http://testserver/media/images/schweierkabine.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1526,
+    "word": "Sicherungsring",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/sicherungsring.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1061,
+        "image": "http://testserver/media/images/sicherungsring.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1527,
+    "word": "Spannfeder",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spannfeder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Feder",
+        "singular_article": 2
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1062,
+        "image": "http://testserver/media/images/spannfeder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1528,
+    "word": "Spannfutter",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/spannfutter.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1063,
+        "image": "http://testserver/media/images/spannfutter.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1529,
+    "word": "Spannhülse",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spannhulse.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1064,
+        "image": "http://testserver/media/images/spannhulse.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1530,
+    "word": "Spanntreppe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spanntreppe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1065,
+        "image": "http://testserver/media/images/spanntreppe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1531,
+    "word": "Tafelschere",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/tafelschere.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1066,
+        "image": "http://testserver/media/images/tafelschere.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1532,
+    "word": "Tiefenmaßstab",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/tiefenmastab.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1067,
+        "image": "http://testserver/media/images/tiefenmastab.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1533,
+    "word": "Trennstemmer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/trennstemmer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1068,
+        "image": "http://testserver/media/images/trennstemmer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1534,
+    "word": "Werkzeugwagen",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/werkzeugwagen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1069,
+        "image": "http://testserver/media/images/werkzeugwagen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1536,
+    "word": "Austreiber",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/austreiber.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1071,
+        "image": "http://testserver/media/images/austreiber.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1537,
+    "word": "Feilenbürste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/feilenburste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1073,
+        "image": "http://testserver/media/images/feilenburste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1538,
+    "word": "Flachspanner",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/flachspanner.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1074,
+        "image": "http://testserver/media/images/flachspanner.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1539,
+    "word": "Haarwinkel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/haarwinkel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1075,
+        "image": "http://testserver/media/images/haarwinkel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1540,
+    "word": "Schlichtfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schlichtfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1078,
+        "image": "http://testserver/media/images/schlichtfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1541,
+    "word": "Schlosserfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schlosserfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1079,
+        "image": "http://testserver/media/images/schlosserfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1542,
+    "word": "Senkkopfschraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/senkkopfschraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1080,
+        "image": "http://testserver/media/images/senkkopfschraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1543,
+    "word": "Schruppfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schruppfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1081,
+        "image": "http://testserver/media/images/schruppfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1544,
+    "word": "Spannpratze",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/spannpratze.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1082,
+        "image": "http://testserver/media/images/spannpratze.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1545,
+    "word": "Stahlmaßstab",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/stahlmastab.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1083,
+        "image": "http://testserver/media/images/stahlmastab.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1546,
+    "word": "Vierkantfeile",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/vierkantfeile.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1084,
+        "image": "http://testserver/media/images/vierkantfeile.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1547,
+    "word": "Werkbank",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/werkbank.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1085,
+        "image": "http://testserver/media/images/werkbank.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1555,
+    "word": "Kreide",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/kreide.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1087,
+        "image": "http://testserver/media/images/kreide.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1556,
+    "word": "Pinsel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/pinsel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1088,
+        "image": "http://testserver/media/images/pinsel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1557,
+    "word": "Schäferkiste",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schaferkiste.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1089,
+        "image": "http://testserver/media/images/schaferkiste.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1558,
+    "word": "Spiritus",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/spiritus.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1090,
+        "image": "http://testserver/media/images/spiritus.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1559,
+    "word": "Sprühreiniger",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/spruhreiniger.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1091,
+        "image": "http://testserver/media/images/spruhreiniger.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1573,
+    "word": "Sechskantschraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/sechskantschraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1599,
+        "image": "http://testserver/media/images/sechskantschraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1594,
+    "word": "Heftklammern",
+    "article": 4,
+    "singular_article": 4,
+    "audio": "http://testserver/media/audio/heftklammern.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1126,
+        "image": "http://testserver/media/images/heftklammern.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1596,
+    "word": "Stempel",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/stempel.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1128,
+        "image": "http://testserver/media/images/stempel.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1599,
+    "word": "Stempelkissen",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/stempelkissen.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1852,
+        "image": "http://testserver/media/images/stempelkissen.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1623,
+    "word": "Dose",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/dose.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1296,
+        "image": "http://testserver/media/images/dose.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1684,
+    "word": "Brandmelder",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/brandmelder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1324,
+        "image": "http://testserver/media/images/brandmelder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1685,
+    "word": "Kapselgehörschutz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/kapselgehorschutz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1325,
+        "image": "http://testserver/media/images/kapselgehorschutz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1707,
+    "word": "Werkzeugkoffer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/werkzeugkoffer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1584,
+        "image": "http://testserver/media/images/werkzeugkoffer.png"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1799,
+    "word": "Feder",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/feder.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1597,
+        "image": "http://testserver/media/images/feder.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1852,
+    "word": "Mundschutz",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/mundschutz.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1499,
+        "image": "http://testserver/media/images/mundschutz.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1857,
+    "word": "Schleifset",
+    "article": 3,
+    "singular_article": 3,
+    "audio": "http://testserver/media/audio/schleifset.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1504,
+        "image": "http://testserver/media/images/schleifset.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1864,
+    "word": "Bandschleifer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/bandschleifer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1516,
+        "image": "http://testserver/media/images/bandschleifer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1874,
+    "word": "Schleifscheibe",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schleifscheibe.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1526,
+        "image": "http://testserver/media/images/schleifscheibe.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1875,
+    "word": "Steinbohrer",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/steinbohrer.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1527,
+        "image": "http://testserver/media/images/steinbohrer.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1888,
+    "word": "Schleifblock",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/schleifblock.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1534,
+        "image": "http://testserver/media/images/schleifblock.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1896,
+    "word": "D3-Leim",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/d3-leim.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1539,
+        "image": "http://testserver/media/images/d3-leim.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1897,
+    "word": "Einschraubhaken",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/einschraubhaken.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1540,
+        "image": "http://testserver/media/images/einschraubhaken.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1900,
+    "word": "Schlossschraube",
+    "article": 2,
+    "singular_article": 2,
+    "audio": "http://testserver/media/audio/schlossschraube.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1543,
+        "image": "http://testserver/media/images/schlossschraube.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 1973,
+    "word": "Textmarker",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/textmarker.mp3",
+    "word_type": "Nomen",
+    "alternatives": [],
+    "document_image": [
+      {
+        "id": 1627,
+        "image": "http://testserver/media/images/textmarker.jpg"
+      }
+    ],
+    "example_sentence": ""
+  },
+  {
+    "id": 2139,
+    "word": "Arbeitsschuh",
+    "article": 1,
+    "singular_article": 1,
+    "audio": "http://testserver/media/audio/arbeitsschuh.mp3",
+    "word_type": "Nomen",
+    "alternatives": [
+      {
+        "alt_word": "Sicherheitsschuh",
+        "singular_article": 1
+      }
+    ],
+    "document_image": [
+      {
+        "id": 1849,
+        "image": "http://testserver/media/images/arbeitsschuh.jpg"
+      }
+    ],
+    "example_sentence": ""
   }
 ]


### PR DESCRIPTION
### Short description
Restore compatibility for v1 API while still providing the new attribute with distinguishable name.


### Proposed changes
- Restore `article` attribute in document API.

### Resolved issues

Fixes: https://chat.tuerantuer.org/digitalfabrik/pl/ch4sghepr7yotr8mod8dw958ch
