### PR TITLE
Update django-import-export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
 ]
 pinned = [
 	"django==5.1.2",
-	"django-import-export==4.2.0",
+	"django-import-export==4.3.13",
 	"django-jazzmin==3.0.1",
 	"django-mptt==0.16.0",
 	"django-qr-code==4.1.0",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR updates `django-import-export`

### Proposed changes
<!-- Describe this PR in more detail. -->

- Update `django-import-export`

### How to test
- Only the old version (v1) uses this library to export all vocabularies for one profession. This is currently the only use case for this library

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/A
