### PR TITLE
Persist pyproject.toml in dev version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - pyproject.toml
             - setup.cfg
             - lunes_cms/__init__.py
   bump-version:


### PR DESCRIPTION
### Short description

Persist the pyproject.toml file after bumping the dev version.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #602 
