### PR TITLE
Fix colors of feedback list in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#512](https://github.com/digitalfabrik/lunes-cms/issues/512) ] Gender neutral language
+* [ [#532](https://github.com/digitalfabrik/lunes-cms/issues/532) ] Fix color of feedback list in dark mode
 
 
 2024.6.0

--- a/lunes_cms/static/css/feedback.css
+++ b/lunes_cms/static/css/feedback.css
@@ -22,6 +22,28 @@ thead tr {
   font-weight: bold;
 }
 
+@media (prefers-color-scheme: dark) {
+
+  .table-striped tbody tr:nth-of-type(odd){
+    background-color: #000e38;
+  
+  }
+
+  .table-striped thead tr {
+    background-color: #47476e;
+    font-weight: bold;
+  }
+  
+  thead th .text {
+    color: #8ba6fa;
+  }
+
+  tbody {
+    color: #8ba6fa;
+  }
+
+}
+
 /* Checkbox column */
 thead th:nth-child(1) {
   width: 3%;


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the color conflict, which is a side effect of #515 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Introduce a new color assignment to feedback list in the dark mode

🤔 The contrast between "bold" and "normal" fonts is sadly not really visible enough in the dark mode (I can only slightly tell whether bold or normal). Should we use different font colors depend on the status (read/unread)? @hauf-toni 

![feedback list dark mode](https://github.com/digitalfabrik/lunes-cms/assets/82345046/d1c5efbd-2691-402b-ab2f-4af37f64956e)
This is how it looks after fix with this PR.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #532 
