### PR TITLE
Add endpoint for units of a job

### DIFF
--- a/lunes_cms/api/v2/serializers/__init__.py
+++ b/lunes_cms/api/v2/serializers/__init__.py
@@ -3,4 +3,5 @@ This module contains the model serializers, see :doc:`django:topics/serializatio
 """
 
 from .word_serializer import WordSerializer
+from .unit_serializer import UnitSerializer
 from .job_serializer import JobSerializer

--- a/lunes_cms/api/v2/serializers/unit_serializer.py
+++ b/lunes_cms/api/v2/serializers/unit_serializer.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+
+from ....cmsv2.models import Unit
+
+
+class UnitSerializer(serializers.ModelSerializer):
+    """
+    Serializer for units.
+    """
+
+    number_words = serializers.IntegerField()
+
+    class Meta:
+        """
+        Define model and the corresponding fields
+        """
+
+        model = Unit
+        fields = (
+            "id",
+            "title",
+            "description",
+            "icon",
+            "number_words",
+        )

--- a/lunes_cms/api/v2/urls.py
+++ b/lunes_cms/api/v2/urls.py
@@ -16,6 +16,7 @@ app_name = "v2"
 router = OptionalSlashRouter()
 router.register(r"jobs", JobViewSet, "jobs")
 router.register(r"words", views.WordViewSet, "words")
+router.register(r"jobs/(?P<job_id>[0-9]+)/units", views.JobUnitsViewSet, "units")
 
 #: The url patterns of this module (see :doc:`django:topics/http/urls`)
 urlpatterns = [

--- a/lunes_cms/api/v2/views/__init__.py
+++ b/lunes_cms/api/v2/views/__init__.py
@@ -1,2 +1,3 @@
 from .word_viewset import WordViewSet
 from .job_viewset import JobViewSet
+from .job_units_viewset import JobUnitsViewSet

--- a/lunes_cms/api/v2/views/job_units_viewset.py
+++ b/lunes_cms/api/v2/views/job_units_viewset.py
@@ -1,0 +1,47 @@
+from django.db.models import Q, Count
+from rest_framework import viewsets
+from rest_framework.exceptions import PermissionDenied
+
+from ..serializers import UnitSerializer
+from ....cmsv2.models import Unit, Job
+
+
+class JobUnitsViewSet(viewsets.ModelViewSet):
+    """
+    Retrieve the list of all units that belong to a job
+    """
+
+    serializer_class = UnitSerializer
+    http_method_names = ["get"]
+
+    def get_queryset(self):
+        """
+        Get the queryset of all released units of a job
+
+        :return: The queryset of units
+        :rtype: ~django.db.models.query.QuerySet
+        """
+        if getattr(self, "swagger_fake_view", False):
+            return Unit.objects.none()
+
+        try:
+            job = Job.objects.get(id=self.kwargs["job_id"])
+        except Job.DoesNotExist as e:
+            raise PermissionDenied() from e
+
+        if not job.released:
+            raise PermissionDenied()
+
+        queryset = Unit.objects.filter(jobs__id=job.id, released=True).annotate(
+            number_words=Count(
+                "unit_word_relations",
+                filter=Q(
+                    unit_word_relations__word__audio_check_status="CONFIRMED",
+                )
+                & (
+                    Q(unit_word_relations__word__image_check_status="CONFIRMED")
+                    | Q(unit_word_relations__image_check_status="CONFIRMED")
+                ),
+            )
+        )
+        return queryset.order_by("title")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Adds a new api v2 endpoint `/jobs/<id>/units` to get all units of a job.

I noticed that the api v2 issues all used singular for the urls, but since I have already used plural in the other prs, I guess its better to just stick to it now.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add the endpoint

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #582 
