### PR TITLE
Inform users of word duplication in document form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#353](https://github.com/digitalfabrik/lunes-cms/issues/353) ] Filter feedback by creator of related objects
 * [ [#468](https://github.com/digitalfabrik/lunes-cms/issues/468) ] Excel list out of existing vocabulary in cms
 * [ [#534](https://github.com/digitalfabrik/lunes-cms/issues/534) ] Adjust form appearance for small screens
+* [ [#470](https://github.com/digitalfabrik/lunes-cms/issues/470) ] Inform users of word duplication in document form
 
 
 2024.5.1

--- a/lunes_cms/api/v1/urls.py
+++ b/lunes_cms/api/v1/urls.py
@@ -4,7 +4,7 @@ URL patterns for the first version of the Lunes API
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from ..utils import OptionalSlashRouter
+from ..utils import OptionalSlashRouter, find_duplicates_for_word
 from . import views
 
 #: The namespace for this URL config (see :attr:`django.urls.ResolverMatch.app_name`)
@@ -58,5 +58,10 @@ urlpatterns = [
             template_name="swagger_ui.html", url_name="api:v1:schema"
         ),
         name="swagger-ui",
+    ),
+    path(
+        "search_duplicate/<word>",
+        find_duplicates_for_word,
+        name="search_duplicate",
     ),
 ]

--- a/lunes_cms/cms/fixtures/test_data.json
+++ b/lunes_cms/cms/fixtures/test_data.json
@@ -6891,6 +6891,7 @@
       "word_type": "Nomen",
       "word": "Ei",
       "singular_article": 3,
+      "definition": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua",
       "audio": "audio/ei.mp3",
       "creation_date": "2021-08-09T13:52:38.131Z",
       "created_by": null,
@@ -13407,6 +13408,20 @@
       "singular_article": 2,
       "audio": "audio/hygiene.mp3",
       "creation_date": "2022-06-23T15:41:41.687Z",
+      "created_by": null,
+      "creator_is_admin": true
+    }
+  },
+  {
+    "model": "cms.document",
+    "pk": 2332,
+    "fields": {
+      "word_type": "Verb",
+      "word": "implementieren",
+      "singular_article": 0,
+      "definition": "in ein bestehendes Computersystem einsetzen, einbauen und so ein funktionsfähiges Programm erstellen",
+      "example_sentence": "eine neue Software implementieren",
+      "creation_date": "2021-04-13T15:58:10.468Z",
       "created_by": null,
       "creator_is_admin": true
     }

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-11 15:29+0000\n"
+"POT-Creation-Date: 2024-06-19 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,30 @@ msgstr ""
 #: api/apps.py:13
 msgid "API"
 msgstr "API"
+
+#: api/utils.py:175
+msgid "This word is assigned to no training set."
+msgstr "Das word ist zu keinem Modul zugeordnet."
+
+#: api/utils.py:182
+msgid "This word is already registered in the system."
+msgstr "Das Wort ist schon im System hinterlegt."
+
+#: api/utils.py:184 api/utils.py:186
+msgid "Definition: "
+msgstr "Definition: "
+
+#: api/utils.py:186
+msgid "No definition is provided for this word."
+msgstr "Für dieses Wort ist keine Definition hinterlegt."
+
+#: api/utils.py:187
+msgid "Training sets: "
+msgstr "Module: "
+
+#: api/utils.py:191
+msgid "This word is not yet registered in the system"
+msgstr "Das Wort ist noch nicht im System hinterlegt."
 
 #: api/v1/serializers/feedback_serializer.py:22
 msgid ""

--- a/lunes_cms/static/js/toggle_plural_field.js
+++ b/lunes_cms/static/js/toggle_plural_field.js
@@ -2,6 +2,7 @@ if (!$) {
   $ = django.jQuery;
 }
 
+//Toggle the plural field depending on the chosen word type
 $(document).ready(() => {
   $("#id_word_type").change((event) =>
     $("#id_plural")
@@ -11,11 +12,86 @@ $(document).ready(() => {
   $("#id_word_type").trigger("change");
 });
 
+//Toggle the drop down for grammatical gender depending on the chosen word type
 $(document).ready(() => {
   $("#id_word_type").change((event) =>
     $("#id_grammatical_gender")
       .closest("div.row")
       .toggle($(event.target).val() == "Nomen"),
   );
+  $("#id_word_type").trigger("change");
+});
+
+function removeDuplicationCheckMessage(){
+  var existingMessage = document.getElementById("result");
+
+  if (existingMessage) {
+    existingMessage.remove();
+  }
+}
+
+function showDuplicates(data, parent) {
+  removeDuplicationCheckMessage();
+
+  result = document.createElement("div");
+  result.setAttribute("id", "result");
+
+
+  if (data["word"]) {
+    // If there is a duplicated word, use orange background
+    result.style.backgroundColor = "#ffbb4a";
+    result.style.padding = "25px"
+
+    // Show alert message
+    messageBox = document.createElement("div");
+    message = document.createTextNode(data["message"]);
+    messageBox.append(message);
+    result.append(messageBox);
+    // Show the duplicated word with its word type
+    wordBox = document.createElement("div");
+    word = document.createTextNode(data["word"]);
+    wordBox.style.fontWeight = "bold";
+    wordBox.append(word);
+    result.append(wordBox);
+    // Show its definition too for more detail
+    definitionBox = document.createElement("div");
+    definition = document.createTextNode(data["definition"]);
+    definitionBox.append(definition);
+    result.append(definitionBox);
+    // Show related training sets
+    trainingSetsBox = document.createElement("div");
+    trainingSets = document.createTextNode(data["training_sets"]);
+    trainingSetsBox.append(trainingSets);
+    result.append(trainingSetsBox);
+  } else {
+    // If there is no duplicate, use green background
+    result.style.backgroundColor = "#72f399";
+    result.style.padding = "25px"
+    // Show message that no duplicate was found
+    messageBox = document.createElement("div");
+    message = document.createTextNode(data["message"]);
+    messageBox.append(message);
+    result.append(messageBox);
+  }
+  
+  parent.prepend(result);
+}
+
+
+$(document).ready(() => {
+  $("#id_word").change((event) => {
+    if ($(event.target).val().length > 0) {
+      $.ajax({
+        type: 'GET',
+        url: '/api/search_duplicate/' + $(event.target).val(),
+        dataType: "json",
+        success: function(data) {
+            showDuplicates(data, $(event.target).closest(".card-body"));
+        }
+      })
+    } else {
+      removeDuplicationCheckMessage();
+    }
+  });
   $("#id_word_type").trigger("change");
 });

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -388,6 +388,26 @@ SPONSOR_ENDPOINTS = [
     },
 ]
 
+
+SEARCH_DUPLICATE_ENDPOINTS = [
+    {
+        "endpoint": "/api/search_duplicate/implementieren",
+        "expected_result": "tests/api/expected-results/duplicate_implementieren.json",
+    },
+    {
+        "endpoint": "/api/search_duplicate/Schere",
+        "expected_result": "tests/api/expected-results/duplicate_Schere.json",
+    },
+    {
+        "endpoint": "/api/search_duplicate/Ei",
+        "expected_result": "tests/api/expected-results/duplicate_Ei.json",
+    },
+    {
+        "endpoint": "/api/search_duplicate/neueswort",
+        "expected_result": "tests/api/expected-results/duplicate_neueswort.json",
+    },
+]
+
 #: The API endpoints
 API_ENDPOINTS = (
     DISCIPLINE_ENDPOINTS
@@ -396,6 +416,7 @@ API_ENDPOINTS = (
     + GROUP_ENDPOINTS
     + FEEDBACK_ENDPOINTS
     + SPONSOR_ENDPOINTS
+    + SEARCH_DUPLICATE_ENDPOINTS
 )
 
 #: Convert the dicts to tuples with a fixed length

--- a/tests/api/expected-results/duplicate_Ei.json
+++ b/tests/api/expected-results/duplicate_Ei.json
@@ -1,0 +1,6 @@
+{
+    "message": "This word is already registered in the system.",
+    "word": "📷 (das) Ei (Nomen)",
+    "definition": "Definition: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua",
+    "training_sets": "Training sets: Zutaten"
+}

--- a/tests/api/expected-results/duplicate_Schere.json
+++ b/tests/api/expected-results/duplicate_Schere.json
@@ -1,0 +1,6 @@
+{
+    "message": "This word is already registered in the system.",
+    "word": "📷 (die) Schere (Nomen)",
+    "definition": "Definition: No definition is provided for this word.",
+    "training_sets": "Training sets: Grundlagen Werkzeuge, Grundlagen Rezeption"
+}

--- a/tests/api/expected-results/duplicate_implementieren.json
+++ b/tests/api/expected-results/duplicate_implementieren.json
@@ -1,0 +1,6 @@
+{
+    "message": "This word is already registered in the system.",
+    "word": "⚠ (keiner) implementieren (Verb)",
+    "definition": "Definition: in ein bestehendes Computersystem einsetzen, einbauen und so ein funktionsfähiges Programm erstellen",
+    "training_sets": "Training sets: This word is assigned to no training set."
+}

--- a/tests/api/expected-results/duplicate_neueswort.json
+++ b/tests/api/expected-results/duplicate_neueswort.json
@@ -1,0 +1,3 @@
+{
+    "message": "This word is not yet registered in the system"
+}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds a functionality that informs user of possible duplication when they are editing/creating a word.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Introduce a new function <s>`get_documents_by_string`</s> `find_duplicates_for_word`, which looks for documents objects with the same "word" attribute.
- Call it whenever something is changed in the `word` field on the document form
- Show users whether the current input has a duplicate in the system or not.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #470 
