### PR TITLE
CircleCI: Fix `publish-package` step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
           name: Publish lunes-cms package to (Test-)PyPI
           command: |
             source .venv/bin/activate
-            twine upload --non-interactive ./dist/lunes-cms-*.tar.gz
+            twine upload --non-interactive ./dist/lunes_cms-*.tar.gz
   create-release:
     docker:
       - image: cimg/python:3.11


### PR DESCRIPTION
### Short description
Since https://github.com/digitalfabrik/lunes-cms/pull/522 is merged the `develop` CircleCI workflow on the `develop` branch fails: https://app.circleci.com/pipelines/github/digitalfabrik/lunes-cms/892/workflows/ff6e4038-dc60-47be-9fdc-7d5f58ccdf9f

Somehow the name of the `tar.gz` file changed from `./dist/lunes-cms-*.tar.gz` to `./dist/lunes_cms-*.tar.gz`.

To find the bug I've listed the files in the workspace: https://app.circleci.com/pipelines/github/digitalfabrik/lunes-cms/936/workflows/01bf749a-3bfa-4a68-af92-588ca6d32c16/jobs/7422

### Proposed changes
Changed the file name pattern in the `publish-package` step.