### PR TITLE
Adjust form appearance for small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ UNRELEASED
 
 * [ [#353](https://github.com/digitalfabrik/lunes-cms/issues/353) ] Filter feedback by creator of related objects
 * [ [#468](https://github.com/digitalfabrik/lunes-cms/issues/468) ] Excel list out of existing vocabulary in cms
+* [ [#534](https://github.com/digitalfabrik/lunes-cms/issues/534) ] Adjust form appearance for small screens
+
+
+2024.5.1
+--------
 
 
 2024.5.0

--- a/lunes_cms/cms/admins/document_admin.py
+++ b/lunes_cms/cms/admins/document_admin.py
@@ -26,8 +26,10 @@ class DocumentAdmin(admin.ModelAdmin):
     fields = (
         "word_type",
         "grammatical_gender",
-        ("singular_article", "word"),
-        ("plural_article", "plural"),
+        "singular_article",
+        "word",
+        "plural_article",
+        "plural",
         "audio",
         "definition",
         "additional_meaning_1",

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-02 09:04+0000\n"
+"POT-Creation-Date: 2024-06-11 15:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "{} with id {} does not exist."
 msgstr "{} mit der ID {} existiert nicht."
 
-#: cms/admin.py:35 cms/admins/document_admin.py:160
+#: cms/admin.py:35 cms/admins/document_admin.py:162
 #: cms/admins/training_set_admin.py:359 cms/forms.py:46 cms/forms.py:48
 #: cms/list_filter.py:14 cms/models/discipline.py:101
 msgid "disciplines"
@@ -79,25 +79,25 @@ msgstr "unveröffentlichte Module"
 msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
-#: cms/admins/discipline_admin.py:387 cms/admins/document_admin.py:177
+#: cms/admins/discipline_admin.py:387 cms/admins/document_admin.py:179
 #: cms/admins/training_set_admin.py:376
 msgid "creator group"
 msgstr "Besitzergruppe"
 
-#: cms/admins/document_admin.py:140 cms/models/training_set.py:25
+#: cms/admins/document_admin.py:142 cms/models/training_set.py:25
 #: cms/models/training_set.py:90
 msgid "training set"
 msgstr "Modul"
 
-#: cms/admins/document_admin.py:194 cms/models/document.py:66
+#: cms/admins/document_admin.py:196 cms/models/document.py:66
 msgid "audio"
 msgstr "Audio"
 
-#: cms/admins/document_admin.py:214 cms/models/document_image.py:123
+#: cms/admins/document_admin.py:216 cms/models/document_image.py:123
 msgid "image"
 msgstr "Bild"
 
-#: cms/admins/document_admin.py:229 cms/models/alternative_word.py:24
+#: cms/admins/document_admin.py:231 cms/models/alternative_word.py:24
 #: cms/models/document.py:43
 msgid "singular article"
 msgstr "Singular-Artikel"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix the problem that input fields are squashed when an user is working on a small screen.

So far as I tested this (or a similar) problem was not found in other parts of the system.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Do not list more than one input field in one row.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #534 
