### PR TITLE
585 list all words of a job

### DIFF
--- a/lunes_cms/api/v2/serializers/unit_word_relation_serializer.py
+++ b/lunes_cms/api/v2/serializers/unit_word_relation_serializer.py
@@ -11,7 +11,9 @@ class UnitWordRelationSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source="word.id")
     word = serializers.CharField(source="word.word")
     article = serializers.CharField(source="word.singular_article_as_text")
-    image = serializers.ImageField(source="effective_public_image")
+    images = serializers.ListSerializer(
+        child=serializers.ImageField(), source="effective_public_images"
+    )
     audio = serializers.FileField(source="word.audio")
 
     class Meta:
@@ -24,6 +26,6 @@ class UnitWordRelationSerializer(serializers.ModelSerializer):
             "id",
             "word",
             "article",
-            "image",
+            "images",
             "audio",
         )

--- a/lunes_cms/api/v2/serializers/word_serializer.py
+++ b/lunes_cms/api/v2/serializers/word_serializer.py
@@ -9,6 +9,9 @@ class WordSerializer(serializers.ModelSerializer):
     """
 
     article = serializers.CharField(source="singular_article_as_text")
+    images = serializers.ListSerializer(
+        child=serializers.ImageField(), source="images_for_api"
+    )
 
     class Meta:
         """
@@ -20,6 +23,6 @@ class WordSerializer(serializers.ModelSerializer):
             "id",
             "word",
             "article",
-            "image",
+            "images",
             "audio",
         )

--- a/lunes_cms/api/v2/urls.py
+++ b/lunes_cms/api/v2/urls.py
@@ -16,6 +16,7 @@ router = OptionalSlashRouter()
 router.register(r"feedback", views.CreateFeedbackViewSet, basename="feedback")
 router.register(r"jobs", views.JobViewSet, "jobs")
 router.register(r"jobs/(?P<job_id>[0-9]+)/units", views.JobUnitsViewSet, "units-of-job")
+router.register(r"jobs/(?P<job_id>[0-9]+)/words", views.JobWordsViewSet, "words-of-job")
 router.register(r"sponsors", views.SponsorsViewSet, "sponsors")
 router.register(
     r"units/(?P<unit_id>[0-9]+)/words", views.UnitWordViewSet, "words-of-units"

--- a/lunes_cms/api/v2/views/__init__.py
+++ b/lunes_cms/api/v2/views/__init__.py
@@ -2,5 +2,6 @@ from .word_viewset import WordViewSet
 from .unit_words_viewset import UnitWordViewSet
 from .job_viewset import JobViewSet
 from .job_units_viewset import JobUnitsViewSet
+from .job_words_viewset import JobWordsViewSet
 from .sponsors_viewset import SponsorsViewSet
 from .feedback_viewset import CreateFeedbackViewSet

--- a/lunes_cms/api/v2/views/job_words_viewset.py
+++ b/lunes_cms/api/v2/views/job_words_viewset.py
@@ -1,0 +1,62 @@
+from django.db.models import Q, OuterRef, Prefetch, Exists
+from rest_framework import viewsets
+from rest_framework.exceptions import PermissionDenied
+
+from ....cmsv2.models import Job, Word
+from ..serializers import WordSerializer
+from ....cmsv2.models.unit import UnitWordRelation
+
+
+class JobWordsViewSet(viewsets.ModelViewSet):
+    """
+    Retrieve the list of all words of a job.
+    A word is returned if it public in at least one unit that belongs to the job.
+    All public images that belong to a public unit of that job will be returned.
+    Images of relations are ordered alphabetically by their unit title
+    and the default image of the word always comes last.
+    """
+
+    serializer_class = WordSerializer
+    http_method_names = ["get"]
+
+    def get_queryset(self):
+        """
+        Get the queryset of words
+
+        :return: The queryset of words
+        :rtype: ~django.db.models.query.QuerySet
+        """
+        if getattr(self, "swagger_fake_view", False):
+            return Word.objects.none()
+
+        try:
+            job = Job.objects.get(id=self.kwargs["job_id"])
+        except Job.DoesNotExist as e:
+            raise PermissionDenied() from e
+
+        if not job.released:
+            raise PermissionDenied()
+
+        unit_word_relations = UnitWordRelation.objects.filter(
+            unit__released=True,
+            unit__jobs=job,
+            word__audio_check_status="CONFIRMED",
+        ).filter(
+            Q(image_check_status="CONFIRMED")
+            | Q(image="", word__image_check_status="CONFIRMED")
+        )
+        queryset = (
+            Word.objects.filter(
+                Exists(unit_word_relations.filter(word__id=OuterRef("id")))
+            )
+            .prefetch_related(
+                Prefetch(
+                    "unit_word_relations",
+                    unit_word_relations.exclude(image="").order_by("unit__title"),
+                    to_attr="unit_word_relations_of_job",
+                )
+            )
+            .order_by("word")
+        )
+
+        return queryset

--- a/lunes_cms/api/v2/views/unit_words_viewset.py
+++ b/lunes_cms/api/v2/views/unit_words_viewset.py
@@ -42,5 +42,6 @@ class UnitWordViewSet(viewsets.ModelViewSet):
                 Q(image_check_status="CONFIRMED")
                 | Q(image="", word__image_check_status="CONFIRMED")
             )
+            .order_by("word__word")
         )
         return queryset

--- a/lunes_cms/cmsv2/models/unit.py
+++ b/lunes_cms/cmsv2/models/unit.py
@@ -115,19 +115,18 @@ class UnitWordRelation(models.Model):
 
     generate_image_link.short_description = _("Generate Image")
 
-    @property
-    def effective_public_image(self):
+    def effective_public_images(self):
         """
         Returns:
-            str: The url to the public image of this unit word relation
+            list[str]: The url to the public images of this unit word relation
         """
         if self.image and self.image_check_status != "CONFIRMED":
-            return ""
+            return []
         if self.image and self.image_check_status == "CONFIRMED":
-            return self.image
+            return [self.image]
         if self.word.image and self.word.image_check_status == "CONFIRMED":
-            return self.word.image
-        return ""
+            return [self.word.image]
+        return []
 
     class Meta:
         """

--- a/lunes_cms/cmsv2/models/word.py
+++ b/lunes_cms/cmsv2/models/word.py
@@ -220,6 +220,24 @@ class Word(models.Model):
 
     image_tag.short_description = ""
 
+    def images_for_api(self):
+        """
+        Returns all images that belong to this word to be returned in the api.
+        By default, this only includes the default image of this word, if it is checked.
+        If the unit word relations for this word have been set, their images will be used as well.
+
+        Returns:
+            list[str]: A list of images that belong to this word.
+        """
+        images = [
+            relation.image
+            for relation in getattr(self, "unit_word_relations_of_job", [])
+        ]
+        if self.image_check_status == "CONFIRMED":
+            images.append(self.image)
+
+        return images
+
     @property
     def singular_article_as_text(self):
         """

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -135,7 +135,7 @@ msgstr "Bild"
 msgid "singular article"
 msgstr "Singular-Artikel"
 
-#: cms/admins/document_resource.py:24 cmsv2/models/word.py:246
+#: cms/admins/document_resource.py:24 cmsv2/models/word.py:264
 msgid "Word"
 msgstr "Vokabel"
 
@@ -343,7 +343,7 @@ msgid "alternative words"
 msgstr "Alternative Wörter"
 
 #: cms/models/discipline.py:20 cms/models/training_set.py:24
-#: cmsv2/models/job.py:19 cmsv2/models/unit.py:150
+#: cmsv2/models/job.py:19 cmsv2/models/unit.py:149
 msgid "released"
 msgstr "veröffentlicht"
 
@@ -353,25 +353,25 @@ msgid "discipline"
 msgstr "Modulgruppe"
 
 #: cms/models/discipline.py:23 cms/models/training_set.py:27
-#: cmsv2/models/unit.py:153
+#: cmsv2/models/unit.py:152
 msgid "description"
 msgstr "Beschreibung"
 
 #: cms/models/discipline.py:26 cms/models/group.py:10
 #: cms/models/training_set.py:30 cmsv2/models/job.py:22
-#: cmsv2/models/unit.py:156
+#: cmsv2/models/unit.py:155
 msgid "icon"
 msgstr "Icon"
 
 #: cms/models/discipline.py:33 cms/models/document.py:94
 #: cms/models/training_set.py:39 cmsv2/models/job.py:30
-#: cmsv2/models/unit.py:164 cmsv2/models/word.py:106
+#: cmsv2/models/unit.py:163 cmsv2/models/word.py:106
 msgid "created by"
 msgstr "Erstellt von"
 
 #: cms/models/discipline.py:36 cms/models/document.py:98
 #: cms/models/training_set.py:41 cmsv2/models/job.py:33
-#: cmsv2/models/unit.py:166 cmsv2/models/word.py:110
+#: cmsv2/models/unit.py:165 cmsv2/models/word.py:110
 msgid "admin"
 msgstr "Admin"
 
@@ -383,7 +383,7 @@ msgstr "Übergeordnete Modulgruppe"
 msgid "word type"
 msgstr "Wortart"
 
-#: cms/models/document.py:33 cmsv2/models/unit.py:161 cmsv2/models/word.py:31
+#: cms/models/document.py:33 cmsv2/models/unit.py:160 cmsv2/models/word.py:31
 msgid "word"
 msgstr "Wort"
 
@@ -665,7 +665,7 @@ msgid "units"
 msgstr "Einheiten"
 
 #: cmsv2/admins/job_admin.py:88 cmsv2/admins/unit_admin.py:122
-#: cmsv2/models/job.py:34 cmsv2/models/unit.py:167
+#: cmsv2/models/job.py:34 cmsv2/models/unit.py:166
 msgid "created at"
 msgstr "Erstellt"
 
@@ -700,15 +700,15 @@ msgstr "Bild Prüfstatus"
 msgid "Vocabulary Management v2"
 msgstr "Vokabelverwaltung v2"
 
-#: cmsv2/models/job.py:20 cmsv2/models/unit.py:159
+#: cmsv2/models/job.py:20 cmsv2/models/unit.py:158
 msgid "job"
 msgstr "Beruf"
 
-#: cmsv2/models/job.py:35 cmsv2/models/unit.py:168 cmsv2/models/word.py:83
+#: cmsv2/models/job.py:35 cmsv2/models/unit.py:167 cmsv2/models/word.py:83
 msgid "modified at"
 msgstr "zuletzt geändert"
 
-#: cmsv2/models/job.py:91 cmsv2/models/unit.py:212
+#: cmsv2/models/job.py:91 cmsv2/models/unit.py:211
 msgid "Icon"
 msgstr "Icon"
 
@@ -728,23 +728,23 @@ msgstr "Berufe"
 msgid "Generate Image"
 msgstr "Bild generieren"
 
-#: cmsv2/models/unit.py:140
+#: cmsv2/models/unit.py:139
 msgid "Unit-Word Relation"
 msgstr "Einheit-Wort Beziehung"
 
-#: cmsv2/models/unit.py:141
+#: cmsv2/models/unit.py:140
 msgid "Unit-Word Relations"
 msgstr "Einheit-Wort Beziehungen"
 
-#: cmsv2/models/unit.py:151
+#: cmsv2/models/unit.py:150
 msgid "unit"
 msgstr "Einheit"
 
-#: cmsv2/models/unit.py:244
+#: cmsv2/models/unit.py:243
 msgid "Unit"
 msgstr "Einheit"
 
-#: cmsv2/models/unit.py:245
+#: cmsv2/models/unit.py:244
 msgid "Units"
 msgstr "Einheit"
 
@@ -752,7 +752,7 @@ msgstr "Einheit"
 msgid "audio checked identifier"
 msgstr "Audio Checked Identifier"
 
-#: cmsv2/models/word.py:247 cmsv2/templates/admin/word_generate_audio.html:10
+#: cmsv2/models/word.py:265 cmsv2/templates/admin/word_generate_audio.html:10
 #: cmsv2/templates/admin/word_generate_image.html:10
 msgid "Words"
 msgstr "Vokabel"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Adds a new api endpoint to list all words of a job.
The query got a bit messy, where basically the same sql query gets executed twice, but I am not sure how to improve it.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Modify the words endpoints to return a list of images, instead of a single image
- Add the new api
- Slightly adjust the words-of-unit endpoint, so that there is an ordering among the results

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #585 