### PR TITLE
Add endpoint to get all words of a unit

### DIFF
--- a/lunes_cms/api/v2/serializers/__init__.py
+++ b/lunes_cms/api/v2/serializers/__init__.py
@@ -3,5 +3,6 @@ This module contains the model serializers, see :doc:`django:topics/serializatio
 """
 
 from .word_serializer import WordSerializer
+from .unit_word_relation_serializer import UnitWordRelationSerializer
 from .unit_serializer import UnitSerializer
 from .job_serializer import JobSerializer

--- a/lunes_cms/api/v2/serializers/unit_word_relation_serializer.py
+++ b/lunes_cms/api/v2/serializers/unit_word_relation_serializer.py
@@ -1,0 +1,29 @@
+from rest_framework import serializers
+
+from ....cmsv2.models.unit import UnitWordRelation
+
+
+class UnitWordRelationSerializer(serializers.ModelSerializer):
+    """
+    Serializer for unit word relations.
+    """
+
+    id = serializers.IntegerField(source="word.id")
+    word = serializers.CharField(source="word.word")
+    article = serializers.CharField(source="word.singular_article_as_text")
+    image = serializers.ImageField(source="effective_public_image")
+    audio = serializers.FileField(source="word.audio")
+
+    class Meta:
+        """
+        Define model and the corresponding fields
+        """
+
+        model = UnitWordRelation
+        fields = (
+            "id",
+            "word",
+            "article",
+            "image",
+            "audio",
+        )

--- a/lunes_cms/api/v2/urls.py
+++ b/lunes_cms/api/v2/urls.py
@@ -15,8 +15,11 @@ app_name = "v2"
 #: Router for dynamic url patterns
 router = OptionalSlashRouter()
 router.register(r"jobs", JobViewSet, "jobs")
+router.register(r"jobs/(?P<job_id>[0-9]+)/units", views.JobUnitsViewSet, "units-of-job")
+router.register(
+    r"units/(?P<unit_id>[0-9]+)/words", views.UnitWordViewSet, "words-of-units"
+)
 router.register(r"words", views.WordViewSet, "words")
-router.register(r"jobs/(?P<job_id>[0-9]+)/units", views.JobUnitsViewSet, "units")
 
 #: The url patterns of this module (see :doc:`django:topics/http/urls`)
 urlpatterns = [

--- a/lunes_cms/api/v2/views/__init__.py
+++ b/lunes_cms/api/v2/views/__init__.py
@@ -1,3 +1,4 @@
 from .word_viewset import WordViewSet
+from .unit_words_viewset import UnitWordViewSet
 from .job_viewset import JobViewSet
 from .job_units_viewset import JobUnitsViewSet

--- a/lunes_cms/api/v2/views/job_units_viewset.py
+++ b/lunes_cms/api/v2/views/job_units_viewset.py
@@ -39,7 +39,10 @@ class JobUnitsViewSet(viewsets.ModelViewSet):
                     unit_word_relations__word__audio_check_status="CONFIRMED",
                 )
                 & (
-                    Q(unit_word_relations__word__image_check_status="CONFIRMED")
+                    Q(
+                        unit_word_relations__image="",
+                        unit_word_relations__word__image_check_status="CONFIRMED",
+                    )
                     | Q(unit_word_relations__image_check_status="CONFIRMED")
                 ),
             )

--- a/lunes_cms/api/v2/views/unit_words_viewset.py
+++ b/lunes_cms/api/v2/views/unit_words_viewset.py
@@ -1,0 +1,46 @@
+from django.db.models import Q
+from rest_framework import viewsets
+from rest_framework.exceptions import PermissionDenied
+
+from ....cmsv2.models import Unit
+from ..serializers import UnitWordRelationSerializer
+from ....cmsv2.models.unit import UnitWordRelation
+
+
+class UnitWordViewSet(viewsets.ModelViewSet):
+    """
+    Retrieve the list of all words that belong to a given unit
+    """
+
+    serializer_class = UnitWordRelationSerializer
+    http_method_names = ["get"]
+
+    def get_queryset(self):
+        """
+        Get the queryset of unit word relations
+
+        :return: The queryset of unit word relations
+        :rtype: ~django.db.models.query.QuerySet
+        """
+        if getattr(self, "swagger_fake_view", False):
+            return UnitWordRelation.objects.none()
+
+        units = Unit.objects.filter(
+            id=self.kwargs["unit_id"], released=True, jobs__released=True
+        ).distinct()
+        if len(units) != 1:
+            raise PermissionDenied()
+        unit = units[0]
+
+        queryset = (
+            UnitWordRelation.objects.select_related("word")
+            .filter(
+                unit=unit,
+                word__audio_check_status="CONFIRMED",
+            )
+            .filter(
+                Q(image_check_status="CONFIRMED")
+                | Q(image="", word__image_check_status="CONFIRMED")
+            )
+        )
+        return queryset

--- a/lunes_cms/cmsv2/models/unit.py
+++ b/lunes_cms/cmsv2/models/unit.py
@@ -115,6 +115,20 @@ class UnitWordRelation(models.Model):
 
     generate_image_link.short_description = _("Generate Image")
 
+    @property
+    def effective_public_image(self):
+        """
+        Returns:
+            str: The url to the public image of this unit word relation
+        """
+        if self.image and self.image_check_status != "CONFIRMED":
+            return ""
+        if self.image and self.image_check_status == "CONFIRMED":
+            return self.image
+        if self.word.image and self.word.image_check_status == "CONFIRMED":
+            return self.word.image
+        return ""
+
     class Meta:
         """
         Meta class for the UnitWordRelation model.

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-21 09:39+0000\n"
+"POT-Creation-Date: 2025-10-22 13:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -338,7 +338,7 @@ msgid "alternative words"
 msgstr "Alternative Wörter"
 
 #: cms/models/discipline.py:20 cms/models/training_set.py:24
-#: cmsv2/models/job.py:19 cmsv2/models/unit.py:136
+#: cmsv2/models/job.py:19 cmsv2/models/unit.py:150
 msgid "released"
 msgstr "veröffentlicht"
 
@@ -348,25 +348,25 @@ msgid "discipline"
 msgstr "Modulgruppe"
 
 #: cms/models/discipline.py:23 cms/models/training_set.py:27
-#: cmsv2/models/unit.py:139
+#: cmsv2/models/unit.py:153
 msgid "description"
 msgstr "Beschreibung"
 
 #: cms/models/discipline.py:26 cms/models/group.py:10
 #: cms/models/training_set.py:30 cmsv2/models/job.py:22
-#: cmsv2/models/unit.py:142
+#: cmsv2/models/unit.py:156
 msgid "icon"
 msgstr "Icon"
 
 #: cms/models/discipline.py:33 cms/models/document.py:94
 #: cms/models/training_set.py:39 cmsv2/models/job.py:30
-#: cmsv2/models/unit.py:150 cmsv2/models/word.py:106
+#: cmsv2/models/unit.py:164 cmsv2/models/word.py:106
 msgid "created by"
 msgstr "Erstellt von"
 
 #: cms/models/discipline.py:36 cms/models/document.py:98
 #: cms/models/training_set.py:41 cmsv2/models/job.py:33
-#: cmsv2/models/unit.py:152 cmsv2/models/word.py:110
+#: cmsv2/models/unit.py:166 cmsv2/models/word.py:110
 msgid "admin"
 msgstr "Admin"
 
@@ -378,7 +378,7 @@ msgstr "Übergeordnete Modulgruppe"
 msgid "word type"
 msgstr "Wortart"
 
-#: cms/models/document.py:33 cmsv2/models/unit.py:147 cmsv2/models/word.py:31
+#: cms/models/document.py:33 cmsv2/models/unit.py:161 cmsv2/models/word.py:31
 msgid "word"
 msgstr "Wort"
 
@@ -659,7 +659,7 @@ msgid "units"
 msgstr "Einheiten"
 
 #: cmsv2/admins/job_admin.py:88 cmsv2/admins/unit_admin.py:122
-#: cmsv2/models/job.py:34 cmsv2/models/unit.py:153
+#: cmsv2/models/job.py:34 cmsv2/models/unit.py:167
 msgid "created at"
 msgstr "Erstellt"
 
@@ -694,15 +694,15 @@ msgstr "Bild Prüfstatus"
 msgid "Vocabulary Management v2"
 msgstr "Vokabelverwaltung v2"
 
-#: cmsv2/models/job.py:20 cmsv2/models/unit.py:145
+#: cmsv2/models/job.py:20 cmsv2/models/unit.py:159
 msgid "job"
 msgstr "Beruf"
 
-#: cmsv2/models/job.py:35 cmsv2/models/unit.py:154 cmsv2/models/word.py:83
+#: cmsv2/models/job.py:35 cmsv2/models/unit.py:168 cmsv2/models/word.py:83
 msgid "modified at"
 msgstr "zuletzt geändert"
 
-#: cmsv2/models/job.py:91 cmsv2/models/unit.py:198
+#: cmsv2/models/job.py:91 cmsv2/models/unit.py:212
 msgid "Icon"
 msgstr "Icon"
 
@@ -722,23 +722,23 @@ msgstr "Berufe"
 msgid "Generate Image"
 msgstr "Bild generieren"
 
-#: cmsv2/models/unit.py:126
+#: cmsv2/models/unit.py:140
 msgid "Unit-Word Relation"
 msgstr "Einheit-Wort Beziehung"
 
-#: cmsv2/models/unit.py:127
+#: cmsv2/models/unit.py:141
 msgid "Unit-Word Relations"
 msgstr "Einheit-Wort Beziehungen"
 
-#: cmsv2/models/unit.py:137
+#: cmsv2/models/unit.py:151
 msgid "unit"
 msgstr "Einheit"
 
-#: cmsv2/models/unit.py:230
+#: cmsv2/models/unit.py:244
 msgid "Unit"
 msgstr "Einheit"
 
-#: cmsv2/models/unit.py:231
+#: cmsv2/models/unit.py:245
 msgid "Units"
 msgstr "Einheit"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Adds a new api v2 endpoint `units/<id>/words` to get all words of a unit, with their correct image

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add the endpoint
- Add method to `UnitWordRelation` to get the image that should be used in the api response

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #583 
