### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/dist/
 docs/src/ref/
 docs/src/changelog.rst
 lunes_cms/lunes-cms.log
+.python-version


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I am using the pyenv tool to work with multiple different python versions. However, it creates a .python-version file in each directory where i specified which python version to use, so i need to .gitignore it.

