### PR TITLE
Rename obj variables

### DIFF
--- a/lunes_cms/api/utils.py
+++ b/lunes_cms/api/utils.py
@@ -90,7 +90,7 @@ def get_overview_discipline_queryset():
             "training_sets", filter=Q(training_sets__released=True)
         ),
     )
-    queryset = [obj for obj in queryset if obj.is_root_node()]
+    queryset = [discipline for discipline in queryset if discipline.is_root_node()]
     queryset = get_non_empty_disciplines(queryset)
     return queryset
 
@@ -113,7 +113,11 @@ def get_discipline_by_group_queryset(discipline_view_set):
             "training_sets", filter=Q(training_sets__released=True)
         ),
     )
-    queryset = [obj for obj in queryset if obj.is_root_node() and obj.is_valid()]
+    queryset = [
+        discipline
+        for discipline in queryset
+        if discipline.is_root_node() and discipline.is_valid()
+    ]
     return queryset
 
 
@@ -128,10 +132,10 @@ def get_non_empty_disciplines(queryset):
     :rtype: QuerySet
     """
     queryset = [
-        obj
-        for obj in queryset
-        if get_child_count(obj) > 0
-        or obj.training_sets.filter(released=True).count() > 0
+        discipline
+        for discipline in queryset
+        if get_child_count(discipline) > 0
+        or discipline.training_sets.filter(released=True).count() > 0
     ]
     return queryset
 

--- a/lunes_cms/api/v1/serializers/discipline_serializer.py
+++ b/lunes_cms/api/v1/serializers/discipline_serializer.py
@@ -36,14 +36,14 @@ class DisciplineSerializer(FallbackIconSerializer):
             "nested_training_sets",
         )
 
-    def get_total_discipline_children(self, obj):
+    def get_total_discipline_children(self, discipline):
         """Returns the total child count by calling
-        utils.get_child_count(obj).
+        utils.get_child_count(discipline).
 
 
-        :param disc: Discipline instance
-        :type disc: ~lunes_cms.cms.models.discipline.Discipline
+        :param discipline: Discipline instance
+        :type discipline: ~lunes_cms.cms.models.discipline.Discipline
         :return: sum of children
         :rtype: int
         """
-        return get_child_count(obj)
+        return get_child_count(discipline)

--- a/lunes_cms/api/v1/serializers/group_serializer.py
+++ b/lunes_cms/api/v1/serializers/group_serializer.py
@@ -27,16 +27,20 @@ class GroupSerializer(serializers.ModelSerializer):
             "total_discipline_children",
         )
 
-    def get_total_discipline_children(self, obj):
+    def get_total_discipline_children(self, group):
         """Returns the total child count of a group.
         A child itself or one of its sub-children needs to
         contain at least one training set.
 
-        :param disc: Discipline instance
-        :type disc: ~lunes_cms.cms.models.discipline.Discipline
+        :param group: Group instance
+        :type group: django.contrib.auth.models.Group
         :return: sum of children
         :rtype: int
         """
-        queryset = Discipline.objects.filter(released=True, created_by=obj.id)
-        queryset = [obj for obj in queryset if obj.is_root_node() and obj.is_valid()]
+        queryset = Discipline.objects.filter(released=True, created_by=group.id)
+        queryset = [
+            discipline
+            for discipline in queryset
+            if discipline.is_root_node() and discipline.is_valid()
+        ]
         return len(queryset)

--- a/lunes_cms/cms/admins/discipline_admin.py
+++ b/lunes_cms/cms/admins/discipline_admin.py
@@ -300,8 +300,8 @@ class DisciplineAdmin(DraggableMPTTAdmin):
 
             dataset = Dataset(
                 *(
-                    resource.export_resource(obj)
-                    for obj in Document.objects.filter(
+                    resource.export_resource(document)
+                    for document in Document.objects.filter(
                         training_sets__discipline=profession
                     )
                 ),
@@ -324,82 +324,82 @@ class DisciplineAdmin(DraggableMPTTAdmin):
         description=_("released modules"),
         ordering="modules_released_order",
     )
-    def modules_released(self, obj):
+    def modules_released(self, discipline):
         """
         returns HTML Tag of the link to released training sets related to the discipline
 
-        :param obj: Discipline object
-        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+        :param discipline: Discipline object
+        :type discipline: ~lunes_cms.cms.models.discipline.Discipline
 
         :return: HTML Tag of the link to released training sets related to the discipline
         :rtype: str
         """
-        if not obj.is_leaf_node():
-            return obj.children_modules_released
+        if not discipline.is_leaf_node():
+            return discipline.children_modules_released
         trainingset_list = reverse("admin:cms_trainingset_changelist")
         return mark_safe(
-            f"<a href={trainingset_list}?disciplines={obj.id}&released__exact=1>{obj.modules_released}</a>"
+            f"<a href={trainingset_list}?disciplines={discipline.id}&released__exact=1>{discipline.modules_released}</a>"
         )
 
     @admin.display(
         description=_("unreleased modules"),
         ordering="modules_unreleased_order",
     )
-    def modules_unreleased(self, obj):
+    def modules_unreleased(self, discipline):
         """
         returns HTML Tag of the link to unreleased training sets related to the discipline
 
-        :param obj: Discipline object
-        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+        :param discipline: Discipline object
+        :type discipline: ~lunes_cms.cms.models.discipline.Discipline
 
         :return: HTML Tag of the link to unreleased training sets related to the discipline
         :rtype: str
         """
-        if not obj.is_leaf_node():
-            return obj.children_modules_unreleased
+        if not discipline.is_leaf_node():
+            return discipline.children_modules_unreleased
         trainingset_list = reverse("admin:cms_trainingset_changelist")
         return mark_safe(
-            f"<a href={trainingset_list}?disciplines={obj.id}&released__exact=0>{obj.modules_unreleased}</a>"
+            f"<a href={trainingset_list}?disciplines={discipline.id}&released__exact=0>{discipline.modules_unreleased}</a>"
         )
 
     @admin.display(
         description=_("published words in released modules"),
         ordering="-words_released_order",
     )
-    def words_released(self, obj):
+    def words_released(self, discipline):
         """
         returns HTML Tag of the link to released words in the relased training sets related to the descipline
 
-        :param obj: Discipline object
-        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+        :param discipline: Discipline object
+        :type discipline: ~lunes_cms.cms.models.discipline.Discipline
 
         :return:
         :rtype: str
         """
-        if not obj.is_leaf_node():
-            return obj.children_words_released
+        if not discipline.is_leaf_node():
+            return discipline.children_words_released
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
-            f"<a href={document_list}?disciplines={obj.id}&assigned=released&images=approved>{obj.words_released}</a>"
+            f"<a href={document_list}?disciplines={discipline.id}&assigned=released&images=approved>{discipline.words_released}</a>"
         )
 
     @admin.display(
         description=_("creator group"),
     )
-    def creator_group(self, obj):
+    def creator_group(self, discipline):
         """
         Include creator group of discipline in list display
 
-        :param obj: Discipline object
-        :type obj: ~lunes_cms.cms.models.discipline.Discipline
+        :param discipline: Discipline object
+        :type discipline: ~lunes_cms.cms.models.discipline.Discipline
 
         :return: Either static admin group or user group
         :rtype: str
         """
-        if obj.creator_is_admin:
+        if discipline.creator_is_admin:
             return Static.admin_group
-        if obj.created_by:
-            return obj.created_by
+        if discipline.created_by:
+            return discipline.created_by
         return None
 
     class Media:

--- a/lunes_cms/cms/admins/document_admin.py
+++ b/lunes_cms/cms/admins/document_admin.py
@@ -128,31 +128,31 @@ class DocumentAdmin(admin.ModelAdmin):
             return qs.filter(creator_is_admin=True)
         return qs.filter(created_by__in=request.user.groups.all())
 
-    def related_training_set(self, obj):
+    def related_training_set(self, document):
         """
         Display related training sets in list display
 
-        :param obj: Document object
-        :type obj: models.Document
+        :param document: Document object
+        :type document: models.Document
         :return: comma seperated list of related training sets
         :rtype: str
         """
-        return ", ".join([child.title for child in obj.training_sets.all()])
+        return ", ".join([child.title for child in document.training_sets.all()])
 
     related_training_set.short_description = _("training set")
 
-    def related_disciplines(self, obj):
+    def related_disciplines(self, document):
         """
         Display related desciplines in list display
 
-        :param obj: Document object
-        :type obj: models.Document
+        :param document: Document object
+        :type document: models.Document
         :return: comma seperated list of related training sets
         :rtype: str
         """
         disciplines = []
 
-        for training_set in obj.training_sets.all():
+        for training_set in document.training_sets.all():
             disciplines += [
                 discipline.title for discipline in training_set.discipline.all()
             ]
@@ -161,34 +161,34 @@ class DocumentAdmin(admin.ModelAdmin):
 
     related_disciplines.short_description = _("disciplines")
 
-    def creator_group(self, obj):
+    def creator_group(self, document):
         """
         Include creator group of discipline in list display
 
-        :param obj: Document object
-        :type obj: models.Document
+        :param document: Document object
+        :type document: models.Document
         :return: Either static admin group or user group
         :rtype: str
         """
-        if obj.creator_is_admin:
+        if document.creator_is_admin:
             return Static.admin_group
-        if obj.created_by:
-            return obj.created_by
+        if document.created_by:
+            return document.created_by
         return None
 
     creator_group.short_description = _("creator group")
     creator_group.admin_order_field = "created_by"
 
-    def has_audio(self, obj):
+    def has_audio(self, document):
         """
         Include in list display whether a document has an audio file.
 
-        :param obj: Document object
-        :type obj: models.Document
+        :param document: Document object
+        :type document: models.Document
         :return: Either static admin group or user group
         :rtype: str
         """
-        if obj.audio:
+        if document.audio:
             return True
         return False
 
@@ -196,19 +196,19 @@ class DocumentAdmin(admin.ModelAdmin):
     has_audio.short_description = _("audio")
     has_audio.admin_order_field = "audio"
 
-    def has_image(self, obj):
+    def has_image(self, document):
         """
         Include in list display whether a document has an image file.
 
-        :param obj: Document object
-        :type obj: models.Document
+        :param document: Document object
+        :type document: models.Document
 
         :return: Whether the document has at least one confirmed image
         :rtype: bool
         """
-        if obj.has_confirmed_image:
+        if document.has_confirmed_image:
             return True
-        if obj.has_image:
+        if document.has_image:
             return None
         return False
 
@@ -216,17 +216,17 @@ class DocumentAdmin(admin.ModelAdmin):
     has_image.short_description = _("image")
     has_image.admin_order_field = "image_sort"
 
-    def singular_article_display(self, obj):
+    def singular_article_display(self, document):
         """
         Include article of document in list display
 
-        :param obj: Document object
-        :type obj: models.Document
+        :param document: Document object
+        :type document: models.Document
 
         :return: Either static admin group or user group
         :rtype: str
         """
-        return obj.get_singular_article_display()
+        return document.get_singular_article_display()
 
     singular_article_display.short_description = _("singular article")
 

--- a/lunes_cms/cms/admins/document_image_admin.py
+++ b/lunes_cms/cms/admins/document_image_admin.py
@@ -19,7 +19,7 @@ class DocumentImageAdmin(admin.StackedInline):
 
     def get_fields(self, request, obj=None):
         """
-        Override djangos get_fields function
+        Override django's get_fields function
         to add custom superuser fields to the
         admin interface if the user has the corresponding
         access rights.

--- a/lunes_cms/cms/admins/sponsor_admin.py
+++ b/lunes_cms/cms/admins/sponsor_admin.py
@@ -22,27 +22,31 @@ class SponsorAdmin(admin.ModelAdmin):
     ]
     list_per_page = 25
 
-    def has_logo(self, obj):
+    def has_logo(self, sponsor):
         """
         Additional field to display whether a logo is set for the sponsor in the list view.
 
+        :param sponsor: Sponsor object
+        :type sponsor: ~lunes_cms.cms.models.sponsor.Sponsor
         :return: Whether the sponsor has a logo
         :rtype: bool
         """
 
-        return bool(obj.logo)
+        return bool(sponsor.logo)
 
     has_logo.boolean = True
     has_logo.short_description = _("logo")
 
-    def image_tag(self, obj):
+    def image_tag(self, sponsor):
         """
         Image thumbnail to display a preview of a image in the form view.
 
+        :param sponsor: Sponsor object
+        :type sponsor: ~lunes_cms.cms.models.sponsor.Sponsor
         :return: img HTML tag to display an image thumbnail
         :rtype: str
         """
-        return get_image_tag(obj.logo)
+        return get_image_tag(sponsor.logo)
 
     image_tag.short_description = ""
 

--- a/lunes_cms/cms/admins/training_set_admin.py
+++ b/lunes_cms/cms/admins/training_set_admin.py
@@ -297,82 +297,82 @@ class TrainingSetAdmin(DraggableMPTTAdmin):
         description=_("words"),
         ordering="-words",
     )
-    def words(self, obj):
+    def words(self, training_set):
         """
         returns HTML tag of the link to the list of words related to the training set
 
-        :param obj: Training set object
-        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :param training_set: Training set object
+        :type training_set: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: HTML tag of the link to the list of words related to the training set
         :rtype: str
         """
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
-            f"<a href={document_list}?training+set={obj.id}>{obj.words}</a>"
+            f"<a href={document_list}?training+set={training_set.id}>{training_set.words}</a>"
         )
 
     @admin.display(
         description=_("published words"),
         ordering="-words_released",
     )
-    def words_released(self, obj):
+    def words_released(self, training_set):
         """
         returns HTML tag of the link to the list of released words related to the training set
 
-        :param obj: Training set object
-        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :param training_set: Training set object
+        :type training_set: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: HTML tag of the link to the list of released words related to the training set
         :rtype: str
         """
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
-            f"<a href={document_list}?training+set={obj.id}&images=approved>{obj.words_released}</a>"
+            f"<a href={document_list}?training+set={training_set.id}&images=approved>{training_set.words_released}</a>"
         )
 
     @admin.display(
         description=_("unpublished words"),
         ordering="-words_unreleased",
     )
-    def words_unreleased(self, obj):
+    def words_unreleased(self, training_set):
         """
         returns HTML tag of the Link to the list of unreleased words related to the training set
 
-        :param obj: Training set object
-        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :param training_set: Training set object
+        :type training_set: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: HTML tag of the Link to the list of unreleased words related to the training set
         :rtype: str
         """
         document_list = reverse("admin:cms_document_changelist")
         return mark_safe(
-            f"<a href={document_list}?training+set={obj.id}&images=no-approved>{obj.words_unreleased}</a>"
+            f"<a href={document_list}?training+set={training_set.id}&images=no-approved>{training_set.words_unreleased}</a>"
         )
 
-    def related_disciplines(self, obj):
+    def related_disciplines(self, training_set):
         """
         Display related disciplines in list display
 
-        :param obj: Training set object
-        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :param training_set: Training set object
+        :type training_set: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: comma separated list of related disciplines
         :rtype: str
         """
-        return ", ".join([child.title for child in obj.discipline.all()])
+        return ", ".join([child.title for child in training_set.discipline.all()])
 
     related_disciplines.short_description = _("disciplines")
 
-    def creator_group(self, obj):
+    def creator_group(self, training_set):
         """
         Include creator group of discipline in list display
 
-        :param obj: Training set object
-        :type obj: ~lunes_cms.cms.models.training_set.TrainingSet
+        :param training_set: Training set object
+        :type training_set: ~lunes_cms.cms.models.training_set.TrainingSet
         :return: Either static admin group or user group
         :rtype: str
         """
-        if obj.creator_is_admin:
+        if training_set.creator_is_admin:
             return Static.admin_group
-        if obj.created_by:
-            return obj.created_by
+        if training_set.created_by:
+            return training_set.created_by
         return None
 
     creator_group.short_description = _("creator group")

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-27 22:23+0000\n"
+"POT-Creation-Date: 2025-02-12 13:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,27 +21,27 @@ msgstr ""
 msgid "API"
 msgstr "API"
 
-#: api/utils.py:175
+#: api/utils.py:179
 msgid "This word is assigned to no training set."
 msgstr "Das word ist zu keinem Modul zugeordnet."
 
-#: api/utils.py:182
+#: api/utils.py:186
 msgid "This word is already registered in the system."
 msgstr "Das Wort ist schon im System hinterlegt."
 
-#: api/utils.py:185 api/utils.py:187
+#: api/utils.py:189 api/utils.py:191
 msgid "Definition: "
 msgstr "Definition: "
 
-#: api/utils.py:187
+#: api/utils.py:191
 msgid "No definition is provided for this word."
 msgstr "Für dieses Wort ist keine Definition hinterlegt."
 
-#: api/utils.py:189
+#: api/utils.py:193
 msgid "Training sets: "
 msgstr "Module: "
 
-#: api/utils.py:193
+#: api/utils.py:197
 msgid "This word is not yet registered in the system"
 msgstr "Das Wort ist noch nicht im System hinterlegt."
 
@@ -184,7 +184,7 @@ msgid "The selected feedback entries were successfully marked as unread."
 msgstr ""
 "Die ausgewählten Feedback-Einträge wurden erfolgreich als ungelesen markiert."
 
-#: cms/admins/sponsor_admin.py:36 cms/models/sponsor.py:26
+#: cms/admins/sponsor_admin.py:38 cms/models/sponsor.py:26
 msgid "logo"
 msgstr "Logo"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr renames `obj` variables to be more descriptive.
I did not change obj variables if they can be more than a single
model type.
Also instances of `obj` variables in methods that overwrite a
super method are kept the same.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Rename variables to be more descriptive


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #514
