### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   install:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - restore_cache:
@@ -33,7 +33,7 @@ jobs:
             - lunes_cms.egg-info
   compile-translations:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -56,7 +56,7 @@ jobs:
             - lunes_cms/locale/de/LC_MESSAGES/djangojs.mo
   pylint:
     docker:
-      - image: "cimg/python:3.9"
+      - image: "cimg/python:3.11"
     steps:
       - checkout
       - attach_workspace:
@@ -84,7 +84,7 @@ jobs:
             - cc-test-reporter
   test:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
         environment:
           LUNES_CMS_SECRET_KEY: circleci-dummy-key
       - image: cimg/postgres:14.1
@@ -137,7 +137,7 @@ jobs:
             ./cc-test-reporter sum-coverage -o - coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
   black:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -149,7 +149,7 @@ jobs:
             black --check .
   check-translations:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -162,7 +162,7 @@ jobs:
           command: ./tools/check_translations.sh
   build-documentation:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -172,7 +172,7 @@ jobs:
           command: ./tools/build_documentation.sh
   bump-dev-version:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -217,7 +217,7 @@ jobs:
             - lunes_cms/__init__.py
   bump-version:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -267,7 +267,7 @@ jobs:
           command: git checkout develop && git merge main --commit --no-edit && git push
   build-package:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -284,7 +284,7 @@ jobs:
             - dist
   publish-package:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -296,7 +296,7 @@ jobs:
             twine upload --non-interactive ./dist/lunes-cms-*.tar.gz
   create-release:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/scripts/create_release.py
+++ b/.circleci/scripts/create_release.py
@@ -34,9 +34,9 @@ def main():
     logo_url = "https://raw.githubusercontent.com/digitalfabrik/lunes-cms/c242f6b723da80e5d9f9ed7ca9c6f961bb095386/.github/logo.png"
     compare_url = "https://github.com/digitalfabrik/lunes-cms/compare"
     body = (
-        f"### ![]({logo_url}) lunes-cms `{args.tag}`"
-        f"\n\n### Changelog\n\n{args.changelog}\n\n"
-        f"Compare changes: [{args.prev_tag} → {args.tag}]({compare_url}/{args.prev_tag}...{args.tag})"
+        f"### ![]({logo_url}) lunes-cms `{args.tag}`\n\n###"
+        f" Changelog\n\n{args.changelog}\n\nCompare changes: [{args.prev_tag} →"
+        f" {args.tag}]({compare_url}/{args.prev_tag}...{args.tag})"
     )
 
     # Create release

--- a/.circleci/scripts/get_access_token.py
+++ b/.circleci/scripts/get_access_token.py
@@ -22,7 +22,8 @@ def main():
         deliverino_private_key = os.environ["DELIVERINO_PRIVATE_KEY"]
     except KeyError as e:
         raise RuntimeError(
-            "Please make sure this step has access to the 'deliverino' CircleCI context."
+            "Please make sure this step has access to the 'deliverino' CircleCI"
+            " context."
         ) from e
 
     # Generate payload for the JWT

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.11"
   jobs:
     pre_build:
       - ./tools/build_documentation.sh

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ For more information please see our [GoVolunteer ad](https://translate.google.co
 
 Following packages are required before installing the project (install them with your package manager):
 
-* python3.8 or higher
-* python3-pip
-* python3-venv
-* libpq-dev to compile psycopg2
-* gettext and pcregrep to use the translation features
-* ffmpeg for audio processing
+* `python3.11` or higher
+* `python3-pip`
+* `python3-venv`
+* `libpq-dev` to compile psycopg2
+* `gettext` and `pcregrep` to use the translation features
+* `ffmpeg` for audio processing
 
 E.g. on Debian-based distributions, use:
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -13,7 +13,7 @@ Prerequisites
 Followings are required before installing the project (install them with your manager):
 
 * `git <https://git-scm.com/>`_
-* `python3.8 <https://www.python.org/downloads/release/python-380/>`_ or higher
+* `python3.11 <https://www.python.org/downloads/release/python-3110/>`_ or higher
 * `python3-pip <https://packages.ubuntu.com/search?keywords=python3-pip>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__) / `python-pip <https://www.archlinux.de/packages/extra/x86_64/python-pip>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)
 * `python3-venv <https://docs.python.org/3/library/venv.html>`__
 * `libpq-dev <https://www.postgresql.org/docs/9.5/libpq.html>`__ to compile `psycopg2 <https://www.psycopg.org/docs/install.html#build-prerequisites>`__

--- a/lunes_cms/README.md
+++ b/lunes_cms/README.md
@@ -19,7 +19,7 @@ This is the content management system for the vocabulary trainer app Lunes, whic
 
 Following packages are required before installing the project (install them with your package manager):
 
-* python3.8 or greater
+* python3.11 or greater
 * python3-pip
 * python3-venv
 * ffmpeg

--- a/lunes_cms/api/exception_handler.py
+++ b/lunes_cms/api/exception_handler.py
@@ -1,0 +1,16 @@
+from rest_framework.views import exception_handler
+from rest_framework import status
+
+
+def custom_exception_handler(exc, context):
+    """
+    Extend the default exception_handler of rest_framework.
+    Purpose: Simplify testing by ensuring that the detail message is the same for all 404 responses.
+    """
+
+    response = exception_handler(exc, context)
+
+    if response.status_code == status.HTTP_404_NOT_FOUND:
+        response.data["detail"] = "Not found."
+
+    return response

--- a/lunes_cms/api/utils.py
+++ b/lunes_cms/api/utils.py
@@ -5,7 +5,7 @@ A collection of helper methods and classes
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Q
 from django.http import JsonResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import routers
 
@@ -181,9 +181,11 @@ def find_duplicates_for_word(request, word):
         result = {
             "message": _("This word is already registered in the system."),
             "word": document_to_string(duplicate) + " (" + duplicate.word_type + ")",
-            "definition": _("Definition: ") + duplicate.definition
-            if duplicate.definition
-            else _("Definition: ") + _("No definition is provided for this word."),
+            "definition": (
+                _("Definition: ") + duplicate.definition
+                if duplicate.definition
+                else _("Definition: ") + _("No definition is provided for this word.")
+            ),
             "training_sets": _("Training sets: ") + training_sets_description,
         }
 

--- a/lunes_cms/api/v1/serializers/feedback_serializer.py
+++ b/lunes_cms/api/v1/serializers/feedback_serializer.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from ....cms.models import Feedback
@@ -19,7 +19,8 @@ class FeedbackSerializer(serializers.ModelSerializer):
         ),
         error_messages={
             "does_not_exist": _(
-                "The content type must be either 'discipline', 'training set' or 'document'."
+                "The content type must be either 'discipline', 'training set' or"
+                " 'document'."
             ),
         },
     )

--- a/lunes_cms/api/v1/urls.py
+++ b/lunes_cms/api/v1/urls.py
@@ -14,7 +14,7 @@ app_name = "v1"
 router = OptionalSlashRouter()
 router.register(r"disciplines", views.DisciplineViewSet, "disciplines")
 router.register(
-    "disciplines_by_level/",
+    "disciplines_by_level",
     views.DisciplineFilteredViewSet,
     "disciplines_overview",
 )
@@ -41,7 +41,9 @@ router.register(
 )
 
 router.register(
-    r"document_by_id/(?P<document_id>[0-9]+)", views.DocumentByIdViewSet, "documents"
+    r"document_by_id/(?P<document_id>[0-9]+)",
+    views.DocumentByIdViewSet,
+    "document_by_id",
 )
 router.register(r"words", views.WordViewSet, "words")
 router.register(r"group_info", views.GroupViewSet, "group_by_id")

--- a/lunes_cms/cms/admin.py
+++ b/lunes_cms/cms/admin.py
@@ -5,7 +5,7 @@ specify autocomplete_fields, search_fields and nested modules
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .admins import (
     DisciplineAdmin,

--- a/lunes_cms/cms/admins/discipline_admin.py
+++ b/lunes_cms/cms/admins/discipline_admin.py
@@ -10,7 +10,7 @@ from django.db.models.functions import Greatest
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from mptt.admin import DraggableMPTTAdmin
 from tablib import Dataset
 

--- a/lunes_cms/cms/admins/document_admin.py
+++ b/lunes_cms/cms/admins/document_admin.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
 from django.db.models import Case, Exists, IntegerField, OuterRef, Value, When
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ..list_filter import (
     ApprovedImageListFilter,

--- a/lunes_cms/cms/admins/document_resource.py
+++ b/lunes_cms/cms/admins/document_resource.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from import_export import fields, resources
 from import_export.admin import ExportActionMixin
 
@@ -103,4 +103,13 @@ class DocumentResource(resources.ModelResource):
         """
 
         model = Document
-        fields = ()
+        fields = (
+            "word",
+            "word_type",
+            "singular_article",
+            "plural_article",
+            "has_audio",
+            "example_sentence",
+            "creation_date",
+            "training_sets",
+        )

--- a/lunes_cms/cms/admins/sponsor_admin.py
+++ b/lunes_cms/cms/admins/sponsor_admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ..utils import get_image_tag
 

--- a/lunes_cms/cms/admins/training_set_admin.py
+++ b/lunes_cms/cms/admins/training_set_admin.py
@@ -6,7 +6,7 @@ from django.db.models import Count, F, Q
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ngettext
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from mptt.admin import DraggableMPTTAdmin
 
 from ..forms import TrainingSetForm
@@ -217,8 +217,10 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
             messages.error(
                 request,
                 ngettext(
-                    "The training set {} could not be released because it contains less than {} vocabulary words with confirmed images.",
-                    "The training sets {} could not be released because they contain less than {} vocabulary words with confirmed images.",
+                    "The training set {} could not be released because it contains less"
+                    " than {} vocabulary words with confirmed images.",
+                    "The training sets {} could not be released because they contain"
+                    " less than {} vocabulary words with confirmed images.",
                     len(invalid_trainingsets),
                 ).format(
                     iter_to_string(invalid_trainingsets),

--- a/lunes_cms/cms/apps.py
+++ b/lunes_cms/cms/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class CmsConfig(AppConfig):

--- a/lunes_cms/cms/forms.py
+++ b/lunes_cms/cms/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Discipline, Document, TrainingSet
 from .widgets import ManyToManyOverlay
@@ -52,7 +52,9 @@ class TrainingSetForm(forms.ModelForm):
         widget=ManyToManyOverlay(verbose_name=(_("vocabulary")), is_stacked=False),
         label=_("vocabulary"),
         help_text=_(
-            "Please select some vocabularies for your training set. To see a preview of the corresponding image and audio files, press the alt key while selecting."
+            "Please select some vocabularies for your training set. To see a preview of"
+            " the corresponding image and audio files, press the alt key while"
+            " selecting."
         ),
     )
 
@@ -74,7 +76,8 @@ class TrainingSetForm(forms.ModelForm):
             self.add_error(
                 "released",
                 _(
-                    "You can only release a training set that contains at least {} vocabulary words with confirmed images."
+                    "You can only release a training set that contains at least {}"
+                    " vocabulary words with confirmed images."
                 ).format(settings.TRAININGSET_MIN_DOCS),
             )
         return cleaned_data

--- a/lunes_cms/cms/list_filter.py
+++ b/lunes_cms/cms/list_filter.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.db.models import F
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Discipline, TrainingSet
 

--- a/lunes_cms/cms/migrations/0001_initial.py
+++ b/lunes_cms/cms/migrations/0001_initial.py
@@ -242,7 +242,10 @@ class Migration(migrations.Migration):
                     "name",
                     models.CharField(
                         default=None,
-                        help_text="A free-form name for the API key. Need not be unique. 50 characters max.",
+                        help_text=(
+                            "A free-form name for the API key. Need not be unique. 50"
+                            " characters max."
+                        ),
                         max_length=50,
                     ),
                 ),
@@ -251,14 +254,19 @@ class Migration(migrations.Migration):
                     models.BooleanField(
                         blank=True,
                         default=False,
-                        help_text="If the API key is revoked, clients cannot use it anymore. (This cannot be undone.)",
+                        help_text=(
+                            "If the API key is revoked, clients cannot use it anymore."
+                            " (This cannot be undone.)"
+                        ),
                     ),
                 ),
                 (
                     "expiry_date",
                     models.DateTimeField(
                         blank=True,
-                        help_text="Once API key expires, clients cannot use it anymore.",
+                        help_text=(
+                            "Once API key expires, clients cannot use it anymore."
+                        ),
                         null=True,
                         verbose_name="Expires",
                     ),

--- a/lunes_cms/cms/migrations/0004_feedback.py
+++ b/lunes_cms/cms/migrations/0004_feedback.py
@@ -62,7 +62,10 @@ class Migration(migrations.Migration):
                     "read_by",
                     models.ForeignKey(
                         blank=True,
-                        help_text="The user who marked this feedback as read. If the feedback is unread, this field is empty.",
+                        help_text=(
+                            "The user who marked this feedback as read. If the feedback"
+                            " is unread, this field is empty."
+                        ),
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="feedback",

--- a/lunes_cms/cms/migrations/0006_convert_group_api_key.py
+++ b/lunes_cms/cms/migrations/0006_convert_group_api_key.py
@@ -60,7 +60,9 @@ class Migration(migrations.Migration):
             name="token",
             field=models.CharField(
                 default=lunes_cms.cms.models.group_api_key.generate_default_token,
-                help_text="10-50 characters, only digits and upper case letters allowed.",
+                help_text=(
+                    "10-50 characters, only digits and upper case letters allowed."
+                ),
                 max_length=50,
                 unique=True,
                 validators=[

--- a/lunes_cms/cms/models/alternative_word.py
+++ b/lunes_cms/cms/models/alternative_word.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .document import Document
 from .static import Static

--- a/lunes_cms/cms/models/discipline.py
+++ b/lunes_cms/cms/models/discipline.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models.deletion import CASCADE
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from mptt.models import MPTTModel, TreeForeignKey
 
 from ..utils import get_child_count, get_image_tag

--- a/lunes_cms/cms/models/document.py
+++ b/lunes_cms/cms/models/document.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.files import File
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from pydub import AudioSegment
 
 from ..utils import document_to_string

--- a/lunes_cms/cms/models/document_image.py
+++ b/lunes_cms/cms/models/document_image.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from PIL import Image, ImageFilter
 
 from ..utils import get_image_tag
@@ -44,6 +44,7 @@ class DocumentImage(models.Model):
         :rtype: None
         """
         name_elements = self.image.path.split(".")
+        new_path = ""
         for elem in name_elements:
             if elem != name_elements[-1]:
                 new_path = elem + "_"

--- a/lunes_cms/cms/models/feedback.py
+++ b/lunes_cms/cms/models/feedback.py
@@ -43,7 +43,8 @@ class Feedback(models.Model):
         related_name="feedback",
         verbose_name=_("marked as read by"),
         help_text=_(
-            "The user who marked this feedback as read. If the feedback is unread, this field is empty."
+            "The user who marked this feedback as read. If the feedback is unread, this"
+            " field is empty."
         ),
     )
 

--- a/lunes_cms/cms/models/group.py
+++ b/lunes_cms/cms/models/group.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import Group
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .static import convert_umlaute_images
 

--- a/lunes_cms/cms/models/group_api_key.py
+++ b/lunes_cms/cms/models/group_api_key.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from django.utils.crypto import get_random_string
 from django.utils.html import mark_safe
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from qr_code.qrcode.maker import make_qr_code_url_with_args
 
 
@@ -99,7 +99,8 @@ class GroupAPIKey(models.Model):
         :rtype: str
         """
         return mark_safe(
-            f'<a download="Lunes-QR-code-{escape(self.group.name)}.jpg" href="{escape(self.qr_code_url)}" title="{title or link}">{link}</a>'
+            f'<a download="Lunes-QR-code-{escape(self.group.name)}.jpg"'
+            f' href="{escape(self.qr_code_url)}" title="{title or link}">{link}</a>'
         )
 
     def qr_code_download_link(self):
@@ -119,7 +120,8 @@ class GroupAPIKey(models.Model):
         return (
             self.qr_code_link(
                 mark_safe(
-                    f'<img src="{escape(self.qr_code_url)}" width="330" height="auto" /></a>'
+                    f'<img src="{escape(self.qr_code_url)}" width="330" height="auto"'
+                    " /></a>"
                 ),
                 escape(_("Download QR code")),
             )

--- a/lunes_cms/cms/models/sponsor.py
+++ b/lunes_cms/cms/models/sponsor.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ..validators import validate_multiple_extensions
 from .static import upload_sponsor_logos

--- a/lunes_cms/cms/models/training_set.py
+++ b/lunes_cms/cms/models/training_set.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.deletion import CASCADE
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from mptt.models import MPTTModel, TreeForeignKey
 
 from ..utils import get_image_tag
@@ -76,7 +76,8 @@ class TrainingSet(MPTTModel):
         """
         if self.parent:
             msg = _(
-                "It is not possible to create child elements for training sets (unlike disciplines)."
+                "It is not possible to create child elements for training sets (unlike"
+                " disciplines)."
             )
             raise ValidationError(msg)
         super().save(*args, **kwargs)

--- a/lunes_cms/cms/urls.py
+++ b/lunes_cms/cms/urls.py
@@ -7,7 +7,7 @@ handles the url patterns described in the `README.md` file
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import path
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.i18n import JavaScriptCatalog
 
 #: The url patterns of this module (see :doc:`django:topics/http/urls`)

--- a/lunes_cms/cms/utils.py
+++ b/lunes_cms/cms/utils.py
@@ -10,7 +10,7 @@ from html import escape
 
 from django.utils.crypto import get_random_string
 from django.utils.html import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 def create_resource_path(parent_dir, filename):
@@ -61,7 +61,7 @@ def document_to_string(doc):
     :rtype: str
     """
     alt_words = [str(elem) for elem in doc.alternatives.all()]
-    has_foto = "\U0001F4F7" if doc.document_image.all() else "\U000026A0"
+    has_foto = "\U0001f4f7" if doc.document_image.all() else "\U000026a0"
 
     if len(alt_words) > 0:
         alt_words = "(" + ", ".join(alt_words) + ")"

--- a/lunes_cms/cms/validators.py
+++ b/lunes_cms/cms/validators.py
@@ -1,7 +1,7 @@
 import os
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def validate_file_extension(value):

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -12,12 +12,11 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
-from distutils.util import strtobool
-
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .logging_formatter import ColorFormatter
+from .utils import strtobool
 
 ###################
 # CUSTOM SETTINGS #
@@ -137,7 +136,8 @@ try:
     }
 except KeyError as e:
     raise ImproperlyConfigured(
-        f"The database backend {os.environ.get('LUNES_CMS_DB_BACKEND')!r} is not supported, must be one of {DATABASE_CHOICES.keys()}."
+        f"The database backend {os.environ.get('LUNES_CMS_DB_BACKEND')!r} is not"
+        f" supported, must be one of {DATABASE_CHOICES.keys()}."
     ) from e
 
 #: Default primary key field type to use for models that don’t have a field with primary_key=True.
@@ -171,7 +171,9 @@ SECRET_KEY = os.environ.get("LUNES_CMS_SECRET_KEY", "dummy" if DEBUG else "")
 #: See Password validation for more details. By default, no validation is performed and all passwords are accepted.
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "NAME": (
+            "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+        ),
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
@@ -333,7 +335,10 @@ LOGGING = {
             "style": "{",
         },
         "email": {
-            "format": "Date and time: {asctime}\nSeverity: {levelname}\nLogger: {name}\nMessage: {message}\nFile: {funcName}() in {pathname}:{lineno}",
+            "format": (
+                "Date and time: {asctime}\nSeverity: {levelname}\nLogger:"
+                " {name}\nMessage: {message}\nFile: {funcName}() in {pathname}:{lineno}"
+            ),
             "datefmt": "%Y-%m-%d %H:%M:%S",
             "style": "{",
         },
@@ -416,6 +421,7 @@ REST_FRAMEWORK = {
     "ALLOWED_VERSIONS": ("v1", "v2"),
     "DEFAULT_VERSION": "default",
     "DEFAULT_API_URL": "http://localhost:8080/api/",
+    "EXCEPTION_HANDLER": "lunes_cms.api.exception_handler.custom_exception_handler",
 }
 
 SPECTACULAR_SETTINGS = {

--- a/lunes_cms/core/urls.py
+++ b/lunes_cms/core/urls.py
@@ -20,12 +20,10 @@ Including another URLconf
 
 """
 from django.conf import settings
-from django.conf.urls import url
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.templatetags.static import static as get_static_url
-from django.urls import include, path, reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.urls import include, path, re_path, reverse_lazy
 from django.views.generic.base import RedirectView
 
 #: The url patterns of this module (see :doc:`django:topics/http/urls`)
@@ -37,7 +35,7 @@ urlpatterns = [
     ),
     path("api/", include("lunes_cms.api.urls", namespace="api")),
     path("", include("lunes_cms.help.urls")),
-    url(r"^i18n/", include("django.conf.urls.i18n")),
+    re_path(r"^i18n/", include("django.conf.urls.i18n")),
     path("qr_code/", include("qr_code.urls", namespace="qr_code")),
 ]
 

--- a/lunes_cms/core/utils.py
+++ b/lunes_cms/core/utils.py
@@ -1,0 +1,13 @@
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {val}")

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-19 14:40+0000\n"
+"POT-Creation-Date: 2024-10-27 22:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,19 +29,19 @@ msgstr "Das word ist zu keinem Modul zugeordnet."
 msgid "This word is already registered in the system."
 msgstr "Das Wort ist schon im System hinterlegt."
 
-#: api/utils.py:184 api/utils.py:186
+#: api/utils.py:185 api/utils.py:187
 msgid "Definition: "
 msgstr "Definition: "
 
-#: api/utils.py:186
+#: api/utils.py:187
 msgid "No definition is provided for this word."
 msgstr "Für dieses Wort ist keine Definition hinterlegt."
 
-#: api/utils.py:187
+#: api/utils.py:189
 msgid "Training sets: "
 msgstr "Module: "
 
-#: api/utils.py:191
+#: api/utils.py:193
 msgid "This word is not yet registered in the system"
 msgstr "Das Wort ist noch nicht im System hinterlegt."
 
@@ -52,17 +52,17 @@ msgstr ""
 "Der Inhaltstyp muss entweder 'discipline', 'trainingset' oder 'document' "
 "sein."
 
-#: api/v1/serializers/feedback_serializer.py:35
+#: api/v1/serializers/feedback_serializer.py:36
 msgid "{} with id {} does not exist."
 msgstr "{} mit der ID {} existiert nicht."
 
 #: cms/admin.py:35 cms/admins/document_admin.py:162
-#: cms/admins/training_set_admin.py:359 cms/forms.py:46 cms/forms.py:48
+#: cms/admins/training_set_admin.py:361 cms/forms.py:46 cms/forms.py:48
 #: cms/list_filter.py:14 cms/models/discipline.py:101
 msgid "disciplines"
 msgstr "Modulgruppen"
 
-#: cms/admin.py:36 cms/list_filter.py:103 cms/models/training_set.py:91
+#: cms/admin.py:36 cms/list_filter.py:103 cms/models/training_set.py:92
 msgid "training sets"
 msgstr "Module"
 
@@ -75,7 +75,7 @@ msgstr "Vokabeln"
 msgid "api keys"
 msgstr "API Keys"
 
-#: cms/admin.py:39 cms/models/feedback.py:89
+#: cms/admin.py:39 cms/models/feedback.py:90
 msgid "feedback"
 msgstr "Feedback"
 
@@ -104,12 +104,12 @@ msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
 #: cms/admins/discipline_admin.py:387 cms/admins/document_admin.py:179
-#: cms/admins/training_set_admin.py:376
+#: cms/admins/training_set_admin.py:378
 msgid "creator group"
 msgstr "Besitzergruppe"
 
 #: cms/admins/document_admin.py:142 cms/models/training_set.py:25
-#: cms/models/training_set.py:90
+#: cms/models/training_set.py:91
 msgid "training set"
 msgstr "Modul"
 
@@ -117,7 +117,7 @@ msgstr "Modul"
 msgid "audio"
 msgstr "Audio"
 
-#: cms/admins/document_admin.py:216 cms/models/document_image.py:123
+#: cms/admins/document_admin.py:216 cms/models/document_image.py:124
 msgid "image"
 msgstr "Bild"
 
@@ -206,43 +206,43 @@ msgstr[1] ""
 "Die Module {} konnten nicht veröffentlicht werden, da sie weniger als {} "
 "Vokabeln mit bestätigten Bildern enthalten."
 
-#: cms/admins/training_set_admin.py:233
+#: cms/admins/training_set_admin.py:235
 msgid "The training set {} is already released."
 msgid_plural "The training sets {} are already released."
 msgstr[0] "Das Modul {} ist bereits veröffentlicht."
 msgstr[1] "Die Module {} sind bereits veröffentlicht."
 
-#: cms/admins/training_set_admin.py:247
+#: cms/admins/training_set_admin.py:249
 msgid "The training set {} was successfully released."
 msgid_plural "The training sets {} were successfully released."
 msgstr[0] "Das Modul {} wurde erfolgreich veröffentlicht."
 msgstr[1] "Die Module {} wurden erfolgreich veröffentlicht."
 
-#: cms/admins/training_set_admin.py:253
+#: cms/admins/training_set_admin.py:255
 msgid "Unrelease selected training sets"
 msgstr "Ausgewählte Module zurückhalten"
 
-#: cms/admins/training_set_admin.py:277
+#: cms/admins/training_set_admin.py:279
 msgid "The training set {} is already unreleased."
 msgid_plural "The training sets {} are already unreleased."
 msgstr[0] "Das Modul {} ist bereits zurückgehalten."
 msgstr[1] "Die Module {} sind bereits zurückgehalten."
 
-#: cms/admins/training_set_admin.py:288
+#: cms/admins/training_set_admin.py:290
 msgid "The training set {} was successfully unreleased."
 msgid_plural "The training sets {} were successfully unreleased."
 msgstr[0] "Das Modul {} wurde erfolgreich zurückgehalten."
 msgstr[1] "Die Module {} wurden erfolgreich zurückgehalten."
 
-#: cms/admins/training_set_admin.py:295
+#: cms/admins/training_set_admin.py:297
 msgid "words"
 msgstr "Vokabeln"
 
-#: cms/admins/training_set_admin.py:313
+#: cms/admins/training_set_admin.py:315
 msgid "published words"
 msgstr "veröffentlichte Vokabeln"
 
-#: cms/admins/training_set_admin.py:331
+#: cms/admins/training_set_admin.py:333
 msgid "unpublished words"
 msgstr "unveröffentlichte Vokabeln"
 
@@ -259,7 +259,7 @@ msgstr ""
 "Bilder und Audio-Dateien zu sehen, drücke die Alt-Taste, während du ein "
 "Element auswählst."
 
-#: cms/forms.py:77
+#: cms/forms.py:79
 msgid ""
 "You can only release a training set that contains at least {} vocabulary "
 "words with confirmed images."
@@ -395,7 +395,7 @@ msgstr "Zusätzliche Bedeutung 1"
 msgid "additional meaning 2"
 msgstr "Zusätzliche Bedeutung 2"
 
-#: cms/models/document_image.py:124
+#: cms/models/document_image.py:125
 msgid "images"
 msgstr "Bilder"
 
@@ -415,7 +415,7 @@ msgstr "Objekt-ID"
 msgid "The id of the object this feedback entry refers to."
 msgstr "Die ID des Objekts, auf das sich dieser Feedback-Eintrag bezieht."
 
-#: cms/models/feedback.py:32 cms/models/feedback.py:72
+#: cms/models/feedback.py:32 cms/models/feedback.py:73
 msgid "refers to"
 msgstr "bezieht sich auf"
 
@@ -435,15 +435,15 @@ msgstr ""
 "Die nutzende Person, die dieses Feedback als gelesen markiert hat. Wenn das "
 "Feedback ungelesen ist, ist dieses Feld leer."
 
-#: cms/models/feedback.py:52
+#: cms/models/feedback.py:53
 msgid "submitted on"
 msgstr "übermittelt am"
 
-#: cms/models/feedback.py:53
+#: cms/models/feedback.py:54
 msgid "The time and date when the feedback was submitted."
 msgstr "Uhrzeit und Datum, an dem das Feedback eingereicht wurde."
 
-#: cms/models/feedback.py:91
+#: cms/models/feedback.py:92
 msgid "feedback entries"
 msgstr "Feedback-Einträge"
 
@@ -487,27 +487,27 @@ msgstr ""
 msgid "valid"
 msgstr "gültig"
 
-#: cms/models/group_api_key.py:110
+#: cms/models/group_api_key.py:111
 msgid "Download"
 msgstr "Herunterladen"
 
-#: cms/models/group_api_key.py:112 cms/models/group_api_key.py:130
+#: cms/models/group_api_key.py:113 cms/models/group_api_key.py:132
 msgid "QR code"
 msgstr "QR-Code"
 
-#: cms/models/group_api_key.py:124
+#: cms/models/group_api_key.py:126
 msgid "Download QR code"
 msgstr "QR-Code herunterladen"
 
-#: cms/models/group_api_key.py:156
+#: cms/models/group_api_key.py:158
 msgid "{}: Token for the group \"{}\""
 msgstr "{}: Token für die Gruppe \"{}\""
 
-#: cms/models/group_api_key.py:163
+#: cms/models/group_api_key.py:165
 msgid "API Key"
 msgstr "API-Key"
 
-#: cms/models/group_api_key.py:164
+#: cms/models/group_api_key.py:166
 msgid "API Keys"
 msgstr "API-Keys"
 
@@ -639,19 +639,19 @@ msgstr "Datei zu groß! Max. 5 MB"
 msgid "Only use one file extension!"
 msgstr "Nur maximal ein Dateityp erlaubt!"
 
-#: core/settings.py:204
+#: core/settings.py:206
 msgid "English"
 msgstr "Englisch"
 
-#: core/settings.py:205
+#: core/settings.py:207
 msgid "German"
 msgstr "Deutsch"
 
-#: core/settings.py:445 core/settings.py:446 core/settings.py:448
+#: core/settings.py:451 core/settings.py:452 core/settings.py:454
 msgid "Lunes Administration"
 msgstr "Lunes-Verwaltung"
 
-#: core/settings.py:447
+#: core/settings.py:453
 msgid "Welcome to the vocabulary management of Lunes!"
 msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,10 @@ classifiers =
 	License :: OSI Approved :: Apache Software License
 	Operating System :: OS Independent
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
-	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
 	Framework :: Django
-	Framework :: Django :: 3.2
+	Framework :: Django :: 5.1
 	Operating System :: POSIX :: Linux
 	Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Content Management System
 	Topic :: Internet :: WWW/HTTP :: WSGI :: Application
@@ -45,16 +44,16 @@ keywords =
 packages =
 	lunes_cms
 install_requires =
-	django==3.2.21
-	django-import-export==3.3.7
-	django-jazzmin==2.6.0
-	django-mptt==0.15.0
-	django-qr-code==3.1.1
-	djangorestframework==3.14.0
-	drf-spectacular==0.26.5
-	ipython==8.16.0
-	pillow==10.0.1
-	psycopg2==2.9.8
+	django==5.1.2
+	django-import-export==4.2.0
+	django-jazzmin==3.0.1
+	django-mptt==0.16.0
+	django-qr-code==4.1.0
+	djangorestframework==3.15.2
+	drf-spectacular==0.27.2
+	ipython==8.29.0
+	pillow==11.0.0
+	psycopg2==2.9.10
 	pydub==0.25.1
 python_requires = >=3.8
 include_package_data = True
@@ -63,24 +62,24 @@ scripts = lunes_cms/lunes-cms-cli
 [options.extras_require]
 dev =
 	black==23.9.1
-	bumpver==2023.1126
-	pre-commit==3.4.0
-	pyjwt==2.8.0
-	pylint-django==2.5.3
-	pylint-runner==0.6.0
-	shellcheck-py==0.9.0.6
-	twine==4.0.2
+	bumpver==2023.1129
+	pre-commit==4.0.1
+	pyjwt==2.9.0
+	pylint-django==2.6.1
+	pylint-runner==0.7.0
+	shellcheck-py==0.10.0.1
+	twine==5.1.1
 doc =
-	sphinx==7.2.6
-	sphinx-rtd-theme==1.3.0
-	sphinx-last-updated-by-git==0.3.6
+	sphinx==8.1.3
+	sphinx-rtd-theme==3.0.1
+	sphinx-last-updated-by-git==0.3.8
 	sphinxcontrib-django==2.5
 test =
 	pytest-circleci-parallelized==0.1.0
-	pytest-cov==4.1.0
-	pytest-django==4.5.2
-	pytest-icdiff==0.8
-	pytest-xdist==3.3.1
+	pytest-cov==5.0.0
+	pytest-django==4.9.0
+	pytest-icdiff==0.9
+	pytest-xdist==3.6.1
 
 [bumpver]
 current_version = 2024.6.0

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -169,22 +169,30 @@ TRAINING_SET_ENDPOINTS = [
     },
     {
         "endpoint": "/api/training_set/15/",
-        "expected_result": "tests/api/expected-results/training_sets_by_discipline_15.json",
+        "expected_result": (
+            "tests/api/expected-results/training_sets_by_discipline_15.json"
+        ),
     },
     {
         "endpoint": "/api/training_set/15/",
         "api_key": "VALIDTOKEN",
-        "expected_result": "tests/api/expected-results/training_sets_by_discipline_15.json",
+        "expected_result": (
+            "tests/api/expected-results/training_sets_by_discipline_15.json"
+        ),
     },
     {
         "endpoint": "/api/training_set/15/",
         "api_key": "INVALIDTOKEN",
-        "expected_result": "tests/api/expected-results/training_sets_by_discipline_15.json",
+        "expected_result": (
+            "tests/api/expected-results/training_sets_by_discipline_15.json"
+        ),
     },
     {
         "endpoint": "/api/training_set/20/",
         "api_key": "VALIDTOKEN",
-        "expected_result": "tests/api/expected-results/training_sets_by_discipline_20.json",
+        "expected_result": (
+            "tests/api/expected-results/training_sets_by_discipline_20.json"
+        ),
     },
     {
         "endpoint": "/api/training_set/20/",
@@ -203,22 +211,30 @@ TRAINING_SET_ENDPOINTS = [
 VOCABULARY_ENDPOINTS = [
     {
         "endpoint": "/api/documents/7/",
-        "expected_result": "tests/api/expected-results/documents_by_training_set_7.json",
+        "expected_result": (
+            "tests/api/expected-results/documents_by_training_set_7.json"
+        ),
     },
     {
         "endpoint": "/api/documents/7/",
         "api_key": "VALIDTOKEN",
-        "expected_result": "tests/api/expected-results/documents_by_training_set_7.json",
+        "expected_result": (
+            "tests/api/expected-results/documents_by_training_set_7.json"
+        ),
     },
     {
         "endpoint": "/api/documents/7/",
         "api_key": "INVALIDTOKEN",
-        "expected_result": "tests/api/expected-results/documents_by_training_set_7.json",
+        "expected_result": (
+            "tests/api/expected-results/documents_by_training_set_7.json"
+        ),
     },
     {
         "endpoint": "/api/documents/108/",
         "api_key": "VALIDTOKEN",
-        "expected_result": "tests/api/expected-results/documents_by_training_set_108.json",
+        "expected_result": (
+            "tests/api/expected-results/documents_by_training_set_108.json"
+        ),
     },
     {
         "endpoint": "/api/documents/108/",
@@ -351,7 +367,9 @@ FEEDBACK_ENDPOINTS = [
     {
         "endpoint": "/api/feedback/",
         "post_data": {"comment": "invalid", "content_type": "invalid", "object_id": 1},
-        "expected_result": "tests/api/expected-results/feedback_invalid_content_type.json",
+        "expected_result": (
+            "tests/api/expected-results/feedback_invalid_content_type.json"
+        ),
         "expected_status_code": 400,
     },
     {
@@ -361,7 +379,9 @@ FEEDBACK_ENDPOINTS = [
             "content_type": "document",
             "object_id": 1,
         },
-        "expected_result": "tests/api/expected-results/feedback_document_not_found.json",
+        "expected_result": (
+            "tests/api/expected-results/feedback_document_not_found.json"
+        ),
         "expected_status_code": 400,
     },
 ]

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,7 +10,7 @@ echo "Checking system requirements..." | print_info
 # Check if requirements are satisfied
 
 # Define the required python version
-required_python_version="8"
+required_python_version="11"
 if [[ ! -x "$(command -v python3)" ]]; then  echo "Python3 is not installed. Please install version 3.${required_python_version} or later manually and run this script again."  | print_error
     exit 1
 fi


### PR DESCRIPTION
### Short description
Update dependencies including update of Django from version 3 to 5.


### Changes
- Updated dependencies
- Updated to latest major version:
  - `django`
  - `django-import-export`
  - `django-jazzmin`
  - `django-qr-code`
  - `pillow`
- Implementation adapted with regard to deprecated / removed functions of the Django API
- Restored functionality of documents export after update
- ~Updated Python to version `3.13.0`~
- ~`audioop` is removed in Python `3.13.0`. As `pydub` depends on it and [there is currently no better workaround](https://github.com/jiaaro/pydub/issues/725), I've added `audioop-lts` as a dependency~
- Updated Python to version `3.11.0` as this is the latest version supported by our servers