### PR TITLE
Use Syft for generating SBOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,11 +194,11 @@ jobs:
       - run:
           name: Generate SBOM
           command: |
-            CURRENT_ALPHA_VERSION=$(python -c "import lunes_cms; print(lunes_cms.__version__)")
-            curl -Lo ./.venv/bin/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
-            chmod +x .venv/bin/sbom-tool
-            rm -rf lunes_cms/_manifest
-            sbom-tool generate -b ./lunes_cms -bc ./ -pn lunes-cms -pv ${CURRENT_ALPHA_VERSION} -ps "Tür an Tür Digitalfabrik gGmbH" -nsb "https://tuerantuer.org"
+            curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
+            export SYFT_SOURCE_VERSION=$(python -c "import lunes_cms; print(lunes_cms.__version__)")
+            export SYFT_SOURCE_NAME="integreat-cms"
+            export SYFT_FORMAT_SPDX_JSON_PRETTY=true
+            syft scan . -o spdx-json=integreat_cms/_manifest/spdx_2.2/manifest.spdx.json
       - persist_to_workspace:
           root: .
           paths:
@@ -248,11 +248,11 @@ jobs:
       - run:
           name: Generate SBOM
           command: |
-            CURRENT_VERSION=$(python -c "import lunes_cms; print(lunes_cms.__version__)")
-            curl -Lo ./.venv/bin/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
-            chmod +x .venv/bin/sbom-tool
-            rm -rf lunes_cms/_manifest
-            sbom-tool generate -b ./lunes_cms -bc ./ -pn lunes-cms -pv ${CURRENT_VERSION} -ps "Tür an Tür Digitalfabrik gGmbH" -nsb "https://tuerantuer.org"
+            curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
+            export SYFT_SOURCE_VERSION=$(python -c "import lunes_cms; print(lunes_cms.__version__)")
+            export SYFT_SOURCE_NAME="integreat-cms"
+            export SYFT_FORMAT_SPDX_JSON_PRETTY=true
+            syft scan . -o spdx-json=integreat_cms/_manifest/spdx_2.2/manifest.spdx.json
             git add lunes_cms/_manifest
             git commit --amend --no-edit
       - run:

--- a/lunes_cms/_manifest/spdx_2.2/manifest.spdx.json
+++ b/lunes_cms/_manifest/spdx_2.2/manifest.spdx.json
@@ -1,0 +1,22104 @@
+{
+ "spdxVersion": "SPDX-2.3",
+ "dataLicense": "CC0-1.0",
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "name": "lunes-cms",
+ "documentNamespace": "https://anchore.com/syft/dir/lunes-cms-3ab02232-ff58-4bc1-833a-eb7030d66fa9",
+ "creationInfo": {
+  "licenseListVersion": "3.27",
+  "creators": [
+   "Organization: Anchore, Inc",
+   "Tool: syft-1.36.0"
+  ],
+  "created": "2025-11-04T17:41:51Z"
+ },
+ "packages": [
+  {
+   "name": "annotated-types",
+   "SPDXID": "SPDXRef-Package-python-annotated-types-a6b5d180efe61a19",
+   "versionInfo": "0.7.0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/annotated_types-0.7.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/annotated_types-0.7.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb_project:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb_project:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangbproject:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangbproject:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb_project:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb_project:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian-garcia-badaracco-\\<1755071\\+adriangb:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian-garcia-badaracco-\\<1755071\\+adriangb:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangbproject:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangbproject:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian-garcia-badaracco-\\<1755071\\+adriangb:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian-garcia-badaracco-\\<1755071\\+adriangb:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:adrian_garcia_badaracco_\\<1755071\\+adriangb:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated-types:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated-types:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated_types:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated_types:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated-types:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated-types:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated_types:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated_types:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated-types:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated-types:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated_types:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated_types:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-annotated:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_annotated:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated-types:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated-types:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated_types:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated_types:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:annotated:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:annotated-types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:annotated_types:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/annotated-types@0.7.0"
+    }
+   ]
+  },
+  {
+   "name": "anyio",
+   "SPDXID": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "versionInfo": "4.11.0",
+   "supplier": "Person: Alex Grönholm (alex.gronholm@nextday.fi)",
+   "originator": "Person: Alex Grönholm (alex.gronholm@nextday.fi)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/anyio-4.11.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/anyio-4.11.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/anyio-4.11.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-anyio:python-anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-anyio:python_anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_anyio:python-anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_anyio:python_anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:anyio:python-anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:anyio:python_anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-anyio:anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_anyio:anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:anyio:anyio:4.11.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/anyio@4.11.0"
+    }
+   ]
+  },
+  {
+   "name": "asgiref",
+   "SPDXID": "SPDXRef-Package-python-asgiref-acd7e572b8ab722a",
+   "versionInfo": "3.10.0",
+   "supplier": "Person: Django Software Foundation (foundation@djangoproject.com)",
+   "originator": "Person: Django Software Foundation (foundation@djangoproject.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/asgiref-3.10.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/asgiref-3.10.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/asgiref-3.10.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_project:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_project:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundationproject:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundationproject:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_project:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundationproject:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundation_project:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundation_project:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundationproject:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundationproject:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-asgiref:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-asgiref:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_asgiref:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_asgiref:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundation_project:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundation:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundation:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundationproject:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:asgiref:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:asgiref:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-asgiref:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_asgiref:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:foundation:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:asgiref:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:asgiref:3.10.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/asgiref@3.10.0"
+    }
+   ]
+  },
+  {
+   "name": "asttokens",
+   "SPDXID": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "versionInfo": "3.0.0",
+   "supplier": "Person: Dmitry Sagalovskiy, Grist Labs (dmitry@getgrist.com)",
+   "originator": "Person: Dmitry Sagalovskiy, Grist Labs (dmitry@getgrist.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/asttokens-3.0.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/asttokens-3.0.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/asttokens-3.0.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-Apache-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labs_project:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labs_project:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labsproject:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labsproject:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labs_project:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labs:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labs:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labsproject:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_sagalovskiy\\,_grist_labs:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-asttokens:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-asttokens:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_asttokens:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_asttokens:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_project:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_project:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitryproject:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitryproject:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:asttokens:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:asttokens:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-asttokens:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_asttokens:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry_project:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitryproject:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:asttokens:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:dmitry:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:asttokens:3.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/asttokens@3.0.0"
+    }
+   ]
+  },
+  {
+   "name": "attrs",
+   "SPDXID": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "versionInfo": "25.4.0",
+   "supplier": "Person: Hynek Schlawack (hs@ox.cx)",
+   "originator": "Person: Hynek Schlawack (hs@ox.cx)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/attrs-25.4.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/attrs-25.4.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hs_project:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hs_project:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hsproject:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hsproject:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hs_project:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek-schlawack-\\<hs:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek-schlawack-\\<hs:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hs:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hs:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hsproject:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek-schlawack-\\<hs:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:hynek_schlawack_\\<hs:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-attrs:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-attrs:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_attrs:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_attrs:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:attrs:python-attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:attrs:python_attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-attrs:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_attrs:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:attrs:attrs:25.4.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/attrs@25.4.0"
+    }
+   ]
+  },
+  {
+   "name": "certifi",
+   "SPDXID": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "versionInfo": "2025.10.5",
+   "supplier": "Person: Kenneth Reitz (me@kennethreitz.com)",
+   "originator": "Person: Kenneth Reitz (me@kennethreitz.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/certifi-2025.10.5.dist-info/METADATA, /.venv/lib/python3.13/site-packages/certifi-2025.10.5.dist-info/RECORD, /.venv/lib/python3.13/site-packages/certifi-2025.10.5.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MPL-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:certifi:certifi:2025.10.5:*:*:*:*:python:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/certifi@2025.10.5"
+    }
+   ]
+  },
+  {
+   "name": "decorator",
+   "SPDXID": "SPDXRef-Package-python-decorator-020ed8d0f8c69ea9",
+   "versionInfo": "5.2.1",
+   "supplier": "Person: Michele Simionato (michele.simionato@gmail.com)",
+   "originator": "Person: Michele Simionato (michele.simionato@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/decorator-5.2.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/decorator-5.2.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/decorator-5.2.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-2-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:decorator:5.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/decorator@5.2.1"
+    }
+   ]
+  },
+  {
+   "name": "diff-match-patch",
+   "SPDXID": "SPDXRef-Package-python-diff-match-patch-e8b58cf67ba36766",
+   "versionInfo": "20241021",
+   "supplier": "Person: Neil Fraser (fraser@google.com)",
+   "originator": "Person: Neil Fraser (fraser@google.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/diff_match_patch-20241021.dist-info/METADATA, /.venv/lib/python3.13/site-packages/diff_match_patch-20241021.dist-info/RECORD",
+   "licenseConcluded": "Apache-2.0",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser_project:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser_project:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraserproject:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraserproject:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match-patch:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match-patch:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match_patch:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match_patch:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser_project:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser_project:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil-fraser-\\<fraser:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil-fraser-\\<fraser:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraserproject:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraserproject:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match-patch:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match-patch:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match_patch:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match_patch:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match-patch:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match-patch:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match_patch:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match_patch:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil-fraser-\\<fraser:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil-fraser-\\<fraser:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:neil_fraser_\\<fraser:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff-match:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff_match:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match-patch:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match-patch:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match_patch:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match_patch:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff:python-diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff:python_diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-diff:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_diff:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff-match:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff_match:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff:diff-match-patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:diff:diff_match_patch:20241021:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/diff-match-patch@20241021"
+    }
+   ]
+  },
+  {
+   "name": "distro",
+   "SPDXID": "SPDXRef-Package-python-distro-defc489bccf4fa26",
+   "versionInfo": "1.9.0",
+   "supplier": "Person: Nir Cohen (nir36g@gmail.com)",
+   "originator": "Person: Nir Cohen (nir36g@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/distro-1.9.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/distro-1.9.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/distro-1.9.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-Apache-License--Version-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohen_project:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohen_project:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohenproject:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohenproject:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36g_project:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36g_project:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36gproject:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36gproject:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-distro:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-distro:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_distro:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_distro:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohen_project:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohen:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohen:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohenproject:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36g_project:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:distro:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:distro:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36g:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36g:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36gproject:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-distro:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_distro:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir_cohen:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:distro:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nir36g:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:distro:1.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/distro@1.9.0"
+    }
+   ]
+  },
+  {
+   "name": "django",
+   "SPDXID": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "versionInfo": "5.2.7",
+   "supplier": "Person: Django Software Foundation (foundation@djangoproject.com)",
+   "originator": "Person: Django Software Foundation (foundation@djangoproject.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/django-5.2.7.dist-info/METADATA, /.venv/lib/python3.13/site-packages/django-5.2.7.dist-info/RECORD, /.venv/lib/python3.13/site-packages/django-5.2.7.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundation_project:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundation_project:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundationproject:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundationproject:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundation_project:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-software-foundation-\\<foundation:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-software-foundation-\\<foundation:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundation:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundation:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundationproject:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-software-foundation-\\<foundation:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_software_foundation_\\<foundation:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django:5.2.7:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/django@5.2.7"
+    }
+   ]
+  },
+  {
+   "name": "django-import-export",
+   "SPDXID": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "versionInfo": "4.3.12",
+   "supplier": "Person: Bojan Mihelač (djangoimportexport@gmail.com)",
+   "originator": "Person: Bojan Mihelač (djangoimportexport@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/django_import_export-4.3.12.dist-info/METADATA, /.venv/lib/python3.13/site-packages/django_import_export-4.3.12.dist-info/RECORD, /.venv/lib/python3.13/site-packages/django_import_export-4.3.12.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-2-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import-export:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import-export:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import_export:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import_export:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import-export:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import-export:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import_export:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import_export:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import-export:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import-export:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import_export:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import_export:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import-export:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import-export:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import_export:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import_export:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-import:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_import:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-import:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_import:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django-import-export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django_import_export:4.3.12:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/django-import-export@4.3.12"
+    }
+   ]
+  },
+  {
+   "name": "django-jazzmin",
+   "SPDXID": "SPDXRef-Package-python-django-jazzmin-1457ffa6ce3386c2",
+   "versionInfo": "3.0.1",
+   "supplier": "Person: Shipit (packages@shipit.ltd)",
+   "originator": "Person: Shipit (packages@shipit.ltd)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/django_jazzmin-3.0.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/django_jazzmin-3.0.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-jazzmin:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-jazzmin:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_jazzmin:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_jazzmin:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages_project:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages_project:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packagesproject:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packagesproject:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-jazzmin:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-jazzmin:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_jazzmin:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_jazzmin:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-jazzmin:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-jazzmin:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_jazzmin:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_jazzmin:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit_project:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit_project:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipitproject:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipitproject:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages_project:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages_project:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packagesproject:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packagesproject:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-jazzmin:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-jazzmin:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_jazzmin:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_jazzmin:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit_project:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit_project:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit:python-django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit:python_django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipitproject:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipitproject:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:packages:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit:django-jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:shipit:django_jazzmin:3.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/django-jazzmin@3.0.1"
+    }
+   ]
+  },
+  {
+   "name": "django-js-asset",
+   "SPDXID": "SPDXRef-Package-python-django-js-asset-269f112427c6751a",
+   "versionInfo": "3.1.2",
+   "supplier": "Person: Matthias Kestenholz (mk@feinheit.ch)",
+   "originator": "Person: Matthias Kestenholz (mk@feinheit.ch)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/django_js_asset-3.1.2.dist-info/METADATA, /.venv/lib/python3.13/site-packages/django_js_asset-3.1.2.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk_project:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk_project:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mkproject:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mkproject:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk_project:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk_project:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias-kestenholz-\\<mk:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias-kestenholz-\\<mk:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mkproject:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mkproject:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js-asset:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js-asset:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js_asset:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js_asset:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias-kestenholz-\\<mk:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias-kestenholz-\\<mk:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matthias_kestenholz_\\<mk:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js-asset:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js-asset:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js_asset:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js_asset:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js-asset:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js-asset:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js_asset:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js_asset:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-js:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_js:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js-asset:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js-asset:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js_asset:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js_asset:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-js:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_js:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django-js-asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django_js_asset:3.1.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/django-js-asset@3.1.2"
+    }
+   ]
+  },
+  {
+   "name": "django-mptt",
+   "SPDXID": "SPDXRef-Package-python-django-mptt-9bfe76c4b9ce3f1c",
+   "versionInfo": "0.18.0",
+   "supplier": "Person: Craig de Stigter (craig.ds@gmail.com)",
+   "originator": "Person: Craig de Stigter (craig.ds@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/django_mptt-0.18.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/django_mptt-0.18.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-MIT-License",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds_project:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds_project:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_dsproject:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_dsproject:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds_project:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds_project:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig-de-stigter-\\<craig-ds:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig-de-stigter-\\<craig-ds:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_dsproject:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_dsproject:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig-de-stigter-\\<craig-ds:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig-de-stigter-\\<craig-ds:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:craig_de_stigter_\\<craig_ds:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-mptt:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-mptt:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_mptt:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_mptt:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-mptt:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-mptt:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_mptt:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_mptt:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-mptt:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-mptt:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_mptt:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_mptt:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-mptt:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-mptt:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_mptt:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_mptt:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django-mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django_mptt:0.18.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/django-mptt@0.18.0"
+    }
+   ]
+  },
+  {
+   "name": "django-qr-code",
+   "SPDXID": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "versionInfo": "4.2.0",
+   "supplier": "Person: Philippe Docourt (philippe@docourt.ch)",
+   "originator": "Person: Philippe Docourt (philippe@docourt.ch)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/django_qr_code-4.2.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/django_qr_code-4.2.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/django_qr_code-4.2.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-BSD-3-clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt_project:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt_project:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourtproject:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourtproject:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr-code:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr-code:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr_code:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr_code:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt_project:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt_project:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourtproject:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourtproject:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_project:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_project:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippeproject:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippeproject:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr-code:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr-code:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr_code:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr_code:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr-code:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr-code:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr_code:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr_code:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_docourt:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_project:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe_project:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django-qr:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django_qr:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippeproject:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippeproject:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr-code:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr-code:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr_code:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr_code:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-django:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_django:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django-qr:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django_qr:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:philippe:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:django:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django-qr-code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:django_qr_code:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/django-qr-code@4.2.0"
+    }
+   ]
+  },
+  {
+   "name": "djangorestframework",
+   "SPDXID": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "versionInfo": "3.16.1",
+   "supplier": "Person: Tom Christie (tom@tomchristie.com)",
+   "originator": "Person: Tom Christie (tom@tomchristie.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/djangorestframework-3.16.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/djangorestframework-3.16.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/djangorestframework-3.16.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-BSD",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-djangorestframework:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-djangorestframework:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_djangorestframework:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_djangorestframework:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_project:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_project:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:djangorestframework:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:djangorestframework:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-djangorestframework:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_djangorestframework:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christieproject:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christieproject:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_project:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:djangorestframework:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christieproject:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_project:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_project:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tomproject:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tomproject:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_project:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom:python-djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom:python_djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tomproject:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom:djangorestframework:3.16.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/djangorestframework@3.16.1"
+    }
+   ]
+  },
+  {
+   "name": "drf-spectacular",
+   "SPDXID": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "versionInfo": "0.28.0",
+   "supplier": "Person: T. Franzel (tfranzel@gmail.com)",
+   "originator": "Person: T. Franzel (tfranzel@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/drf_spectacular-0.28.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/drf_spectacular-0.28.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/drf_spectacular-0.28.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-BSD",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf-spectacular:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf-spectacular:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf_spectacular:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf_spectacular:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel_project:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel_project:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzelproject:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzelproject:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel_project:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel_project:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf-spectacular:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf-spectacular:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf_spectacular:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf_spectacular:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf-spectacular:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf-spectacular:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf_spectacular:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf_spectacular:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzelproject:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzelproject:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel_project:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel_project:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzelproject:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzelproject:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel_project:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel_project:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf-spectacular:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf-spectacular:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf_spectacular:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf_spectacular:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzelproject:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzelproject:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf:python-drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf:python_drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-drf:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_drf:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:t__franzel:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tfranzel:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf:drf-spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:drf:drf_spectacular:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/drf-spectacular@0.28.0"
+    }
+   ]
+  },
+  {
+   "name": "executing",
+   "SPDXID": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "versionInfo": "2.2.1",
+   "supplier": "Person: Alex Hall (alex.mojaki@gmail.com)",
+   "originator": "Person: Alex Hall (alex.mojaki@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/executing-2.2.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/executing-2.2.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/executing-2.2.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-executing:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-executing:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_executing:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_executing:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:executing:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:executing:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-executing:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_executing:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:executing:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:executing:2.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/executing@2.2.1"
+    }
+   ]
+  },
+  {
+   "name": "h11",
+   "SPDXID": "SPDXRef-Package-python-h11-532967227a5a6258",
+   "versionInfo": "0.16.0",
+   "supplier": "Person: Nathaniel J. Smith (njs@pobox.com)",
+   "originator": "Person: Nathaniel J. Smith (njs@pobox.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/h11-0.16.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/h11-0.16.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/h11-0.16.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smith_project:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smith_project:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smithproject:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smithproject:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smith_project:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smith:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smith:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smithproject:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:nathaniel_j__smith:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njs_project:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njs_project:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njsproject:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njsproject:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-h11:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-h11:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_h11:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_h11:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njs_project:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:h11:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:h11:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njs:python-h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njs:python_h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njsproject:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-h11:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_h11:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:h11:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:njs:h11:0.16.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/h11@0.16.0"
+    }
+   ]
+  },
+  {
+   "name": "httpcore",
+   "SPDXID": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "versionInfo": "1.0.9",
+   "supplier": "Person: Tom Christie (tom@tomchristie.com)",
+   "originator": "Person: Tom Christie (tom@tomchristie.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/httpcore-1.0.9.dist-info/METADATA, /.venv/lib/python3.13/site-packages/httpcore-1.0.9.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tom_project:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tom_project:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tomproject:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tomproject:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tom_project:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom-christie-\\<tom:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom-christie-\\<tom:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tom:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tom:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tomproject:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-httpcore:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-httpcore:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_httpcore:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_httpcore:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom-christie-\\<tom:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tom_christie_\\<tom:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:httpcore:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:httpcore:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-httpcore:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_httpcore:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:httpcore:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:httpcore:1.0.9:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/httpcore@1.0.9"
+    }
+   ]
+  },
+  {
+   "name": "httpx",
+   "SPDXID": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "versionInfo": "0.28.1",
+   "supplier": "Person: Tom Christie (tom@tomchristie.com)",
+   "originator": "Person: Tom Christie (tom@tomchristie.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/httpx-0.28.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/httpx-0.28.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:encode:httpx:0.28.1:*:*:*:*:python:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/httpx@0.28.1"
+    }
+   ]
+  },
+  {
+   "name": "idna",
+   "SPDXID": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "versionInfo": "3.11",
+   "supplier": "Person: Kim Davies (kim+pypi@gumleaf.org)",
+   "originator": "Person: Kim Davies (kim+pypi@gumleaf.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/idna-3.11.dist-info/METADATA, /.venv/lib/python3.13/site-packages/idna-3.11.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypi_project:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypi_project:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypiproject:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypiproject:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypi_project:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim-davies-\\<kim\\+pypi:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim-davies-\\<kim\\+pypi:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypi:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypi:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypiproject:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim-davies-\\<kim\\+pypi:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kim_davies_\\<kim\\+pypi:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-idna:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-idna:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_idna:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_idna:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:idna:python-idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:idna:python_idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-idna:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_idna:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:idna:idna:3.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/idna@3.11"
+    }
+   ]
+  },
+  {
+   "name": "inflection",
+   "SPDXID": "SPDXRef-Package-python-inflection-b21cbbca91c9455c",
+   "versionInfo": "0.5.1",
+   "supplier": "Person: Janne Vanhala (janne.vanhala@gmail.com)",
+   "originator": "Person: Janne Vanhala (janne.vanhala@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/inflection-0.5.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/inflection-0.5.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/inflection-0.5.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhala_project:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhala_project:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhalaproject:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhalaproject:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-inflection:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-inflection:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_inflection:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_inflection:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhala_project:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne-vanhala:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne-vanhala:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhala:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhala:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhalaproject:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:inflection:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:inflection:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-inflection:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_inflection:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne-vanhala:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:janne_vanhala:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:inflection:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:inflection:0.5.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/inflection@0.5.1"
+    }
+   ]
+  },
+  {
+   "name": "ipython",
+   "SPDXID": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "versionInfo": "9.6.0",
+   "supplier": "Person: The IPython Development Team (ipython-dev@python.org)",
+   "originator": "Person: The IPython Development Team (ipython-dev@python.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/ipython-9.6.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/ipython-9.6.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/ipython-9.6.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_project:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_project:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_teamproject:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_teamproject:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_project:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_teamproject:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_dev_project:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_dev_project:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_devproject:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_devproject:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_dev_project:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-dev:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-dev:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_dev:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_dev:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_devproject:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-dev:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_dev:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:ipython:9.6.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/ipython@9.6.0"
+    }
+   ]
+  },
+  {
+   "name": "ipython-pygments-lexers",
+   "SPDXID": "SPDXRef-Package-python-ipython-pygments-lexers-89eb775af3dc7e6e",
+   "versionInfo": "1.1.1",
+   "supplier": "Person: The IPython Development Team (ipython-dev@python.org)",
+   "originator": "Person: The IPython Development Team (ipython-dev@python.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/ipython_pygments_lexers-1.1.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/ipython_pygments_lexers-1.1.1.dist-info/RECORD",
+   "licenseConcluded": "BSD-3-Clause",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments-lexers:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments-lexers:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments_lexers:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments_lexers:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments-lexers:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments-lexers:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments_lexers:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments_lexers:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments-lexers:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments-lexers:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments_lexers:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments_lexers:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments-lexers:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments-lexers:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments_lexers:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments_lexers:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython-pygments:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython_pygments:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-pygments:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_pygments:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ipython:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ipython:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:ipython-pygments-lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:ipython_pygments_lexers:1.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/ipython-pygments-lexers@1.1.1"
+    }
+   ]
+  },
+  {
+   "name": "jedi",
+   "SPDXID": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "versionInfo": "0.19.2",
+   "supplier": "Person: David Halter (davidhalter88@gmail.com)",
+   "originator": "Person: David Halter (davidhalter88@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/jedi-0.19.2.dist-info/METADATA, /.venv/lib/python3.13/site-packages/jedi-0.19.2.dist-info/RECORD, /.venv/lib/python3.13/site-packages/jedi-0.19.2.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88_project:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88_project:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter_project:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter_project:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88project:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88project:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halterproject:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halterproject:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88_project:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter_project:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88project:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halterproject:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jedi:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jedi:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jedi:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jedi:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jedi:python-jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jedi:python_jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jedi:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jedi:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jedi:jedi:0.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/jedi@0.19.2"
+    }
+   ]
+  },
+  {
+   "name": "jiter",
+   "SPDXID": "SPDXRef-Package-python-jiter-01ec1bc0a6d5319b",
+   "versionInfo": "0.11.1",
+   "supplier": "Person: Samuel Colvin (s@muelcolvin.com)",
+   "originator": "Person: Samuel Colvin (s@muelcolvin.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/jiter-0.11.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/jiter-0.11.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jiter:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jiter:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jiter:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jiter:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiter:python-jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiter:python_jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jiter:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jiter:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiter:jiter:0.11.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/jiter@0.11.1"
+    }
+   ]
+  },
+  {
+   "name": "jsonschema",
+   "SPDXID": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "versionInfo": "4.25.1",
+   "supplier": "Person: Julian Berman (Julian+jsonschema@GrayVines.com)",
+   "originator": "Person: Julian Berman (Julian+jsonschema@GrayVines.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/jsonschema-4.25.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/jsonschema-4.25.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_project:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_project:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschemaproject:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschemaproject:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_project:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschemaproject:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:jsonschema:4.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/jsonschema@4.25.1"
+    }
+   ]
+  },
+  {
+   "name": "jsonschema-specifications",
+   "SPDXID": "SPDXRef-Package-python-jsonschema-specifications-efb9708363f3ab7b",
+   "versionInfo": "2025.9.1",
+   "supplier": "Person: Julian Berman (Julian+jsonschema-specifications@GrayVines.com)",
+   "originator": "Person: Julian Berman (Julian+jsonschema-specifications@GrayVines.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/jsonschema_specifications-2025.9.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/jsonschema_specifications-2025.9.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications_project:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications_project:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specificationsproject:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specificationsproject:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications_project:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications_project:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema-specifications:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema-specifications:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specificationsproject:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specificationsproject:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema-specifications:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+jsonschema-specifications:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+jsonschema_specifications:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema-specifications:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema-specifications:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema_specifications:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema_specifications:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema-specifications:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema-specifications:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema_specifications:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema_specifications:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema-specifications:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema-specifications:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema_specifications:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema_specifications:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema-specifications:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema-specifications:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema_specifications:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema_specifications:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-jsonschema:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_jsonschema:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jsonschema:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:jsonschema-specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:jsonschema_specifications:2025.9.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/jsonschema-specifications@2025.9.1"
+    }
+   ]
+  },
+  {
+   "name": "lunes-cms",
+   "SPDXID": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "versionInfo": "2025.10.9a0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": true,
+   "packageVerificationCode": {
+    "packageVerificationCodeValue": "7c8dd1b0442c7cef77059553893d23d5457c7076"
+   },
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/direct_url.json, /.venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "Apache-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/lunes-cms@2025.10.9a0"
+    }
+   ]
+  },
+  {
+   "name": "lunes-cms",
+   "SPDXID": "SPDXRef-Package-python-lunes-cms-a654bc1ff904c0f1",
+   "versionInfo": "2025.10.9a0",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /lunes_cms.egg-info/PKG-INFO, /lunes_cms.egg-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "Apache-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes-cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes_cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:python-lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:python_lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-lunes:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_lunes:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes-cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes_cms:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:lunes-cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lunes:lunes_cms:2025.10.9a0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/lunes-cms@2025.10.9a0"
+    }
+   ]
+  },
+  {
+   "name": "matplotlib-inline",
+   "SPDXID": "SPDXRef-Package-python-matplotlib-inline-36ab3770d1c8da4b",
+   "versionInfo": "0.2.1",
+   "supplier": "Person: IPython Development Team (ipython-dev@python.org)",
+   "originator": "Person: IPython Development Team (ipython-dev@python.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/matplotlib_inline-0.2.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/matplotlib_inline-0.2.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib-inline:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib-inline:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib_inline:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib_inline:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib-inline:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib-inline:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib_inline:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib_inline:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib-inline:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib-inline:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib_inline:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib_inline:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib-inline:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib-inline:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib_inline:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib_inline:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-matplotlib:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_matplotlib:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:matplotlib:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:matplotlib-inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:matplotlib_inline:0.2.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/matplotlib-inline@0.2.1"
+    }
+   ]
+  },
+  {
+   "name": "openai",
+   "SPDXID": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "versionInfo": "2.6.1",
+   "supplier": "Person: OpenAI (support@openai.com)",
+   "originator": "Person: OpenAI (support@openai.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/openai-2.6.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/openai-2.6.1.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "Apache-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<support_project:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<support_project:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<supportproject:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<supportproject:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<support_project:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai-\\<support:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai-\\<support:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<support:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<support:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<supportproject:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-openai:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-openai:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_openai:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_openai:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai-\\<support:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai_\\<support:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-openai:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_openai:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:openai:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:openai:2.6.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/openai@2.6.1"
+    }
+   ]
+  },
+  {
+   "name": "parso",
+   "SPDXID": "SPDXRef-Package-python-parso-425b83e4d9560860",
+   "versionInfo": "0.8.5",
+   "supplier": "Person: David Halter (davidhalter88@gmail.com)",
+   "originator": "Person: David Halter (davidhalter88@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/parso-0.8.5.dist-info/METADATA, /.venv/lib/python3.13/site-packages/parso-0.8.5.dist-info/RECORD, /.venv/lib/python3.13/site-packages/parso-0.8.5.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88_project:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88_project:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter_project:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter_project:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88project:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88project:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halterproject:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halterproject:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88_project:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter_project:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88project:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halterproject:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-parso:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-parso:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_parso:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_parso:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:davidhalter88:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:david_halter:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:parso:python-parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:parso:python_parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-parso:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_parso:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:parso:parso:0.8.5:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/parso@0.8.5"
+    }
+   ]
+  },
+  {
+   "name": "pexpect",
+   "SPDXID": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "versionInfo": "4.9.0",
+   "supplier": "Person: Noah Spurrier; Thomas Kluyver; Jeff Quast (noah@noah.org, thomas@kluyver.me.uk, contact@jeffquast.com)",
+   "originator": "Person: Noah Spurrier; Thomas Kluyver; Jeff Quast (noah@noah.org, thomas@kluyver.me.uk, contact@jeffquast.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pexpect-4.9.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pexpect-4.9.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/pexpect-4.9.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-ISC-license",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quast_project:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quast_project:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quastproject:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quastproject:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quast_project:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quast:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quast:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quastproject:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_spurrier\\;_thomas_kluyver\\;_jeff_quast:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pexpect:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pexpect:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pexpect:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pexpect:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_project:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_project:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noahproject:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noahproject:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pexpect:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pexpect:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pexpect:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pexpect:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah_project:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah:python-pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah:python_pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noahproject:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pexpect:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:noah:pexpect:4.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pexpect@4.9.0"
+    }
+   ]
+  },
+  {
+   "name": "pillow",
+   "SPDXID": "SPDXRef-Package-python-pillow-01b8b61581f6a2e5",
+   "versionInfo": "12.0.0",
+   "supplier": "Person: \"Jeffrey A. Clark\" (aclark@aclark.net)",
+   "originator": "Person: \"Jeffrey A. Clark\" (aclark@aclark.net)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pillow-12.0.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pillow-12.0.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/pillow-12.0.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT-CMU",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclark_project:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclark_project:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclarkproject:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclarkproject:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclark_project:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey-a--clark\\\"-\\<aclark:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey-a--clark\\\"-\\<aclark:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclark:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclark:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclarkproject:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey-a--clark\\\"-\\<aclark:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"jeffrey_a__clark\\\"_\\<aclark:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pillow:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pillow:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pillow:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pillow:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pillow:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pillow:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pillow:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pillow:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pillow:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pillow:12.0.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pillow@12.0.0"
+    }
+   ]
+  },
+  {
+   "name": "pip",
+   "SPDXID": "SPDXRef-Package-python-pip-606c9e4a58298897",
+   "versionInfo": "25.1.1",
+   "supplier": "Person: The pip developers (distutils-sig@python.org)",
+   "originator": "Person: The pip developers (distutils-sig@python.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sig_project:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sig_project:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sigproject:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sigproject:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sig_project:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip-developers-\\<distutils-sig:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip-developers-\\<distutils-sig:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sig:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sig:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sigproject:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip-developers-\\<distutils-sig:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip_developers_\\<distutils_sig:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pip:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pip:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pip:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pip:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pypa:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pypa:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip:python-pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip:python_pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pip:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pip:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pypa:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pip:pip:25.1.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pip@25.1.1"
+    }
+   ]
+  },
+  {
+   "name": "prompt-toolkit",
+   "SPDXID": "SPDXRef-Package-python-prompt-toolkit-368848b58a66b4c3",
+   "versionInfo": "3.0.52",
+   "supplier": "Person: Jonathan Slenders",
+   "originator": "Person: Jonathan Slenders",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/prompt_toolkit-3.0.52.dist-info/METADATA, /.venv/lib/python3.13/site-packages/prompt_toolkit-3.0.52.dist-info/RECORD, /.venv/lib/python3.13/site-packages/prompt_toolkit-3.0.52.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders_project:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders_project:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slendersproject:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slendersproject:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt-toolkit:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt-toolkit:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt_toolkit:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt_toolkit:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders_project:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders_project:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slendersproject:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slendersproject:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt-toolkit:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt-toolkit:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt_toolkit:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt_toolkit:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt-toolkit:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt-toolkit:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt_toolkit:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt_toolkit:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jonathan_slenders:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt-toolkit:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt-toolkit:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt_toolkit:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt_toolkit:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-prompt:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_prompt:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:prompt:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:prompt-toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:prompt_toolkit:3.0.52:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/prompt-toolkit@3.0.52"
+    }
+   ]
+  },
+  {
+   "name": "psycopg2",
+   "SPDXID": "SPDXRef-Package-python-psycopg2-127e95f45199e153",
+   "versionInfo": "2.9.11",
+   "supplier": "Person: Federico Di Gregorio (fog@initd.org)",
+   "originator": "Person: Federico Di Gregorio (fog@initd.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/psycopg2-2.9.11.dist-info/METADATA, /.venv/lib/python3.13/site-packages/psycopg2-2.9.11.dist-info/RECORD, /.venv/lib/python3.13/site-packages/psycopg2-2.9.11.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-LGPL-with-exceptions",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorio_project:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorio_project:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorioproject:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorioproject:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorio_project:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorio:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorio:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorioproject:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-psycopg2:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-psycopg2:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_psycopg2:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_psycopg2:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:federico_di_gregorio:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fog_project:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fog_project:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fogproject:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fogproject:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:psycopg2:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:psycopg2:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-psycopg2:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_psycopg2:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fog_project:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fog:python-psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fog:python_psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fogproject:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:psycopg2:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:fog:psycopg2:2.9.11:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/psycopg2@2.9.11"
+    }
+   ]
+  },
+  {
+   "name": "ptyprocess",
+   "SPDXID": "SPDXRef-Package-python-ptyprocess-4df83817440496d5",
+   "versionInfo": "0.7.0",
+   "supplier": "Person: Thomas Kluyver (thomas@kluyver.me.uk)",
+   "originator": "Person: Thomas Kluyver (thomas@kluyver.me.uk)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/ptyprocess-0.7.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/ptyprocess-0.7.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-UNKNOWN",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyver_project:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyver_project:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyverproject:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyverproject:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ptyprocess:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ptyprocess:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ptyprocess:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ptyprocess:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyver_project:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyver:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyver:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyverproject:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_project:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_project:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomasproject:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomasproject:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ptyprocess:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ptyprocess:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-ptyprocess:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_ptyprocess:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_kluyver:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas_project:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas:python-ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas:python_ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomasproject:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ptyprocess:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:thomas:ptyprocess:0.7.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/ptyprocess@0.7.0"
+    }
+   ]
+  },
+  {
+   "name": "pure-eval",
+   "SPDXID": "SPDXRef-Package-python-pure-eval-6a837dddcf51590b",
+   "versionInfo": "0.2.3",
+   "supplier": "Person: Alex Hall (alex.mojaki@gmail.com)",
+   "originator": "Person: Alex Hall (alex.mojaki@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pure_eval-0.2.3.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pure_eval-0.2.3.dist-info/RECORD, /.venv/lib/python3.13/site-packages/pure_eval-0.2.3.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure-eval:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure-eval:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure_eval:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure_eval:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure-eval:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure-eval:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure_eval:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure_eval:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure-eval:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure-eval:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure_eval:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure_eval:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure:python-pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure:python_pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pure:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pure:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure-eval:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure-eval:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure_eval:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure_eval:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure:pure-eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pure:pure_eval:0.2.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pure-eval@0.2.3"
+    }
+   ]
+  },
+  {
+   "name": "pydantic",
+   "SPDXID": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "versionInfo": "2.12.3",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pydantic-2.12.3.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pydantic-2.12.3.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pydantic:2.12.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pydantic@2.12.3"
+    }
+   ]
+  },
+  {
+   "name": "pydantic-core",
+   "SPDXID": "SPDXRef-Package-python-pydantic-core-2a3bd733f665f52f",
+   "versionInfo": "2.41.4",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pydantic_core-2.41.4.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pydantic_core-2.41.4.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic-core:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic-core:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic_core:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic_core:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s_project:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<sproject:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic-core:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic-core:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic_core:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic_core:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic-core:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic-core:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic_core:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic_core:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel-colvin-\\<s:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:samuel_colvin_\\<s:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydantic:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydantic:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic-core:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic-core:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic_core:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic_core:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydantic:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pydantic-core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pydantic_core:2.41.4:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pydantic-core@2.41.4"
+    }
+   ]
+  },
+  {
+   "name": "pydub",
+   "SPDXID": "SPDXRef-Package-python-pydub-59f16a6341fa43c6",
+   "versionInfo": "0.25.1",
+   "supplier": "Person: James Robert (jiaaro@gmail.com)",
+   "originator": "Person: James Robert (jiaaro@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pydub-0.25.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pydub-0.25.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/pydub-0.25.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robert_project:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robert_project:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robertproject:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robertproject:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaro_project:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaro_project:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robert_project:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaroproject:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaroproject:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robert:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robert:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robertproject:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydub:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydub:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydub:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydub:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaro_project:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaro:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaro:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaroproject:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:james_robert:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydub:python-pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydub:python_pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pydub:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pydub:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jiaaro:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pydub:pydub:0.25.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pydub@0.25.1"
+    }
+   ]
+  },
+  {
+   "name": "pygments",
+   "SPDXID": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "versionInfo": "2.19.2",
+   "supplier": "Person: Georg Brandl (georg@python.org)",
+   "originator": "Person: Georg Brandl (georg@python.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pygments-2.19.2.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pygments-2.19.2.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-2-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georg_project:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georg_project:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georgproject:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georgproject:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georg_project:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg-brandl-\\<georg:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg-brandl-\\<georg:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georg:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georg:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georgproject:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pygments:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pygments:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pygments:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pygments:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg-brandl-\\<georg:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:georg_brandl_\\<georg:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pygments:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pygments:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pygments:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pygments:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pygments:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pygments:2.19.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pygments@2.19.2"
+    }
+   ]
+  },
+  {
+   "name": "pyyaml",
+   "SPDXID": "SPDXRef-Package-python-pyyaml-4979bc836022c4b6",
+   "versionInfo": "6.0.3",
+   "supplier": "Person: Kirill Simonov (xi@resolvent.net)",
+   "originator": "Person: Kirill Simonov (xi@resolvent.net)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/pyyaml-6.0.3.dist-info/METADATA, /.venv/lib/python3.13/site-packages/pyyaml-6.0.3.dist-info/RECORD, /.venv/lib/python3.13/site-packages/pyyaml-6.0.3.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonov_project:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonov_project:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonovproject:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonovproject:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonov_project:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonov:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonov:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonovproject:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pyyaml:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pyyaml:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pyyaml:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pyyaml:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xi_project:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xi_project:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xiproject:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xiproject:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:kirill_simonov:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-pyyaml:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_pyyaml:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pyyaml:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pyyaml:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xi_project:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xi:python-pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xi:python_pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xiproject:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:pyyaml:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:xi:pyyaml:6.0.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/pyyaml@6.0.3"
+    }
+   ]
+  },
+  {
+   "name": "referencing",
+   "SPDXID": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "versionInfo": "0.37.0",
+   "supplier": "Person: Julian Berman (Julian+referencing@GrayVines.com)",
+   "originator": "Person: Julian Berman (Julian+referencing@GrayVines.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/referencing-0.37.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/referencing-0.37.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencing_project:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencing_project:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencingproject:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencingproject:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencing_project:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+referencing:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+referencing:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencing:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencing:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencingproject:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+referencing:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+referencing:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-referencing:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-referencing:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_referencing:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_referencing:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-referencing:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_referencing:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:referencing:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:referencing:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:referencing:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:referencing:0.37.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/referencing@0.37.0"
+    }
+   ]
+  },
+  {
+   "name": "rpds-py",
+   "SPDXID": "SPDXRef-Package-python-rpds-py-346354dc3b719d2c",
+   "versionInfo": "0.28.0",
+   "supplier": "Person: Julian Berman (Julian+rpds@GrayVines.com)",
+   "originator": "Person: Julian Berman (Julian+rpds@GrayVines.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/rpds_py-0.28.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/rpds_py-0.28.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds_project:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds_project:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpdsproject:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpdsproject:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds_project:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds_project:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+rpds:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+rpds:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpdsproject:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpdsproject:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+rpds:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian-berman-\\<julian\\+rpds:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:julian_berman_\\<julian\\+rpds:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds-py:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds-py:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds_py:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds_py:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds-py:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds-py:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds_py:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds_py:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds-py:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds-py:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds_py:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds_py:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-rpds:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_rpds:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds:python-rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds:python_rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds-py:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds-py:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds_py:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds_py:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds:rpds-py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:rpds:rpds_py:0.28.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/rpds-py@0.28.0"
+    }
+   ]
+  },
+  {
+   "name": "segno",
+   "SPDXID": "SPDXRef-Package-python-segno-4c50a64427c78b15",
+   "versionInfo": "1.6.6",
+   "supplier": "Person: Lars Heuer (heuer@semagia.com)",
+   "originator": "Person: Lars Heuer (heuer@semagia.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/segno-1.6.6.dist-info/METADATA, /.venv/lib/python3.13/site-packages/segno-1.6.6.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuer_project:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuer_project:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuerproject:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuerproject:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuer_project:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars-heuer-\\<heuer:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars-heuer-\\<heuer:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuer:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuer:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuerproject:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-segno:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-segno:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_segno:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_segno:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars-heuer-\\<heuer:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:lars_heuer_\\<heuer:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-segno:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_segno:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:segno:python-segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:segno:python_segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:segno:segno:1.6.6:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/segno@1.6.6"
+    }
+   ]
+  },
+  {
+   "name": "sniffio",
+   "SPDXID": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "versionInfo": "1.3.1",
+   "supplier": "Person: \"Nathaniel J. Smith\" (njs@pobox.com)",
+   "originator": "Person: \"Nathaniel J. Smith\" (njs@pobox.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/sniffio-1.3.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/sniffio-1.3.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/sniffio-1.3.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "(MIT OR Apache-2.0)",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njs_project:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njs_project:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njsproject:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njsproject:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njs_project:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel-j--smith\\\"-\\<njs:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel-j--smith\\\"-\\<njs:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njs:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njs:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njsproject:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel-j--smith\\\"-\\<njs:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:\\\"nathaniel_j__smith\\\"_\\<njs:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-sniffio:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-sniffio:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_sniffio:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_sniffio:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-sniffio:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_sniffio:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:sniffio:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:sniffio:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:sniffio:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:sniffio:1.3.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/sniffio@1.3.1"
+    }
+   ]
+  },
+  {
+   "name": "sqlparse",
+   "SPDXID": "SPDXRef-Package-python-sqlparse-0535a323d8c5515b",
+   "versionInfo": "0.5.3",
+   "supplier": "Person: Andi Albrecht (albrecht.andi@gmail.com)",
+   "originator": "Person: Andi Albrecht (albrecht.andi@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/sqlparse-0.5.3.dist-info/METADATA, /.venv/lib/python3.13/site-packages/sqlparse-0.5.3.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:sqlparse_project:sqlparse:0.5.3:*:*:*:*:python:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/sqlparse@0.5.3"
+    }
+   ]
+  },
+  {
+   "name": "stack-data",
+   "SPDXID": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "versionInfo": "0.6.3",
+   "supplier": "Person: Alex Hall (alex.mojaki@gmail.com)",
+   "originator": "Person: Alex Hall (alex.mojaki@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/stack_data-0.6.3.dist-info/METADATA, /.venv/lib/python3.13/site-packages/stack_data-0.6.3.dist-info/RECORD, /.venv/lib/python3.13/site-packages/stack_data-0.6.3.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack-data:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack-data:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack_data:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack_data:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki_project:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojakiproject:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall_project:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack-data:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack-data:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack_data:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack_data:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack-data:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack-data:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack_data:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack_data:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hallproject:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-stack:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_stack:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack:python-stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack:python_stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex-mojaki:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_mojaki:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack-data:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack-data:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack_data:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack_data:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:alex_hall:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack:stack-data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:stack:stack_data:0.6.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/stack-data@0.6.3"
+    }
+   ]
+  },
+  {
+   "name": "tablib",
+   "SPDXID": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "versionInfo": "3.9.0",
+   "supplier": "Person: Kenneth Reitz (me@kennethreitz.org)",
+   "originator": "Person: Kenneth Reitz (me@kennethreitz.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/tablib-3.9.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/tablib-3.9.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/tablib-3.9.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-MIT-License",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:tablib:3.9.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/tablib@3.9.0"
+    }
+   ]
+  },
+  {
+   "name": "tqdm",
+   "SPDXID": "SPDXRef-Package-python-tqdm-0a069a66b5941349",
+   "versionInfo": "4.67.1",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/tqdm-4.67.1.dist-info/METADATA, /.venv/lib/python3.13/site-packages/tqdm-4.67.1.dist-info/RECORD, /.venv/lib/python3.13/site-packages/tqdm-4.67.1.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "(MPL-2.0 AND MIT)",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-tqdm:python-tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-tqdm:python_tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_tqdm:python-tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_tqdm:python_tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-tqdm:tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_tqdm:tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tqdm:python-tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tqdm:python_tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:tqdm:tqdm:4.67.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/tqdm@4.67.1"
+    }
+   ]
+  },
+  {
+   "name": "traitlets",
+   "SPDXID": "SPDXRef-Package-python-traitlets-e8c2bdc7c55ae62c",
+   "versionInfo": "5.14.3",
+   "supplier": "Person: IPython Development Team (ipython-dev@python.org)",
+   "originator": "Person: IPython Development Team (ipython-dev@python.org)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/traitlets-5.14.3.dist-info/METADATA, /.venv/lib/python3.13/site-packages/traitlets-5.14.3.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "BSD-3-Clause",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev_project:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_devproject:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython-development-team-\\<ipython-dev:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ipython_development_team_\\<ipython_dev:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-traitlets:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-traitlets:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_traitlets:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_traitlets:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-traitlets:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_traitlets:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:traitlets:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:traitlets:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:traitlets:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:traitlets:5.14.3:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/traitlets@5.14.3"
+    }
+   ]
+  },
+  {
+   "name": "typing-extensions",
+   "SPDXID": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "versionInfo": "4.15.0",
+   "supplier": "Person: \"Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Michael Lee\" (levkivskyi@gmail.com)",
+   "originator": "Person: \"Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Michael Lee\" (levkivskyi@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/typing_extensions-4.15.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/typing_extensions-4.15.0.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "PSF-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-extensions:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-extensions:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_extensions:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_extensions:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-extensions:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_extensions:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-extensions:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-extensions:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_extensions:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_extensions:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-extensions:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_extensions:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_extensions:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:python-typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:python_typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:typing-extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:typing_extensions:4.15.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/typing-extensions@4.15.0"
+    }
+   ]
+  },
+  {
+   "name": "typing-inspection",
+   "SPDXID": "SPDXRef-Package-python-typing-inspection-0aa3fd5cf879490c",
+   "versionInfo": "0.4.2",
+   "supplier": "Person: Victorien Plot (contact@vctrn.dev)",
+   "originator": "Person: Victorien Plot (contact@vctrn.dev)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/typing_inspection-0.4.2.dist-info/METADATA, /.venv/lib/python3.13/site-packages/typing_inspection-0.4.2.dist-info/RECORD",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact_project:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact_project:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contactproject:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contactproject:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-inspection:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-inspection:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_inspection:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_inspection:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact_project:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact_project:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien-plot-\\<contact:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien-plot-\\<contact:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contactproject:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contactproject:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-inspection:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing-inspection:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_inspection:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing_inspection:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-inspection:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-inspection:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_inspection:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_inspection:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien-plot-\\<contact:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien-plot-\\<contact:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:victorien_plot_\\<contact:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-inspection:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing-inspection:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_inspection:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing_inspection:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-typing:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_typing:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:python-typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:python_typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:typing-inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:typing:typing_inspection:0.4.2:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/typing-inspection@0.4.2"
+    }
+   ]
+  },
+  {
+   "name": "uritemplate",
+   "SPDXID": "SPDXRef-Package-python-uritemplate-c187d2c8320503c2",
+   "versionInfo": "4.2.0",
+   "supplier": "Person: Ian Stapleton Cordasco (graffatcolmingov@gmail.com)",
+   "originator": "Person: Ian Stapleton Cordasco (graffatcolmingov@gmail.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/uritemplate-4.2.0.dist-info/METADATA, /.venv/lib/python3.13/site-packages/uritemplate-4.2.0.dist-info/RECORD, /.venv/lib/python3.13/site-packages/uritemplate-4.2.0.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "LicenseRef-BSD-3-Clause-OR-Apache-2.0",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordasco_project:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordasco_project:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordascoproject:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordascoproject:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingov_project:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingov_project:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingovproject:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingovproject:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordasco_project:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordasco:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordasco:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordascoproject:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-uritemplate:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-uritemplate:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_uritemplate:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_uritemplate:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingov_project:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingov:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingov:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingovproject:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:ian_stapleton_cordasco:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-uritemplate:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_uritemplate:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:uritemplate:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:uritemplate:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:graffatcolmingov:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:uritemplate:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:uritemplate:4.2.0:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/uritemplate@4.2.0"
+    }
+   ]
+  },
+  {
+   "name": "vocabulary-trainer",
+   "SPDXID": "SPDXRef-Package-python-vocabulary-trainer-d4d44e04c67d3313",
+   "versionInfo": "0.0.1",
+   "supplier": "Person: Tür an Tür Digitalfabrik gGmbH (info@integreat-app.de)",
+   "originator": "Person: Tür an Tür Digitalfabrik gGmbH (info@integreat-app.de)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /src/Vocabulary_Trainer.egg-info/PKG-INFO, /src/Vocabulary_Trainer.egg-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "GPL-2.0-or-later",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary-trainer:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary-trainer:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary_trainer:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary_trainer:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary-trainer:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary-trainer:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary_trainer:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary_trainer:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary-trainer:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary-trainer:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary_trainer:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary_trainer:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info_project:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info_project:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:infoproject:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:infoproject:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary-trainer:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary-trainer:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary_trainer:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary_trainer:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-vocabulary:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_vocabulary:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info_project:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info_project:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info:python-vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info:python_vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:infoproject:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:infoproject:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:vocabulary:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info:vocabulary-trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:info:vocabulary_trainer:0.0.1:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/vocabulary-trainer@0.0.1"
+    }
+   ]
+  },
+  {
+   "name": "wcwidth",
+   "SPDXID": "SPDXRef-Package-python-wcwidth-83749aeb76d031a0",
+   "versionInfo": "0.2.14",
+   "supplier": "Person: Jeff Quast (contact@jeffquast.com)",
+   "originator": "Person: Jeff Quast (contact@jeffquast.com)",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "sourceInfo": "acquired package info from installed python package manifest file: /.venv/lib/python3.13/site-packages/wcwidth-0.2.14.dist-info/METADATA, /.venv/lib/python3.13/site-packages/wcwidth-0.2.14.dist-info/RECORD, /.venv/lib/python3.13/site-packages/wcwidth-0.2.14.dist-info/top_level.txt",
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "MIT",
+   "copyrightText": "NOASSERTION",
+   "externalRefs": [
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quast_project:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quast_project:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quastproject:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quastproject:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contact_project:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contact_project:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contactproject:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contactproject:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-wcwidth:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-wcwidth:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_wcwidth:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_wcwidth:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quast_project:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quast:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quast:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quastproject:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contact_project:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contact:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contact:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contactproject:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python-wcwidth:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python_wcwidth:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:wcwidth:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:wcwidth:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python-wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:python_wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:jeff_quast:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:contact:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:wcwidth:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "SECURITY",
+     "referenceType": "cpe23Type",
+     "referenceLocator": "cpe:2.3:a:python:wcwidth:0.2.14:*:*:*:*:*:*:*"
+    },
+    {
+     "referenceCategory": "PACKAGE-MANAGER",
+     "referenceType": "purl",
+     "referenceLocator": "pkg:pypi/wcwidth@0.2.14"
+    }
+   ]
+  },
+  {
+   "name": "lunes-cms",
+   "SPDXID": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "versionInfo": "2025.10.1",
+   "supplier": "NOASSERTION",
+   "downloadLocation": "NOASSERTION",
+   "filesAnalyzed": false,
+   "licenseConcluded": "NOASSERTION",
+   "licenseDeclared": "NOASSERTION",
+   "copyrightText": "NOASSERTION",
+   "primaryPackagePurpose": "FILE"
+  }
+ ],
+ "files": [
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_avif.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-avif.cpython-313-x86-64-linux-gnu.so-cb2f1f0ebb958d32",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_imaging.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-imaging.cpython-313-x86-64-linux-gnu.so-dbff9b197a779b90",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_imagingcms.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-imagingcms.cpython-313-x86-64-linux-gnu.so-ef6048c397e2d0a2",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_imagingft.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-imagingft.cpython-313-x86-64-linux-gnu.so-ebeae97730cee8bd",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_imagingmath.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-imagingmath.cpython-313-x86-64-linux-gnu.so-45fcaac23894a186",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_imagingmorph.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-imagingmorph.cpython-313-x86-64-linux-gnu.so-fbd5fed678e5968e",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_imagingtk.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-imagingtk.cpython-313-x86-64-linux-gnu.so-b0f1f40f3f440562",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/PIL/_webp.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-webp.cpython-313-x86-64-linux-gnu.so-2d79c1613004eb69",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/annotated_types-0.7.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-40ac67d5665956dd",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b11011181822ac765c9f66c8aa42c26952de6a96"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ee5b6ac64b09274c026051813484025939564067801f485115d9cadc207cf791"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/annotated_types-0.7.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...annotated-types-0.7.0.dist-info-RECORD-bf79e9940b6bb24e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e68768d051c77b7f9188537ee61984c772b9110e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f7c0160ccf09bebdec2eb160bb86d1a170670af060991dd2b16299da91a43b84"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/anyio-4.11.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...anyio-4.11.0.dist-info-METADATA-d20e30483566949e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bfacbc574bc00eb4d548675ff2c777bf9e31f053"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "cab41c4ad137ce03f81be673fbba956b0f7da9bf834ccda01e0c0fff5a4006ee"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/anyio-4.11.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...anyio-4.11.0.dist-info-RECORD-80db395e87979e9e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a13f0a07cb1c0834698418b694c6dbc27d6598c4"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a1ea42666d21792739cc8f8264f84cf75b5e937ceadeb9900b74c22abca60b9b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/anyio-4.11.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...anyio-4.11.0.dist-info-top-level.txt-9a0b3adb70ec5011",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c9c83a8593e3f7592eda260352fe06b835778816"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "420952322597f3fe5da685401081dd118cefa8531d4985a60a3ead630d884e44"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/asgiref-3.10.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...asgiref-3.10.0.dist-info-METADATA-407d131b3be207eb",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b2210876ef346d0dc76063083d45d7f13a297a46"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4e570a3829f7170482183eb68d991b7243d187e4630219022cb0e77e60d94f20"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/asgiref-3.10.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...asgiref-3.10.0.dist-info-RECORD-28f304b560223e58",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0fd1d34db94e0406e05eda65624fd6dd871ff8b7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "73cf24dce973604ab8f85e2324650a0f00326a7078ff2c1ece156353ca69b805"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/asgiref-3.10.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...asgiref-3.10.0.dist-info-top-level.txt-9714f182246972a9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "612390bd0d0227c009f9c99b479878adf7ac2f23"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6e89108c2cf0c0446174188f76f60465ae1c1f14f83427807df40d52a27cb2c8"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/asttokens-3.0.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...asttokens-3.0.0.dist-info-METADATA-e56f89dfa94844c4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "13141c9845659c46c6e5ad0a24f9c75f6201a521"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "720d7258d2603bac73a90cda2ac428289b8a64c11fb89021d3b8902c080dbfa9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/asttokens-3.0.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...asttokens-3.0.0.dist-info-RECORD-668ad3e7d2ccd2ec",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "37f0adedd1bbe26743d94c0a3dc4674dfe27d383"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "025cfb5da5ee67cd35f17e89d8ba4be0a3380fe5cee914bbb443b20a8d698160"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/asttokens-3.0.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-7054ecf31f7fb1da",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9b064258ceeb6f8bcf042a8c1d53014a0d414846"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9c90f07920fbfcd0613a547773c6e428930a33ea719404bc2b287c19c093d9d9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/attrs-25.4.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...attrs-25.4.0.dist-info-METADATA-e70fa87e19aee285",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9e593ab8f12d14d819a81ca9c41b9df0b4864a59"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d917abc63eda81c311c62c1d92dea50b682ea870269062821f5de75962bb6684"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/attrs-25.4.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...attrs-25.4.0.dist-info-RECORD-7a575e54b8713c68",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "aeddcbcdff7121cd86ae6e0652c68fee24c475b9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "af51690e2e69b75c5da7d67cff104a16ec432dcf7df038c1b6ecb5fcaae9d24d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/certifi-2025.10.5.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...certifi-2025.10.5.dist-info-METADATA-e30b61ecf8fcde67",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0d7af39dbf0a67e925d40391a6dbb2ebb3f37cab"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "473c91e2c4fac51375a4d372db820754e959b83261d4135f68c6b4e3311a76d9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/certifi-2025.10.5.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...certifi-2025.10.5.dist-info-RECORD-ebd4eecc63c9d687",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "99077b780968afc6eb2ac85cba3f62eec80bd2d8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8143790fa961fc5f24271329bf1d385e2ced646459959aad870b17af91dfa9f7"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/certifi-2025.10.5.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-e704e80eb06cee6c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bc5ea804a025dffde14fbf3746e34487196073d7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "28cbb8bd409fb232eb90f6d235d81d7a44bea552730402453bffe723c345ebe5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/decorator-5.2.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...decorator-5.2.1.dist-info-METADATA-15857040c0aa335d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6c06e8950c30d2278d2ad8b77144c6c129564f5d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8bbe9fa7b94da3441b8a75f73412634aefc6855a7d03c8ae69bfbe9bef26281e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/decorator-5.2.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...decorator-5.2.1.dist-info-RECORD-7bcc0dbdeb378d9d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "dc25f4ee3662880fe3b260cb25d46aae917d8562"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "fbef561a6fc9b685f7a4452509af2f88466fd7b4a50c64338fad9d84c50b119b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/decorator-5.2.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-c1c55f57e84f1f5d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d5cde0b27f3caa302e8ab03bdf70087d33203b25"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2a7e9e423a3cddcb56c5757204c398b74fd8a634630739ca615b8dcae0bf0d22"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/diff_match_patch-20241021.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-49bd2b4697ee9773",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e14c1aba292acf4e08bc2c6397cb8050d2b52792"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a7c93bcbe17813f3395de795bdec7c59fb7e633998936f8c09c1f0e47cc00532"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/diff_match_patch-20241021.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-d542947701df956c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f90e8dbb345522306c3c0b43108e5eb3605bb12f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f9153a6e37d4884a3ab1be46972f6b2be8abc89be7156237d988329d2c3fdc45"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/distro-1.9.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...distro-1.9.0.dist-info-METADATA-33705d47f1690b00",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ce14620cf14e15a64d2ff574796543f99619e7f3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "31632ab2de5591131091b3397bdcdf797718579d85a75186f06839dd0c09e81d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/distro-1.9.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...distro-1.9.0.dist-info-RECORD-3a728df9ce6331ee",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "57064aff62f6e248265b5149dbe38156974da832"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "697b9ce5fb00b950d5462fa689b6f51e271f32601900983c9300b2708c809f33"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/distro-1.9.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...distro-1.9.0.dist-info-top-level.txt-0c3d92328a186adb",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1b0117e87175387a42cb90d875fbb9e0481c17bf"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8a475efd5fd711d481a9a19de6d12b88dff0cd81cb8135ffcd5b65b062c7bf04"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django-5.2.7.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...django-5.2.7.dist-info-METADATA-240bf42a42cae009",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "df9fd36e24b241a2c40ddea786cf61996b0fd572"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7d5b69524872505438c9e316b74be9bf143df8caffa9e17427a9ed50c6d2a182"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django-5.2.7.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...django-5.2.7.dist-info-RECORD-deac26504bc1bf67",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f46a82ff9d95febafbb35c1b0e70ecffc5264b3f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "34d1d807d74b53eb0f7e22fe1af407d110cc22a39d8306381762f30ae0870d7a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django-5.2.7.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...django-5.2.7.dist-info-top-level.txt-2fc835bb9b654e30",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5e9221c8be22311032aea0708da4f54525117f76"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "57f8288a383db5f3b6d28c7fee8b3a09c9cfbe605abdbc6ee3a2e926234bc230"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_import_export-4.3.12.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-c6644d9d14da1be3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d8d8968cd7ff88157213e6464ea849fb37f932bf"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a97f1a56eaab7280cd42f10c4bff1219f63dd1bf219e23b6673fc2a9d2b3cbca"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_import_export-4.3.12.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-0c4c58437e2e3398",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f322e88c58edfe075b7e2d4040959a32158c41f9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8ae52f38e975e3f71c6e67062b4cb8e6eb9e59cba538f52b5687ec731a01b356"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_import_export-4.3.12.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-ba30bf832a008ec0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bcb3e6b4cf7e7a5cbec23f462457c579689bd668"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e5108d910aae206afa821201783e9cbba00ae32e6bcf265cf5f495bcb83781b2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_jazzmin-3.0.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-069ae4b3e0452970",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8bbb30e07cbb91a6a0d36cceb8def24b2a39bdf9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "abc4284f09703901ad20e256cce3c96513db6c811cbf8426ca01eca8692f63f4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_jazzmin-3.0.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...django-jazzmin-3.0.1.dist-info-RECORD-32073f4f06e0a849",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2a369758be25d73d71694c413f3b50d66e9866fb"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9a1c5b58c2e55768acb86d39aaf5f2adb1fb8a4f49415775f70ca9d88e5290b0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_js_asset-3.1.2.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-819e7b21eff44d7e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c361376493befa2007baac7dc96d8cd7ff5b5ec0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1c722be18e9cabcc18a65b3d95446186b0373c1a5bd4831d963a4f1b90c99ae2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_js_asset-3.1.2.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...django-js-asset-3.1.2.dist-info-RECORD-12cadbed23c34453",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "04b55b5e7b3b07704c2e8699c8e8ba7d5acc6407"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "409f9d9d94499eaa58544bcca3e13bf1afe69f4b4391f482b3683a8904dc3096"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_mptt-0.18.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...django-mptt-0.18.0.dist-info-METADATA-96af7192787c2868",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4501d749b5c4da73ec91366a8fa6b2709a29a45b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "fd40904675768e169db55f9d5bde82e400a465a77bfa94d2de2c9fc84bba3d02"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_mptt-0.18.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...django-mptt-0.18.0.dist-info-RECORD-4a20946224b974b6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c857976337f573751dae3a789f89eefc86b895a1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "29aa2d9b4d53ed331e91733021062c3abe4bffcf2988a3da0560ec471c021b4f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_qr_code-4.2.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-6e3b654fb725bc59",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8f29633449da397019ce71966aec48e6a7211c4c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "451290b00ee6bda89a6e70ff7b1f20e16ab0febc0aa05d96058163b37bc2efc0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_qr_code-4.2.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...django-qr-code-4.2.0.dist-info-RECORD-2f3e6690cdebbd86",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "69f99424dd601168387347761dd50876951e48ac"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d8a396dcdf3220c8ce603a7bd73a3a2ed92363274c02e877adea4a67e06e1384"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/django_qr_code-4.2.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-762a7829e057951e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9c5bd7bb23ba913c5a28e88abcfe3a8314baa710"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c16f92fbacc0d6bf4f98b9593dfa0d32484e48f55e0d05514602db535cc0e7c8"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/djangorestframework-3.16.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-cefd19f681996755",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "39ccb29c8b02c6f65ed40f1f6224614583ac6d11"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5d07a3efed3b615883394a7bc5ccab3ef366cf641cc0b3418b374367e810babf"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/djangorestframework-3.16.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-1e0a680bf8c3056d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "13d120bec421f8166d93e85232a6bf47c196e818"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d5713f11e72d6ae6b4cec4ae700619e3a0b4bf0a5163436cb3f12645819741c7"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/djangorestframework-3.16.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-734660a9a7d8c784",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "848ca929f68e9f1586c93518b0e8298f143e9ea8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "fec0ce20de53edeb2000de739677cb1cba3b006ed35aa058553c8529545d5efe"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/drf_spectacular-0.28.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-80021d507067fea5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "21daa215cfdf45bb2487af518783f47552401991"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "22857755f23a36eccc32652c25eaa2dc24ef1a32fcfc91905ee948358861fd1c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/drf_spectacular-0.28.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-c6b10abd5e86c6aa",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "53fcf074b3a282e667aab3bdfb076d785c26440a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e0a1d904272e22234911001b22e7bc151fd47a0d61825873328f32302511628d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/drf_spectacular-0.28.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-f4b4520645b720b4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e83e6696a0d8c7d22471ed503aad0aa5d1fbded8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8504f266061641aa1d5f4613fae824e8565469e83a773486174979a5e5cdb3c9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/executing-2.2.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...executing-2.2.1.dist-info-METADATA-2cbcb88f2e390284",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "411d2bc05129dbc7160b8ea8f19f4c248a0cb6b5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d7586d1ae225bee126c4237eb0c4d7699a8580b81eb558cc500c263d29a633ff"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/executing-2.2.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...executing-2.2.1.dist-info-RECORD-71b303f8e407752d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c038f77fd5fe67ee11515e7b84825d347e77cf37"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "730c7f2eefa2fd2ef71b81e1f6a801d3ed83e17efed1ee393750602b7fe03e1b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/executing-2.2.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-09b9097296c40322",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2e855c368d5396cb1dddf1ceaa34d0f6e176f4ea"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6fd46d7f736d4aa734fca6a4e8bfe5be76dd28f0341948a6da9f9770542c7f98"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/h11-0.16.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...h11-0.16.0.dist-info-METADATA-ffc4d796fa93621a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5d41eddffefef5f6e8ff383a2537e81a38a37807"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "28f326098ac09fcba79b8f180f96087c841fe2456215cb7b872a9c7d5cd19d64"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/h11-0.16.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...h11-0.16.0.dist-info-RECORD-8aa5144cb3e8617b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f8aedab218e4d8f2d5d262c1f364dafa7e64556e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "38f9d4e04b4ffd3b889098c3cac68a9854db8b06f2fdd501157c89cdbf0d80f6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/h11-0.16.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...h11-0.16.0.dist-info-top-level.txt-f75c0caa9a460d2d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "af3e481d6cd18c46887bf876b3d934054bc4d820"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "17b742e23977cde87c4c61c43da589acc6deba859b4b7efd1b0762f98bdd722b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/httpcore-1.0.9.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...httpcore-1.0.9.dist-info-METADATA-7ce46233e5dc9720",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2981d359ae33f31d339189a9680db85785339a56"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "fe2d4fda6199128978779e0cf27f3c045c531863fcdd987eacc74f3a18d41c21"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/httpcore-1.0.9.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...httpcore-1.0.9.dist-info-RECORD-06f81504e0ab14af",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3608707f18fe361538b9e1f99d9ecf1b4b491258"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "857d1792fa6969c1fc4169b68159fc032a65f8de14e067d6ea5f3c7a464babed"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/httpx-0.28.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...httpx-0.28.1.dist-info-METADATA-dd425c3ff8c0cac5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "537da7e4f29438278e124e10e02d1a500fe33bcc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "febb9b0f8f3e80d57c8199c304f35c4336e8581d1d18d7983c92766b82793b25"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/httpx-0.28.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...httpx-0.28.1.dist-info-RECORD-fd750fb0141b1724",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a56ceb3533d36bbfbbe92c32da12dfb4be405e2b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "38e8affef15e140af5521160db6d6e355c2aa4bd4bbece617f0fbd120312f3b4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/idna-3.11.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...idna-3.11.dist-info-METADATA-bf3f14eab9c293f4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5e73674d19cce0601253436a2e5544abe09b9bc3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7c2c12c30f52ba237c4c81e59454804944025b9e6102cf1dcca9ebf5168411b0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/idna-3.11.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...idna-3.11.dist-info-RECORD-692b765886f9f9ec",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b81658aa154223b9c0ff1bdc1e12c08f5b56b31b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a83a7c95189068a850dbb479a1d9b8dad22e29dc67d6ce049121d18db62041a9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/inflection-0.5.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...inflection-0.5.1.dist-info-METADATA-94a7b73b3d9d0b5f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "06eb89d01518857a8219eb24d65d78e4d741531b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1f384438420dd71287d030fecfd98f276ff8657bbf9989380d50f199c1e20c25"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/inflection-0.5.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...inflection-0.5.1.dist-info-RECORD-d4792dac9d4e51b6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "daaa7cc1aaa7930b21ecd7eae3512c233477446a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a819e9053da181c0b28574823bd976f2216097f2866b3e034e22ded80064a243"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/inflection-0.5.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-d8c34255d1ff5612",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b771ecd44f5d8e59f8fb111f6ce4a5f3e231f407"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "013daf6116463066276ac35d8f8a096e949d765b58499ddc6461fc063a3bc50a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ipython-9.6.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...ipython-9.6.0.dist-info-METADATA-340ae984800cc366",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "cdf831c1e28ba7a0ca99d67c928367731816864f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "501c8699e1affb71f96a269e65535f61d21d51e6200eaffe80f7a8925af726d0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ipython-9.6.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...ipython-9.6.0.dist-info-RECORD-b17052ac665cb127",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "712bd3e935358a8709d07cf8dbf60bca11256955"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6a526404054ee3a272f4be6edc6b358a4cbdfbf78aa32cca5d718a8b9ce041bf"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ipython-9.6.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...ipython-9.6.0.dist-info-top-level.txt-939452ecb20d1e7a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b1e8ae8afabcd603a2cfb351847b649c498c33c3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3ca8ef1ed342059f441d399dda6c09d49fe4de3d05e83d654c5cc87091453c45"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ipython_pygments_lexers-1.1.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-da2136468e4c387f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c3d7d961ebc6f2444fa8af6611055a7d9c0d261c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6b38c0946bdbc4778f4e38e2298547cbd7d13aeba9979ec4e4a412eabfbdfadb"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ipython_pygments_lexers-1.1.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-bdc80593e814dd5a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ed875078eec483760d3613bd6992011a4daf11aa"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5c5d0a65d78f9c88968abf189a73f97155b83536dc6b269d638f824fc202122b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jedi-0.19.2.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...jedi-0.19.2.dist-info-METADATA-3bbc4a79684f4456",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "db769b405059e723ecb775ccb9167773b93d128f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "34154330a5f5f3462ac080460e640ccb1e3b2fb145c416161bd32b09b0987ffb"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jedi-0.19.2.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...jedi-0.19.2.dist-info-RECORD-d1e2f6c779da458b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4167b6cf7d93e3c3bbae59139760cc55976f6677"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e2d0db8b7a0135e8f037e9ee826adf7859bbd34f8a8e748003f1a2a21714c4d3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jedi-0.19.2.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...jedi-0.19.2.dist-info-top-level.txt-536c0c34040d068b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "fba3cc15b9417de1ca56ce15e8edd717ac10f1e9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4aa363f54efbc8e9f965fe098ba0aa2fcf83d9e360fc5ef5187a3c57c48c574e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jiter-0.11.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...jiter-0.11.1.dist-info-METADATA-47e38a5814d862b8",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a99ca899118e2c2acd11687f52f0697802883b58"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "59624a753b976d885157794b71e02740a95bca2795e7b048f2a03b0e1c23b161"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jiter-0.11.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...jiter-0.11.1.dist-info-RECORD-207eaca6d6136257",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "15d9ace48f8b1b06b3c8283ec4dc998ba1f5111e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5f605a9cb71dbf8197c4d5a8448e1311c0d655165e365adb89e128ddc6f5a40e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jiter/jiter.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...jiter.cpython-313-x86-64-linux-gnu.so-1432773fe29b8497",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jsonschema-4.25.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...jsonschema-4.25.1.dist-info-METADATA-559d4dee68de9c77",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "474d9fada0f55b4259409eea31ed4273434169b6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "31f83c1579e46e1af62269cefa5d83534ef155f3ee21914f7881bbd544bc125c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jsonschema-4.25.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...jsonschema-4.25.1.dist-info-RECORD-ec7ffe94495145a2",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a9d5ea1e88af28ed5ddb35ed6ccba1c32a840406"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a37fb8b401fce288d0181492b358bee6e43012f4c3e2fcd147c21ca5fcf288b2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jsonschema_specifications-2025.9.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-872d4c695a6dc872",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ac33f477be9d3336ae67bc454f68a9ff39c91cf3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "35abd41757f32b4ea24756920ded47b70173d77cbc052a5a6d3ab583b2e8d89d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/jsonschema_specifications-2025.9.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-418de5b73c7a9a90",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "519277296bc9707f2f3c8d9675af5f0a5bdfceb7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "81556fd7fef103bebb3768a52c78676b124e96ecc61e13a5b0511ae02cb13cfd"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-7d7d25e79d299fe7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2eb644f8326d0ea33210514bc768ffbc815300ad"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "abe2ef3b47b65e77d5154a3a2f96bcd8e4777f9ad25dd4c5a45a12ff7ab2ee47"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...lunes-cms-2025.10.9a0.dist-info-RECORD-14981702d25d3f44",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "cb134bf7b49de6c904c5df0e94dfa5aaffcce36f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "82e0a1d15f00c9f525f597221caa9674834169080fec65ac73d0afa72a9d9be5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/direct_url.json",
+   "SPDXID": "SPDXRef-File-...direct-url.json-e22cf8a484d2bae2",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b00712a8e129d5b1fd9b486756a98d00b48db9e2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d535b484ea698388779ab8d51a85bab0bbe276edbe53416a82a4b66e8948d386"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/lunes_cms-2025.10.9a0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-941ae1cfd39e5b31",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "63491a457b1b1ddbead98b8b825246b86f1ac41b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "37bab477f50ff36c79fff2e701a8542cccfcfd63b9e4125416489fbd984f9cba"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/matplotlib_inline-0.2.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-0ea4cf70a6f9310a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e3222b1d7e27bbcc2a68d114ac5112d6872c9263"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "801c03fa93d34b68b35ea067c1448822691b09358b8032cde208ed6c3ee0b6b4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/matplotlib_inline-0.2.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-3d945d03d5f17cb8",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "517b5cdfe41fa0aceff2e297ff036d5d7761585d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "54ce161990332d5a9a26d855c264b0aa43b7a97a89bb8fb352e0252f792ce6af"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/openai-2.6.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...openai-2.6.1.dist-info-METADATA-de6cddc0a3db3450",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2ac0525598f475675b8433caf8c78974400b5ccc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6a55da43ce61efa69aa6c8a4d728c3a4e976d02e8fa8cbe565229e26aea91410"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/openai-2.6.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...openai-2.6.1.dist-info-RECORD-9177565be8486f08",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "96437d624ce5cfe8a360c11d6431367cdf53dbb9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a987ed974d27393096a3c4fd3b467b25406e3ce04c824a172373a091a61424f2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/parso-0.8.5.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...parso-0.8.5.dist-info-METADATA-b03638925c191d99",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5622c8193a9d96a2473d3b40b02b728494e686d7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "31c80c89d86c5c9f24d164602be117fd11dd129cbb583019fa765e45b02c495f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/parso-0.8.5.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...parso-0.8.5.dist-info-RECORD-4a28590ba140011e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "eeec9a2b77897cdad8ac14e6797fe42ae1be378b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b41479b0be7b318e78ac11b91376e7398c9e77f203dd5fec58ad49e8f87c3850"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/parso-0.8.5.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...parso-0.8.5.dist-info-top-level.txt-e1fa6895745462be",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6550b7333f8037cd63fb8c5931a4178f6c842b65"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "18e38a4023dc9ebd3fec8440af1c88d025f92cbbb858b973211015592faf278b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pexpect-4.9.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pexpect-4.9.0.dist-info-METADATA-fd3b266c7b50031f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f31642dfa90681633830ac5c8d9a6dbbfc39e49d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2d7c5ac5fdefde4a0194ec522fbcc0ca70e99e1a2a956eea444168f8591650aa"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pexpect-4.9.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pexpect-4.9.0.dist-info-RECORD-7a4c7b81619c0adc",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "aef1f4b5b0916d34cf6e92409af7fc40b8c75d39"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6f7e30e50f89923c30d9e3498404c4aa812f28880dacbabd3a652abc71f51576"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pexpect-4.9.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...pexpect-4.9.0.dist-info-top-level.txt-68ae51c98aeca1c5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d0ecd34bf1fa737b033e68a74d7ed6264c960909"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3be6f7518f55419916df20c078535ab5438a3b81a88d558ee134c7a08f7e13b9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow-12.0.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pillow-12.0.0.dist-info-METADATA-5064ef1c54462ee1",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "44887a22e7dcc9a9ab7ed250dfa38331382cdcbe"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ad620452bfa53cbfa294d7da7b66dab5a086a54ede0ce178bd74e380ebc434c8"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow-12.0.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pillow-12.0.0.dist-info-RECORD-8aec256b8cc7bc53",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "404c6e59d6e8984d41c7426f455d5f991528aef1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c4fdfbbc8ed4be3f18b536b556cb337fa91e0145d61fc1adc890abc889c3c2cd"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow-12.0.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...pillow-12.0.0.dist-info-top-level.txt-6c1e5e4217086bf7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7874f2b6a9121fb487328754f5b4c521e2fb7e94"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ae266aae4fa1c99aa1e5fd59d19c228b774a7f112c07286ef5c53d20e0c5f8d6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libXau-154567c4.so.6.0.0",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libXau-154567c4.so.6.0.0-7993c432da85f727",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libavif-01e67780.so.16.3.0",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libavif-01e67780.so.16.3.0-1795f8deb4e11380",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libbrotlicommon-c55a5f7a.so.1.1.0",
+   "SPDXID": "SPDXRef-File-...libbrotlicommon-c55a5f7a.so.1.1.0-74eaddb22c38556f",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libbrotlidec-2ced2f3a.so.1.1.0",
+   "SPDXID": "SPDXRef-File-...libbrotlidec-2ced2f3a.so.1.1.0-8ff0810eb0342bc9",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libfreetype-5bb46249.so.6.20.4",
+   "SPDXID": "SPDXRef-File-...libfreetype-5bb46249.so.6.20.4-3fccc99ae48c06ce",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libharfbuzz-525aa570.so.0.61210.0",
+   "SPDXID": "SPDXRef-File-...libharfbuzz-525aa570.so.0.61210.0-981e3fb4e009adc9",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libjpeg-a41b0190.so.62.4.0",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libjpeg-a41b0190.so.62.4.0-d553ced45927ad9c",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/liblcms2-cc10e42f.so.2.0.17",
+   "SPDXID": "SPDXRef-File-...liblcms2-cc10e42f.so.2.0.17-dac323c6806439d9",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/liblzma-64b7ab39.so.5.8.1",
+   "SPDXID": "SPDXRef-File-...pillow.libs-liblzma-64b7ab39.so.5.8.1-5846596592884ac0",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libopenjp2-94e588ba.so.2.5.4",
+   "SPDXID": "SPDXRef-File-...libopenjp2-94e588ba.so.2.5.4-047cce061ab55f51",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libpng16-00127801.so.16.50.0",
+   "SPDXID": "SPDXRef-File-...libpng16-00127801.so.16.50.0-b8da60293dc7523c",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libsharpyuv-95d8a097.so.0.1.2",
+   "SPDXID": "SPDXRef-File-...libsharpyuv-95d8a097.so.0.1.2-532eb7ad566760ca",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libtiff-295fd75c.so.6.2.0",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libtiff-295fd75c.so.6.2.0-b308be2260bcb1cb",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libwebp-d8b9687f.so.7.2.0",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libwebp-d8b9687f.so.7.2.0-de8b80df7d63f32e",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libwebpdemux-747f2b49.so.2.0.17",
+   "SPDXID": "SPDXRef-File-...libwebpdemux-747f2b49.so.2.0.17-852c36718aeedddf",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libwebpmux-7f11e5ce.so.3.1.2",
+   "SPDXID": "SPDXRef-File-...libwebpmux-7f11e5ce.so.3.1.2-f50e48219424fc9e",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libxcb-64009ff3.so.1.1.0",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libxcb-64009ff3.so.1.1.0-f1fee28fd85d0317",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pillow.libs/libzstd-761a17b6.so.1.5.7",
+   "SPDXID": "SPDXRef-File-...pillow.libs-libzstd-761a17b6.so.1.5.7-af00a90e708a70e3",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pip-25.1.1.dist-info-METADATA-401d82b643527256",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "09b606885861bc42ef728f0ee459c2e3cf58cd33"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "405c63d6d2e993c8465ab8102d1849614a70a3fd45a81af8dce4f4b2b2197265"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pip-25.1.1.dist-info-RECORD-a679af0b926125ad",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "572cda7a3e438b4eeae9edebb0c2b5c3732d1ca8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4d37608b38090c5f0ea0d2b246fd911c0a41f5425e5aee587c151f9cb04b94cf"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pip-25.1.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...pip-25.1.1.dist-info-top-level.txt-e95b6d3e4a6f322f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d7a03141d5d6b1e88b6b59ef08b6681df212c599"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ceebae7b8927a3227e5303cf5e0f1f7b34bb542ad7250ac03fbcde36ec2f1508"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/prompt_toolkit-3.0.52.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-4a912a496e256ad9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9fa9c840f57a71dbf80c461bebff6b16348a0ff9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "80d4bd40a6a171dfd25c332baebee1fd8722342f133db5385e2d5719a5da2e29"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/prompt_toolkit-3.0.52.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...prompt-toolkit-3.0.52.dist-info-RECORD-313a5fa5505c8124",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a112750db8e5e07046a5eadf6fc04031c3a165d3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "99b07c7afe1a11bce37d34919929037ffdb4329f2f6e2fca03ac63893ae4b1e5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/prompt_toolkit-3.0.52.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-1374bc864264b724",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a54d3c8b4eef8813a6453f862fbfde517e7a60ed"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e6b257ac41b1eacb782a49a138f47a9742130db579df1fd7cba32eaceba45df0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/psycopg2-2.9.11.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...psycopg2-2.9.11.dist-info-METADATA-3d791ee7dbd32e4d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6105ca9d5dcbb4e5def0fca97b0c430dd9d600cf"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "40c9d08e9172f1841e07ae34791e871c80e3370032ba275b4482901e1f6f4355"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/psycopg2-2.9.11.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...psycopg2-2.9.11.dist-info-RECORD-2d5885058117afb7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f211cb70add651f66d4bbfcdb9a71892c259663e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2c0a6188f02608f8d5e5da4cd7b0df288e3eab388b71e669526d0a98def3355a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/psycopg2-2.9.11.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-fa2f716c9a81cf17",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "46fa75fa1cee52ce844df1a7c86200a53b81d677"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "edd1c6a4ba90df0faf1a6184567fbbb8af74a94f5fcab19d5968bb4be8137273"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/psycopg2/_psycopg.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-psycopg.cpython-313-x86-64-linux-gnu.so-da8d6fa364b6bc1b",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ptyprocess-0.7.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...ptyprocess-0.7.0.dist-info-METADATA-68634241d3f42d31",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d6643f4095bb329dec106a6f17abc6eb3cef0387"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c3c2b96b5d9a55da5958c34d08c18a0849f56609026cc46d5c95b8b77fcf3e0c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/ptyprocess-0.7.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...ptyprocess-0.7.0.dist-info-RECORD-7b120a5947b0c21d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "85adf77647a9b01abfb805655634e816c234b998"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0d4cff4cd36c7c75ab5f452ec1f275d09698ca65d43f4c619d50a38ae93ab639"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pure_eval-0.2.3.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pure-eval-0.2.3.dist-info-METADATA-62c4e4149ad79ea6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0df8cca421897448e6b38d3a31515391146ea4de"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "97cdad3355bf3083668e8a5e98ad2a958cd68839b369a35b171e372ab48ee986"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pure_eval-0.2.3.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pure-eval-0.2.3.dist-info-RECORD-d3c040c918707639",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4c7a4d3b215ff1607732212d9b22ef1fb72d20a5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "27965f0e3953c490c10c6ccfcf0b45e9f108293960f6d4b0281b97486aa54548"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pure_eval-0.2.3.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-7f8568b014c88714",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "faf99fc15dd24d3ea93ef5587e728a521e01cc96"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6a3db8bf3c37c1cdd7b0bdd0d2c1e27485fa37b4da562103af547f47841b823a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydantic-2.12.3.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pydantic-2.12.3.dist-info-METADATA-26a588bcc1cdea4c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2de3acc66c01430c45855ce7201ea7ecd30959dd"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "348336c208743aafeabfa5537c29f429035a3107b7a78bbb6a3bf7b3a42fe4aa"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydantic-2.12.3.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pydantic-2.12.3.dist-info-RECORD-00d868b3788eaad2",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5fc9b0601492fc8e7a7ac72695e99eca0d2d28b7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9b26cf9acb2b15f3fc550ca77a5c628546cb63faa8da25c867329f48a55cb502"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydantic_core-2.41.4.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-fd9dac09da539e0b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a9ce80cb09a41d1ae7606069cf39fe36426a6136"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3434fb886fe254ed414541f305a86e43ff575093f8f6d15c89bd11144ed8e131"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydantic_core-2.41.4.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pydantic-core-2.41.4.dist-info-RECORD-74eb392fcf79c86e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "81038cd04094077a6c55a64610c4c7533712280f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d4b8e1f1a63c99fc5db75538177684101d27969559ef7b1c3d89a04a7807a59d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydantic_core/_pydantic_core.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-pydantic-core.cpython-313-x86-64-linux-gnu.so-2fc469971aebb3fc",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydub-0.25.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pydub-0.25.1.dist-info-METADATA-992d0cf0d292c3ac",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6e31e3a804e9d716fec7a97b823cf22cfaea219b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7f433cfd956d6e2628508f5e8d721e274dc9a3d03935b8bed15d5b56ab398989"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydub-0.25.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pydub-0.25.1.dist-info-RECORD-85bb811980246831",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4569c58734b6eae2992b6bd5cacc51398fefec3e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ba4c9b7cbec1a54d53ee98d7fa41455999aaa732bfbc01862a68eec0a766d15b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pydub-0.25.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...pydub-0.25.1.dist-info-top-level.txt-7eaa0393c9e214e3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0f2416b8603ba17ae20246a65d8fa4d75035e2ae"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3c78620c241565dc9c6717ca2f6950a33aee053e9986fc99030aa346bc37b74c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pygments-2.19.2.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pygments-2.19.2.dist-info-METADATA-5d3944500090b4e3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "afee6b8cae57db32719d0559389750d7923f0605"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7ae100d67d67006c6479803dd835fcf47a9b59fac794441ea8e66aa7f5984d82"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pygments-2.19.2.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pygments-2.19.2.dist-info-RECORD-0bdedfb16dd50dbe",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "dfbf5e855754e8d418b9b1caf73a53563b0eea9b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "df2dfb1f4acaeeb264aacccff587a569dbc4b1042457fe5a5c1b882246e8c10d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pyyaml-6.0.3.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...pyyaml-6.0.3.dist-info-METADATA-dee5877627fb8f77",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3be76483e6df5a4f8f8be5eaedfb8d7f40678c48"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "03c3b415ed38d09faedc49360e930769b40c58f68585e6de00e2e4916a858d34"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pyyaml-6.0.3.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...pyyaml-6.0.3.dist-info-RECORD-aef4f0f37b857a9a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7aaa990d6fa35c24b024cb28023ce443e7094d48"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ca4b6cda0baa753a5b7bb2a4d5499f661db77f31b182148058a4490e78e86080"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/pyyaml-6.0.3.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...pyyaml-6.0.3.dist-info-top-level.txt-0ed225bb40e7dbd1",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9e8a73cfb8a2d50dd6446e55a4019eea9f6004bc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ae98f42153138ac02387fd6f1b709c7fdbf98e9090c00cfa703d48554e597614"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/referencing-0.37.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...referencing-0.37.0.dist-info-METADATA-448975660e03be42",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f6fa004340bef5d23995b09dab75ce12e3f367a7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c93b00e6ab1524fd60848376604c189a114374776475c25a31d57be47b29de6a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/referencing-0.37.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...referencing-0.37.0.dist-info-RECORD-dfcfefd716752686",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "33e908ca750f24117a6aa66733383c13ec4319d2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1f000e19b89666cefa152e450750f87a2da152fc1f282f0ad85b1e9c67e7fe68"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/rpds/rpds.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...rpds.cpython-313-x86-64-linux-gnu.so-c5be40a362f5faff",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/rpds_py-0.28.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...rpds-py-0.28.0.dist-info-METADATA-cf1d85aeb4b5c7d5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "59024d6a57d2f7a2dec246a051c9f97b83bfbf58"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "76e47a0b9f9651267eda03729663563948108b9d76df2755ff8e9f4426da6423"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/rpds_py-0.28.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...rpds-py-0.28.0.dist-info-RECORD-d3957c4e59f0e283",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3b5ab0fbaeed0e18f622be77f584415c29fc6e93"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d0e52f9f147d95a4dc3800a92f36b412588b41316003feb60d495367147b01cf"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/segno-1.6.6.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...segno-1.6.6.dist-info-METADATA-cbe78c73022c187b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6211ef9acb99bffdc82ece388005aebf897b8a21"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e478bb1f9c7b7d53d2af9392d2c7d1a89073b5a92e6e109f37cbc085bc3d7935"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/segno-1.6.6.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...segno-1.6.6.dist-info-RECORD-7e8aad7e57a5480a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "48f1912917a7ef131d79fd9098e88e3b52c1edcf"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4a9d539429538965b82316c70323012e4b0a0aab149d60eceb6a08c782e3a235"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/sniffio-1.3.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...sniffio-1.3.1.dist-info-METADATA-5ad7ea3731fa3037",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bc1d7aead770fe23c8d22666b84558edb3686da3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0b318b57098edeccf585e60a889a6b6a7b5c4086f3a9aa62eff76a1d3cee12d9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/sniffio-1.3.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...sniffio-1.3.1.dist-info-RECORD-92408a715ad34356",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "30f77f8cdf8bb52844bdec3e9ddc825bbf8e6028"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "39ac5b0cb05cd02478b7ea86a7429ce10cefaf09c3166216ee562e344fac5541"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/sniffio-1.3.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...sniffio-1.3.1.dist-info-top-level.txt-f37a93c6063a6311",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "029477e7b858820bd39189b62703d5a4e597ca24"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "bfd5095c6b390b275d095780a979108963aba69e96b71e86791acfb7dfa38c78"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/sqlparse-0.5.3.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...sqlparse-0.5.3.dist-info-METADATA-c5aa3bcb409aaeb9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "501d4996962c66d8f516b9d26029d98cbab46abc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ea1e5df5a969ef19d62e05c00896a64d6aee79d65997c8d86ed4ee3b06e9ac8e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/sqlparse-0.5.3.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...sqlparse-0.5.3.dist-info-RECORD-b32a862113014605",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "78cf3f429077349cfb964175fbdb4eaecd7158f8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0ee0d2e512e687b39ec22691deb149b6393541b425dbd5cc3f6f2370f9facc91"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/stack_data-0.6.3.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...stack-data-0.6.3.dist-info-METADATA-1c662725f04fb5a2",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "50229eb4df7afdb15ede1d22ed42dfdb2d715a19"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f28a66f2adde54e7031355e09a166e437bc0d023a31c10c973ac494288ca4c6f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/stack_data-0.6.3.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...stack-data-0.6.3.dist-info-RECORD-f69e11a96c2e7907",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a5013e0de1812f07d927e0f4ef861ca16c1e7e80"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d1f2b73db4dd4814c10d325b3adf72ddda8aaca44cb31041868a9fff52fcadfc"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/stack_data-0.6.3.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-0857beaaee2e54ef",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5b12e382e8a40b2ca77f7ed3c26e78b9113d4d25"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "21aacf058618f5e7c99008149eeca43143f39d047e79b590618b1072a606c42a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/tablib-3.9.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...tablib-3.9.0.dist-info-METADATA-21d79beab506fd12",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "192829b330e8adce986bce6e72681903ed32729c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "396c68bf690f3e85ec7601e4a878181697dc9029b5e7622de186cf66ff19da89"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/tablib-3.9.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...tablib-3.9.0.dist-info-RECORD-83f4c940ae280943",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d82eeb7b78336ee6508cf878edfb0879fdddf065"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e7afffed2e902212a46aaeb60aae1f08b3392b6dcff1607a2a145523d5c177e8"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/tablib-3.9.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...tablib-3.9.0.dist-info-top-level.txt-d0e93bbd3a259780",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "461b5ea032e9ec5b958af83a743b61ae36c6b97a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5ec744b06fac0a25c418d91320fca9ed4c15a9742aa42b4f886bb98d80dd0dac"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/tqdm-4.67.1.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...tqdm-4.67.1.dist-info-METADATA-c5abad2d5baf5df3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "13fdc62748a0d682db11ab8d825b764849c7ffa4"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "688a1632df525a198fec52dcfefb1246d31eacee9c035aacac2d7eaf8d8ff669"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/tqdm-4.67.1.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...tqdm-4.67.1.dist-info-RECORD-8d316a3c679a71c6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "13d10ee2709c7b12957639ce87684cc17f84fed2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "48138f46f2f01a0a3291d28a24ab08ff6b6f6c92b2ca296f4589f26d8594d37a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/tqdm-4.67.1.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...tqdm-4.67.1.dist-info-top-level.txt-ada67eb0d739c627",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f288ff9f58180dbd806ac6654da8173c4af634a7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "34b89424d7e673d02dd79b3b254462c2fa8c123522f46e4f30646b98c6333523"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/traitlets-5.14.3.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...traitlets-5.14.3.dist-info-METADATA-b5bedc01ebd87a75",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5fd919888bfd7b48df9f78ecd70d5502d0f04929"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ca0707dd88c2f8bbfd99800813df0b2cd19b884921efce72dcc9bf604fee5d56"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/traitlets-5.14.3.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...traitlets-5.14.3.dist-info-RECORD-43410095b4ba205e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "40d48b994ff44c5a0447f7a4acc8025d782fa79f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e3da9ccedcf6e4f4d508a7dc350eb9bf054eae1a01b37441144326dddbb84ff2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/typing_extensions-4.15.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-0dbfc72f069d4ae5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c5c2ce18351f8f2ae0f4a6f7c84c523f342010ee"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c138378fe8f18934ac99de060535c53ec6c13aeed65e94c32641da7ee3192a72"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/typing_extensions-4.15.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-94abd28d867f3c7d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "60df6a868dbb68510a83f7d82f027929adc5d681"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "bc33f38d8815a517c92b52d412a5a06e1957f4e57fbb4a6fff89295bac427629"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/typing_inspection-0.4.2.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...METADATA-db4978372b0f05ca",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "455fdb9c8e246ba02c2a28655287401b62028b60"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "61096cd0bfe3c7040b6f98c22b02d190fe01936d0ff7616c5134fed02891953a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/typing_inspection-0.4.2.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...RECORD-ee3aeb6b1f7b6ed3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0707b31552556ba56ba3aee447a09a7456990abc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0f03ce122a0ee9bbadaf2877040b7b14ca553bdead97797be3333171f7ab153c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/uritemplate-4.2.0.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...uritemplate-4.2.0.dist-info-METADATA-d6c54fae11a06a72",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "23d93a7467b14d86e4541df8324cca8633544964"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "352afd43b6f1ab8f94ca31af2a1ad4f0d1a94dbd712c1b6d9e44e35d4bb3a962"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/uritemplate-4.2.0.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...uritemplate-4.2.0.dist-info-RECORD-4ed3088fba4c44cf",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9c562989bf7e00901da6a44ad1c71384ad44f337"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c00cf1ca1aaa369ee602413febfed898b763f01686256632050772727b6cf7b1"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/uritemplate-4.2.0.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-a5fa9d65217433b6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3e01b57d2447ef1112d909883eb804776f0c0c7e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "589ce414420d59b830bb3b9410ff240fc4a4d9f147610cc182b8cedef8b2b9b1"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/wcwidth-0.2.14.dist-info/METADATA",
+   "SPDXID": "SPDXRef-File-...wcwidth-0.2.14.dist-info-METADATA-410ac0524505acf6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f3c28f2b2df4c008316b45a2200f28525cda2b8b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "cce22e9342cea3868f735c074c97d23490120a24b3464abf10c1d1b0bb162b53"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/wcwidth-0.2.14.dist-info/RECORD",
+   "SPDXID": "SPDXRef-File-...wcwidth-0.2.14.dist-info-RECORD-1879c4deb3037871",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2c6446d13331b5f85833b4c78c300797178f50d1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5378eb5db27ddf22b7dc6ebdd8462d0876632a6ebcdd339eaf0642be2aead40e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/wcwidth-0.2.14.dist-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...wcwidth-0.2.14.dist-info-top-level.txt-a965915f79ad5901",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ae4dfbf802da41489ab250fba6605f4b02fd91d0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2cb8d2f121625d7b8b11c0f604d7457468692967b9a291edbe7eca363f402112"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": ".venv/lib/python3.13/site-packages/yaml/_yaml.cpython-313-x86_64-linux-gnu.so",
+   "SPDXID": "SPDXRef-File-...-yaml.cpython-313-x86-64-linux-gnu.so-a3251b16ddd0cde1",
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms.egg-info/PKG-INFO",
+   "SPDXID": "SPDXRef-File-lunes-cms.egg-info-PKG-INFO-caaa47a98ed7d475",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2eb644f8326d0ea33210514bc768ffbc815300ad"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "abe2ef3b47b65e77d5154a3a2f96bcd8e4777f9ad25dd4c5a45a12ff7ab2ee47"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms.egg-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-lunes-cms.egg-info-top-level.txt-b3ef667a33538fb0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "63491a457b1b1ddbead98b8b825246b86f1ac41b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "37bab477f50ff36c79fff2e701a8542cccfcfd63b9e4125416489fbd984f9cba"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/README.md",
+   "SPDXID": "SPDXRef-File-lunes-cms-README.md-9c6b61a95bead74a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9b8a849e9d105943692cb2c898d6e54780c500ec"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "96d59d497fb8bcce8fd0db84f2ceb706727d488c35a7b1fb28a9917f7a2bc998"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms---init--.py-4741dcd4e971b997",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c2fde3e1c6792595e4545d6a1a259e7ce3dc67e9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "64438ca0c62c18fcace0a2c4f5e8a42a9a012bc1b16831f7dc60753c07b5c599"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/__pycache__/__init__.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-5eb23c8ae310de7f",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e4f831b80cc8c40182eca390e5aac75a8eb36c16"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "93fb8f931c34406dc9b7e18c4155a49c035086386055cd25704d84f28438fed6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api---init--.py-c14f85accff35a7f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "34f56dbf806552e52aceac1681b56d2af7668ef5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3057f1ac7789427888dbb91d17329a0e14f6448eceab6c2651fdeeb4be22061a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/__pycache__/__init__.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-889fe823bbf2cfbd",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c18b7c71fa28f67290a563b29ebf3e3ad83c0efb"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b4bfefc87c6f65419a3662f9888c104cad5e58c194f65d7513e3c5e1c00c6794"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/__pycache__/apps.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...api---pycache---apps.cpython-313.pyc-46bae4bb73979856",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5fc84a13d7eabc0389443d31bd77e3c0c51c7ff5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4cc18b1e35052c7bd6ded61fa39417f265844aae99a48705bf0ae33d846f9512"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/apps.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-apps.py-417dc6d8c2157366",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "db8108850f3b06d7b9b86f0e65ccd7493b67fa65"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "fa26231c6a89c5ec97f723fb442eb94e140f94b084403303597d2593cecbb6f2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/exception_handler.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-exception-handler.py-94f99bf4c9c3bc15",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a7f93cadc1d37f3438bc73ea85abe3feb829290f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2463cbadd3c8ff896a9d11c31b5116525ac5e6def5fa2866f773f1b5ece24ea0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/permissions.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-permissions.py-48a6ae643918303f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "61d61db8730cc45fa97685b4dcf6af848f0edddd"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "44883b044676ece316254f12ecce93a9026673cc647200c201d6e91b6dc4d84c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/templates/swagger_ui.html",
+   "SPDXID": "SPDXRef-File-...api-templates-swagger-ui.html-d27b60011c9c53b5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "462e22c3674b21d024c9711902d7ec4f0009376e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "baf2ecd1ecb73b1aaf613b07d47065b8bae7f1e86bc4d8866562577731b2c0f6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-urls.py-8ceb24e3eef93db3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4dd40d2fa964fe3204b8d07b16df61e2b6337298"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "999d658cc031a92e62a374517343e62b3e30d6bf6d5a47fd57527f7b4d515259"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/utils.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-utils.py-63f5e9448686385a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b70d6102cc7071d87ac3da16a0e3e8dec995065e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f9d8aa11a0316b85b86cb707b0dbab30f151da72b120f384ab9a044eb11680e0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v1---init--.py-7cb799de1df5382f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e8fd239b1ac9c36ee5b58876a2d052b48ec7cd7c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "34ea9593abeb101a1152ac29e40f40335d6b81ce14f181ba0e568268c7577d16"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/__init__.py",
+   "SPDXID": "SPDXRef-File-...api-v1-serializers---init--.py-b2c34769a09156b3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ce841fe0f01a1602bf5d045b38eb2d504b62fad9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "da339ecc2e9f6582d730990a9041cf3fe56908567dab9af6eccfff5fbb25b3b4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/alternative_word_serializer.py",
+   "SPDXID": "SPDXRef-File-...alternative-word-serializer.py-1cc8f3999aa95a08",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "55bfc7e5aa0befee90090f37310903b39e875997"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "165e5bd925a4bb099041205a0ce646225c13c45ae0d63570b787ae749e09d457"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/discipline_serializer.py",
+   "SPDXID": "SPDXRef-File-...serializers-discipline-serializer.py-7131f20a3eadfa1a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7cb6097eacb275eb4d0edbd1b667be0d4fd352ad"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "527edac762938e45b676df1f1f00d2b51bc03744e9006a0bdce94dfc3a0b4b80"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/document_image_list_serializer.py",
+   "SPDXID": "SPDXRef-File-...document-image-list-serializer.py-ca5b1afd04be85ea",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c86236fc7838f827c7a61ff1ee991382300b94a2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "04f1d7375e9d46426e973633658a06f3fe36099b0e67fb4a761611efb0bea827"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/document_image_serializer.py",
+   "SPDXID": "SPDXRef-File-...document-image-serializer.py-3f7fd50004a3d913",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "54c427d1803e5c096d0d24b90110b5026b9ebe4e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2217ffd2129a3edd57cfe7e40a26b2a7239413dc24e93f60278dbc605aa4e3ff"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/document_serializer.py",
+   "SPDXID": "SPDXRef-File-...v1-serializers-document-serializer.py-f4f022b549326e91",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "064fba01ce5f11df002df1f7e9a849ccf30235dc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "599d07499547b4f14bafb9e2a74d5cf8216ce65f77b48ce7f0fa567e4a8269c4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/fallback_icon_serializer.py",
+   "SPDXID": "SPDXRef-File-...fallback-icon-serializer.py-7dda7a2e652ef552",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ded25ae8f59c1f43b6fa7bcd10f54b1515d86328"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8d5339f8d56eb8bc3cec89a053338a7ff4d1938218c2a6d6fec096f413669e5b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/feedback_serializer.py",
+   "SPDXID": "SPDXRef-File-...v1-serializers-feedback-serializer.py-da5bd5b5e4c59314",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c0fccb68b4ff2b9cac31cbbfd7ab97935d8e290d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "86a95aa3e0a4458f99ce211e82d6dc8f3e4532dbd0b565e08f30d9793ab83aca"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/group_serializer.py",
+   "SPDXID": "SPDXRef-File-...api-v1-serializers-group-serializer.py-8143901ea2deaa0d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bc4ea3a7058a536b7956cdfaecdc330d350e0894"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "dca8c6b24e9759148a8da7963355d88793db351e4bb6dab09a51805c93c4aef6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/sponsor_serializer.py",
+   "SPDXID": "SPDXRef-File-...v1-serializers-sponsor-serializer.py-ebdc2ae6f70804f7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "535f09ad17ae36adb625f0bce4232299d2d3381d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d415b2022dd2d3e8a8d559505a4fa1c0be94ca6bff9a94ab016443a9e812dcf4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/serializers/training_set_serializer.py",
+   "SPDXID": "SPDXRef-File-...serializers-training-set-serializer.py-6487def6869989cd",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "30842404fc18f670d94173b7394eb97144302475"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b87adfcde87fc599cc60c4f650697a56a66beb209565d65080f4d687f87f20be"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v1-urls.py-9e2d323ec386c7ca",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e2ddadd56d68c086b4d6237de486598cac2bfe19"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "35a52f60ff6f394f31787f0754c29815c2a6d33e9b038e8665ddfac2dddb7657"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v1-views---init--.py-4a55066f7fb319d9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0c59009cfa2ff042b0a842e468b77697afee9558"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5a3badfede7093f0d9c36e5d97ca741bee4960b7138847fd47facecca1c50aa8"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/discipline_filtered_viewset.py",
+   "SPDXID": "SPDXRef-File-...views-discipline-filtered-viewset.py-949719fac81cd0c3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2b4756a25405e4ba100dc179c2c72bc57ab9a8ae"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2f10958f3e8005d900f74d9e8cc54c7fd98371d788888e479f8fcc3b3cc4bc30"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/discipline_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-discipline-viewset.py-e531b0ca923b18b7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f29b7be982663d2da21908b2b927325d083db520"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "97424fa210957b0f59e6fc4ee7311bff4ca77e454c84f08cbb9d0d09e8d950b9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/document_by_id_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-document-by-id-viewset.py-2dfaa5648bf786a1",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "04345e7d6b6ca4c5dae449974b7262fcaae5cb3f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "493028f9756c49069738fa249d33a1040e1aa0d27c074bc1cbe9d8861b61ba83"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/document_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-document-viewset.py-02e82163d5526286",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a26dd736957ec681b05417a00e778e2b5d86673e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9cf6233a35be823c60a7c7a90491d453412fdebff0e53f250c45c081b822bc2d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/feedback_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-feedback-viewset.py-590b367c78d4eee9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "22e3bc00534c57662f9fd1d14ec195ef14334270"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "67bcaacf912585e65fb1e1af497bdf5d602eb3a26b7c48b195b3f50b85793da2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/group_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-group-viewset.py-54bab187fe42ee47",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "06d000ce57d82887dd67a299496542dc199e9d16"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6bb5ec252a7b7d26dd3c05e0a6e5f3064f7306ad6a931b4b641da43b859c1e2f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/sponsors_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-sponsors-viewset.py-f4e35d2d219532f6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3c676962c8f9af607535db632b38e2bad39d7ae1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a906cb3a68ad538f7cacfd4c701a7ef99dc8333c88a737f0819cc7edc1cf6bf3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/training_set_by_id_viewset.py",
+   "SPDXID": "SPDXRef-File-...v1-views-training-set-by-id-viewset.py-217fe952163c6af8",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bb8653ee5b477eef375feeb758d213ddb4b6b03c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "bf4f4aff5ea45f8ba53a1218e78777b7ed345e5fe1e84da15c959a736d643e70"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/training_set_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v1-views-training-set-viewset.py-36ce3a51ebdfb5a3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "64eca26f318218debbffcd8b2457b7248fff9c8b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a5ecac806b997f653c84f73ce8611299da1ee5590c63ffb0568400d9ba180e02"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v1/views/word_viewset.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v1-views-word-viewset.py-4330a15d1506369a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a0822a82640bf316b12f0521e79acd1d4203d0f9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0574001727d7749492f202c2f8d9204791918194e38c3ef0eaca348f919d67a7"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v2---init--.py-869a4a3ddfc42fde",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "37cfe371bbc894943c178e3492edacb4d136cecb"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ca244d780ced3090ab745e8858c7ff8d882e96720566999322f34ced3642c109"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/serializers/__init__.py",
+   "SPDXID": "SPDXRef-File-...api-v2-serializers---init--.py-ef377bd8a2365ba4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c9d58cfdeec26dba7c683e728e6ef2e0753a4775"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "26a981629ed8f79bbfc01129e7b4bcd1bc0c47d5785eab888a5eaff8c49f108b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/serializers/job_serializer.py",
+   "SPDXID": "SPDXRef-File-...api-v2-serializers-job-serializer.py-ff3c6931251eb7f7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "691421b3cbc8cf7ce4907d3a8fd0532140bbca8c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e9b7677e97a8c2f3f864bb9a92f8ee560e668e7d40970bf7dcf624bd78a11095"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/serializers/unit_serializer.py",
+   "SPDXID": "SPDXRef-File-...api-v2-serializers-unit-serializer.py-bf399f3bbbd5ca9f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "fae15cfe59513a816155ef80359fd92bd2a1c320"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "db7977f22c8bdc962114084d5aefa5d6c358815614dc9222e9d7879089f89ce2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/serializers/unit_word_relation_serializer.py",
+   "SPDXID": "SPDXRef-File-...unit-word-relation-serializer.py-37e54445ad4ebd04",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "42e31cd8039285952e7dc8513e464f5e09c49f6c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0aa8d86c2d406bd267ea6ecf988de5130dc158452a477ec9fd91d8d9969b268c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/serializers/word_serializer.py",
+   "SPDXID": "SPDXRef-File-...api-v2-serializers-word-serializer.py-b037199aba4e2d15",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9ca0431bf77732c56c3e771a720b78d8b44648eb"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a2604007eb8dee895ea1deec3466bc8d0308b8b94ee5946791e6ced9cb3717b0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v2-urls.py-acaed70d5c76ffd0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b44aec4c3578f593751e6fb15cc4393f7123ce79"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f587fe0f9b2f02fa6f4445f4fbaa3656b2be10fef2112a5a803bf8d2781721cb"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/views/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v2-views---init--.py-10aecb93ce7d12e4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "26eae3c4b9823c92e313c3fc2d89db5c5d84ed93"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f269a90bb1826a7c53817b3a1e4d276e3e60f168f69ba14a00618b1a4eb7a3b9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/views/job_units_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v2-views-job-units-viewset.py-f5dab3ebf821a97e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "eea68af2672f1311eb660e371527ccf49f4aa4c0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f99c409c66b422a21924c3ef0edb56a1bd0f4a7f33b04c2577c206be516b452a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/views/job_viewset.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v2-views-job-viewset.py-28bce07ed1d49e9d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5ef8f409e86929afa79c4d1be51475bce145c167"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f0c7b9649811bec4156371cd4e3c9b3c375440c98e701fef07c0e4c24cca95a4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/views/unit_words_viewset.py",
+   "SPDXID": "SPDXRef-File-...api-v2-views-unit-words-viewset.py-6ec942c245be16d9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e3edf9c829725cb99f0a672def7b6a950adc21e7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5e199f431d045f5e1b4918d974a3f230fb8d5e6c2d5fac247dfb6e8617ed84fc"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/api/v2/views/word_viewset.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-api-v2-views-word-viewset.py-19f69feae7c61fe3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "836e0665e3b282ceb5d9bd00e8b07fd80ef3143e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3965d5fc0fcf4a306a222382e6b373d16f2f654012e83109e04ae369b19e3b6d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms---init--.py-5f6252aca2035fb0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c6be217840f35f62ea6a85990554a1d217f1c13c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6d3868bebb722599642bc2eb2a484a91877a12d297d29fcc1070bf558655c847"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/__pycache__/__init__.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-75a68313392aa7d8",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4f48664ed502bfa3377c3813e9da2d3221a09308"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "da1c1e32e6dc544d2594b31cf871103865e5fb6ea0d8583cfc1eddefcfc87a12"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/__pycache__/apps.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...cms---pycache---apps.cpython-313.pyc-108a00fa2a74b234",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "86d93a763565a2133524c75265ffd7f0c021f1e8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "45bec0bc0b33b125311f69bdb54555ae960ecdbf9bf135e42c0f7e98ea142e73"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-admin.py-101415a4dc328e81",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9eda240d7ff3dd1c8e7fd0d998fac9ace81d8e8f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7d032affd51a9e20ee3d40e423b779401c8c6bd97fb0f8ec5772487e7fd76a01"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-admins---init--.py-46f7a343107c2d27",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ac2410f26bd559ece7bac78bc531c422deb038e3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "cd60d4c667c7ef11991b4917a5f20e23fbdae21fcd90ceb72536d9ec9a50025d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/alternative_word_admin.py",
+   "SPDXID": "SPDXRef-File-...cms-admins-alternative-word-admin.py-c73f85acef2c990f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c1549f1041772b1b012f128e73c9341a516b78f1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f4e5efd7a2741a60653bd9d1428f562dea094224f7c44a5586234cff025f93ce"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/discipline_admin.py",
+   "SPDXID": "SPDXRef-File-...cms-admins-discipline-admin.py-0e607e7fbd574cfe",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1e5a3afda7de32e062d87b4d13cc1fcd6a2dee5a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2631962e08b1ce2c87dafa79d806fea67ed1321ad3cb89f172ef328b83eadf4a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/document_admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-admins-document-admin.py-6442c6ea2e8e8673",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d9dc3e6d0201278936bb28207b1eab8c9070c3de"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "edc0d227745963123eafcccea8cdd1b7046654d0f1ab9e78d7dd00bc890a22b3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/document_image_admin.py",
+   "SPDXID": "SPDXRef-File-...cms-admins-document-image-admin.py-5e7fb7d49d08df43",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "486a2286202881257c0e2a813e9da9187574d103"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "74a38dea922555fb971bb3e674cd32a11cb8790b687b73befd3b86638eb2df8a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/document_resource.py",
+   "SPDXID": "SPDXRef-File-...cms-admins-document-resource.py-6aed99f133cb2d6c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0a43c26582e83d5f564deaf8b8b142d7e142be89"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "00bb2efd55dd83b29b6048c05a884dd7a1014ae3d1c584bee811f92a62e54a32"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/feedback_admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-admins-feedback-admin.py-7110642436af5973",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e320ca2909d9f45e1db299b6530570788e067ed0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "99be82aa265cf4f4eb0e143e192a2d68395230ee97c714acdbdf7d49d188ccd1"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/group_api_key_admin.py",
+   "SPDXID": "SPDXRef-File-...cms-admins-group-api-key-admin.py-9408a35f62ea7797",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3c31c8437891c284d0656c7e668092f763c3f31c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6a863c2fe4667bfe1bc0e5de59497d353c35cf59f77805974d4bae93e535672f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/sponsor_admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-admins-sponsor-admin.py-6037cddffc43490f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1f9d7ee07e0628b6876212deeda3745c7da108b5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c6c0fd4971b10562c132464b1e398ca4dfe78790bc61c8b9412b94c4dfde9ea3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/admins/training_set_admin.py",
+   "SPDXID": "SPDXRef-File-...cms-admins-training-set-admin.py-88b5ae55a41fb398",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1bd5491b6fb488a3b8ad4f4cfcee2567e08385dc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2e24b01fb67477d825ddb2851e5b8a10b26f980ea1784d3a6ad24d964d7ec889"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/apps.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-apps.py-a30f6ea27ffbfa9a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "437a7e70d65e3a0935dc039159f0f2b0fa94bd88"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c2eb92c4788c7f61de107c2e62789eedd0c31440f02455e950f00c8e9ebe311a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/feedback_filter.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-feedback-filter.py-a17beea54507c344",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5492d18cb705f3cd8f23139c44e40af07ab85b1a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5df37e2366f8b8c060c4fe2cd40cd4d116bf47808ed35ce7ced28fd870154b07"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/forms.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-forms.py-82f1b20696b06c7c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a645d83e0847e8da4a5d64dda8a7b55c8e6084ff"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c6fff5a7d0ae38cf67dbebdce46069c78bd652d177a2879ac9183d9f201c24dd"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/list_filter.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-list-filter.py-862a1ee4a8a6e257",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "142ae546ada1f2dfb2375221692054fcf78be330"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4118011407f9d47e678acd41024a36392995fd56e21715109d392416b9d6e754"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0001_initial.py",
+   "SPDXID": "SPDXRef-File-...cms-migrations-0001-initial.py-d43a2348df7f446a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e7e0e3ded43311e64ecffcafbcf559e53ee6f119"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "323f74a7b1b825717c8deebe52b931c455e79bf5bf02d854bdbf2211856c3469"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0002_modify_group_model.py",
+   "SPDXID": "SPDXRef-File-...migrations-0002-modify-group-model.py-0db56c83b42941db",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c3e7d3b4466092b34e69d3d6320a2df36ad8ab82"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c7fcd6b78569b6175cad3c1d462c267c8bbcf46e239f5d2c576d9481bd705e0c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0003_remove_documentimage_name.py",
+   "SPDXID": "SPDXRef-File-...0003-remove-documentimage-name.py-22a1730d3a5e62cc",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "94123b7d64050906e069ddf936b52bf1aa8e803e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b4ed2db958354e6873ef10b6b0e4e496cf6d06772f28d0ad552e737272b33d68"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0004_feedback.py",
+   "SPDXID": "SPDXRef-File-...cms-migrations-0004-feedback.py-3a69969cf1e46dd2",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7fd9b41e2af2a99a122f13a785f5a53cd768ac71"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c59ad75928a91bff6707c0d73dd4e5b6683afb3b2f97b567b94a9df81129e775"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0005_auto_create_id.py",
+   "SPDXID": "SPDXRef-File-...cms-migrations-0005-auto-create-id.py-e4718401fa196708",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "783f909655ba787dc617c9f1beb3413674bea288"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1a5b57cd86cc1d14d2d8225d9988abd804ae6c843b2959b9b78ab9f2659270d4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0006_convert_group_api_key.py",
+   "SPDXID": "SPDXRef-File-...0006-convert-group-api-key.py-65d746060d6aba74",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ebc94e9d726b2c0b37e93dd0ebdb9b48fd9616a3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7187322119f59f1be5408909efdef564b6eb379fb7af6d1439ca1d9099980082"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0007_document_created_by_link.py",
+   "SPDXID": "SPDXRef-File-...0007-document-created-by-link.py-dd4c4a7bfa011eab",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d825e73d661e1c94097e2f06c65114b043712b02"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "be0d6ac7723f427d8d843cab240c75ae315c04be65dbb56a5b53d4b60a1f2b0c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0008_add_numerals_adverbs_and_pronouns_as_word_types.py",
+   "SPDXID": "SPDXRef-File-...0008-add-numerals-adverbs-and-pronouns-as-word-types.py-8f1fdf0b1a38e4fd",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9b7e20f91dd721a1c3a597048ca61991572a69e3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "32cabcd64257c0bedd803b62bf95ad3c7cc04449f6f865b9228fb4c109c83cac"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0009_sponsor.py",
+   "SPDXID": "SPDXRef-File-...cms-migrations-0009-sponsor.py-b561a1ae9cc37764",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "be6ea2ecb53120c1a6473604e427db20031b803b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "501274454448b25d5078f674178c9479012d5903a3340804e50b54403365dbff"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0010_sponsor_url.py",
+   "SPDXID": "SPDXRef-File-...cms-migrations-0010-sponsor-url.py-56c3f2aa689a85b8",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8f9177cde8c6d8cdcc43725e23ba6006ad739de8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "535284795b38eedea6b8e8bce9aa3970db260d63162f6b9b699a61c80b21a726"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0011_document_example_sentence.py",
+   "SPDXID": "SPDXRef-File-...0011-document-example-sentence.py-83ca30e4e0d841d6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "336f71b6fab8e8de6bbce44d13cfc3eba69b1c62"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4c34161fe341444a7163df2d96e29431158e31fbdb7aa93ef1c54e9b5265b831"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0012_add_additional_field.py",
+   "SPDXID": "SPDXRef-File-...0012-add-additional-field.py-24fc5a4be501b7de",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "18edc7c97f3268d36c188d1e4a7d650f7618bcb6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "68d13d15cbf204e3897ccca2d69b8873274e5aec6a36caa85699a03cc70d60fd"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0013_add_plural_field.py",
+   "SPDXID": "SPDXRef-File-...migrations-0013-add-plural-field.py-ad3a2e7efad564b6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2c0e9bad5fd21dd3e296bed86472ed4951185548"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "170345737229985412e988f6d30272cb6ffc47f558297e07c0ae3e5bd0aa375f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0014_add_plural_field_and_plural_article.py",
+   "SPDXID": "SPDXRef-File-...0014-add-plural-field-and-plural-article.py-165f39629be1f7b4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "828bf813d4d9467a14279f03f7757de4e5ba7ff3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ce52574a05a6951c4d20b447849343be8bc8580abe2a15e4250f3a72358142c9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/0015_add_grammatical_gender_fields.py",
+   "SPDXID": "SPDXRef-File-...0015-add-grammatical-gender-fields.py-e7140b4b0dab779f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "cadc26ab9aefe4cdba52efd94465bf1f1f3033cd"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6c70bf37755a3a38b59c4cb05a0b7da174db24f2e20a6beeb821a3eea177c23f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/migrations/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-migrations---init--.py-ae1ff7943539c067",
+   "fileTypes": [
+    "OTHER"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models---init--.py-a98f92edd05e3c5d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8f696dc85f08538f6c8b30f39f0ba6a07f009f99"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a748a85a46f0e93632110fee93319e8c347c3d7108a6cbf5c272532d451489f6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/alternative_word.py",
+   "SPDXID": "SPDXRef-File-...cms-models-alternative-word.py-08e7eaf7cb925870",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "eed5f16626cf1d0cb05cbd33cd88ded9fae2315a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "cc4ee7f0eaaa771cb4d2aa69ac1547cd94a83b6c68fb51c7b5392a72aba361b0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/content_type.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-content-type.py-487cf638ed32a84f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "371508f8b647e1069510a0793ac7d166a4e0acb7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0943b52d86fa73bb5af52d0d9b12ed7a78f7332bd1b59fa266d206145f8ecb2c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/discipline.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-discipline.py-5992d6c393ad06ce",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "888cce6b34ef13d071d99841506472c4360c9236"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "61c2a967fe13a4a65b944277df6909d695fe117337027dbbb4cc8d9c4633fc65"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/document.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-document.py-0f1a3ea70ef4537d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2542f5130813e2d82c0876239ad0b7fb7413c551"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1f5adae55637a161b15727bc03863ecc086596d581b853a5f585075a56113c27"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/document_image.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-document-image.py-c0e26273db9e9051",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1e11d5bd8b33ae9438a71c7c76c2f798faaaee5a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ecb8a22b13a167c3ae2f2bbf99b8dcd10c75bc70ec0f920973f7d03be84159de"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/feedback.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-feedback.py-daec96dd0a253a40",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0fe8db6e9af4dbccf15c2267efd6419597808ad5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0f3f1fb0f0b3936aa0d9b5f878b0ea5a8dc5603d3bafd3af1f6e52ecdbe7dcf0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/group.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-group.py-2ccbe4e393116324",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "21e9df592facf96e04cc61b3ffe992c804e28d03"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2636602fc2714455a5cf20d7a67dfa44721fb5f0d269fb72ca964ae665f4fd3b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/group_api_key.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-group-api-key.py-5596947447d97815",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4ab115c22513bf1b45aaf172480eb2294b951642"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f57d5a79172b257d58af4c8f4d1421e70a0bc9131309fc2d65d69343758a16bf"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/sponsor.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-sponsor.py-95cbe5c25b2e55d0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a9597208416699225826347a6b164d7cd2b18ab6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0b5a63547dd2f4a76102975af1b07c7402ff2ebef7596a1b420f9c6440bec8d3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/static.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-static.py-92a83638cc9c6fb4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b0faed4c9435119c2a12211555415fdf0a65bbd2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3e32ef596b4e35047bbfa7dabe63c7ffe9512d2c4b4626a6187dd5b530374f56"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/models/training_set.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-models-training-set.py-63ba6fa0f764a0c0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3fa95fb96987f897486b67c39cb10935eac8c45c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6d9e2134ae43644f1dcb9f65a5a6384025b4aff993f453f1fb26d198521a8ebc"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templates/admin/base.html",
+   "SPDXID": "SPDXRef-File-...cms-templates-admin-base.html-531e907678b80dd5",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0f6b54f14888d5a598e5586a0dbe4f130a4945fd"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "69db370f7ec9edf0595b6c4c314641102917a75567af03b7e7bb734305644865"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templates/admin/delete_confirmation.html",
+   "SPDXID": "SPDXRef-File-...admin-delete-confirmation.html-32fe7a7fa111fea6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "860e4b40f081f6836c490158687898f5ed83c02f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6e5e0925ce5943e617ac073c84fddcb9508f6ff48fbc4580bfad93a2c6dd263e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templates/admin/delete_selected_confirmation.html",
+   "SPDXID": "SPDXRef-File-...delete-selected-confirmation.html-7e0186f7d3ed92fd",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4a88d15d56d9fb6b690116e8e308bbe4ffd5f34b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "76f68d62479b8e61eff3048263b20e7e62d065c6d36be43e57a9b7924bf8b5b5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templates/admin/discipline_filter.html",
+   "SPDXID": "SPDXRef-File-...templates-admin-discipline-filter.html-fac9fd3606c5c487",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "948ed6562fb5be33ad887cfa35b81f2bdd5fcac7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "880de88eb3a3d3e75319a8109942529ca90ad0c91b954dac7f2ffc38dff1ae3a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templates/admin/object_delete_summary.html",
+   "SPDXID": "SPDXRef-File-...admin-object-delete-summary.html-3b099481a396fe5e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2a89f7b266501cfc55098cc0fd3a03f4383933f1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "756243d28ccf4883c4b32e992248376235d99da47213c41a925ea6d34dac812d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templatetags/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-templatetags---init--.py-8b24b3b62ed85f1a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6d2587bbcfa89976dc637cbc33086dbe987d4587"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "cee9822a79c86c58aa8877dd494980c7caa1d1f13a6e8de3b3bef56377fa3c24"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/templatetags/admin_filter_tags.py",
+   "SPDXID": "SPDXRef-File-...cms-templatetags-admin-filter-tags.py-a02eef458ea37a82",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e0731d08ae3939ff94a155bcec80e79371004a88"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c17e7cf22b8f119014f9e74ada5c2282473ea6450c84c8c93e4186abd1b8c1b3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-urls.py-a91da67ad694984a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5383a47439fa73e9daa87953455dd8d82e25ce27"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "026037babda736a3490bee12fff85ecfa09cee32304247f5960c96f28de2c80b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/utils.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-utils.py-0cab86024d169367",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d452d70232257114f6be3d13d54250fc3aa67a16"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8eba5b86a2db826d04665e7d3a1bcbf4557d63a40c9b5101ab3504be9f8d3150"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/validators.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-validators.py-05e6ec31f835944f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "5177f0f3a9c9df62a455077c017084be2b9d370c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4f8dbc49cef33752a85e0911961138029c58c189290a2c767c227a811d2e3d30"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cms/widgets.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cms-widgets.py-017336f979fb0237",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "27dbfe8290caf32dc4aee89400664d1110bc006c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "00d7ccdb78d02b9b1489a85485c8196b0680b3359acb71a473425a5d09536d6c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2---init--.py-4a7b864f63173605",
+   "fileTypes": [
+    "OTHER"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/__pycache__/__init__.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-1d91800d7f45278d",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "995c3cddca15da85a2fe69a8a2bb19e81b978161"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e3cb456555da7adf77b37a6a23205ec4d8924615404b1c5135b54de7dcd3930d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/__pycache__/apps.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...cmsv2---pycache---apps.cpython-313.pyc-95f4bdc19e3543c8",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8a5a668c815272f0a59bb42803afd5f491656bd2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "de48e0edd76b12e207d27b7ee6cdb0a3be649ffedb9a848e8f3d70068333ab31"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/__pycache__/utils.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache---utils.cpython-313.pyc-ba8a1991379b32ab",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a91641ca18b6676cfc6736ac21e1c9226bb774c0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "784275be2da5d7f08d51ee3ee26d61f2aa34de42d0fada57c836c68f0823726d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-admin.py-4a7fc304a39685d0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6fa3076ff0e162a55aeccc812db94c70efc9e2fd"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4f6fc54c659a6b80f9dd1e4c2007c09ddf10112bcf9f61c05854372ae959aa7b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/admins/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-admins---init--.py-86b68b38cd67f874",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ea711e8c7fd01b97e9fb9c15f6aa7958cc220d81"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "216cf52d44cadb4ca0f94877c2559119dba793d8063ad9a51130b0aa0d2562f0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/admins/base.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-admins-base.py-2bfc1c2cc6c2e6a0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "9b64a94ceaf35db14d9fb3a50b943df574e27d44"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c4b308fe8d2626c367e35aa61395ac1651ea6e65c8474738da9910354937dad5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/admins/job_admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-admins-job-admin.py-5e7edfb2fe973181",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "fa95e2d9757972c13a9fcf29149e780511ccea20"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ffa8be800aefbdb8c632aad1ecb90e61d6cd49935e394776a82c22129cc00e53"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/admins/unit_admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-admins-unit-admin.py-96d8c352009cb1ca",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "203b21fc5c065dbc84c7745c57d7ef2d447ca84d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d93c2a9dc1fe388dda8253eb76bdcc88629fc2f7cc27d988b668429e1c3dfc9d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/admins/word_admin.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-admins-word-admin.py-b3b7b7b76b23863d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b95c443a585ea835c95cbc6baa6ad50c230f87a0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "77393193e9639943ded784023c31d035a18b630c11899534d57a51760bed8492"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/apps.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-apps.py-2f4d5ad718399cb9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "adaa1e7dd5b30dc6908883f05b880d4d5499ddb7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1db2d7866124efe9ff327fe683eb4124b0e84fbd430fc04834d5d79dbe7f202e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0001_initial.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-migrations-0001-initial.py-3893a6dacfb17d63",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b1db6024429fafa8a6398a6ba330ad2b6eb4d6c5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "cfbb4f45753f1499dbea310998b7ed0fd832e94e42fd78b3210d68e1723587ac"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0002_alter_job_options_alter_unit_options_and_more.py",
+   "SPDXID": "SPDXRef-File-...0002-alter-job-options-alter-unit-options-and-more.py-548bf2138703d4ff",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3275f7d549a5ef75251bbb4037da4afca369d86a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4b199b20f2d606d23dcb120720bca2d774a6a01af1e5f4d9d1db38a3ce1e4481"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0003_alter_job_created_by_alter_unit_created_by_and_more.py",
+   "SPDXID": "SPDXRef-File-...0003-alter-job-created-by-alter-unit-created-by-and-more.py-6596d7a7c766cbf9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4633d0287845099093a73606db546cf3a8ee7309"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0ed7f7ed1c7c80f0bff2b5ca5058ec2a8b3ad525133fad83aefe7e410321ceff"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0004_rename_title_job_name.py",
+   "SPDXID": "SPDXRef-File-...0004-rename-title-job-name.py-d05544c2fc9cb60c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "008d805a3c7914dd40ffe37a3ebde43056512280"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "91974e02fa7b83ec356bc2d7c3ff319c8ebc3b7c1a3cff1321cf3467bff1d704"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0005_alter_job_icon_alter_unit_icon_alter_word_audio.py",
+   "SPDXID": "SPDXRef-File-...0005-alter-job-icon-alter-unit-icon-alter-word-audio.py-6ac45bfcafdd4a37",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "44f908ea58725b69967b1dd2bd5951a645167730"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "206a3d90c0af6349402b66bd97f4d4cfbe843a1555b934088c5dcadde0334348"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0006_word_image.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-migrations-0006-word-image.py-e9d16c1bd780f506",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2e164d3468478ce8735b29150079c767c2934a9d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "14e891ba523122c568a70214f583ebdf08d222d705eb4d8b92febfaa3316a6fb"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0007_remove_unit_words.py",
+   "SPDXID": "SPDXRef-File-...migrations-0007-remove-unit-words.py-88fadad8c7c7f652",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "da5df807355659df6f84edda3411846a240c881f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "63fa05b128512a956df421dfcb41717b79c0f15a5ca9e5fe8c1621f3bfe0f960"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0008_unitwordrelation_unit_words.py",
+   "SPDXID": "SPDXRef-File-...0008-unitwordrelation-unit-words.py-4401f367430a1686",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3a49c76fe75eaaad8d8c88d517d882d57ad0a15e"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a628a39ded02c03f666b0b6b77da07456325247978ee7581fd9e8d94249ab189"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0009_word_audio_check_status_and_more.py",
+   "SPDXID": "SPDXRef-File-...0009-word-audio-check-status-and-more.py-71fef902f8ee0f37",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c427ede692eea74d5781c698100de6f37be71fa5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5b6fb94b31fa7084b620b8e0d21a573942906c0cca8dcc93b8225b1e0d41840d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0010_alter_word_audio_check_status.py",
+   "SPDXID": "SPDXRef-File-...0010-alter-word-audio-check-status.py-af2d4f37b765ad81",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f10457bd37514979e789f779605281a20a1afb29"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f863ab9b9f2e63acda8bda75c7cbc2c892e2101742cdd126a701b398a7549c63"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0011_unitwordrelation_image_check_status_and_more.py",
+   "SPDXID": "SPDXRef-File-...0011-unitwordrelation-image-check-status-and-more.py-58e5402f4fb80e1b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1827f8d3e9048fe720ce0edff913a71709eaa948"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b0ffa1442e19e892ae227596c42a89ce0f82c5542d6addfdad512f72f709b46e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0012_alter_unitwordrelation_image_check_status_and_more.py",
+   "SPDXID": "SPDXRef-File-...0012-alter-unitwordrelation-image-check-status-and-more.py-8aba7f7b98acfa8b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "39f0a08c3f9f313fb088dbe934c3977e70b75400"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ce62e99de5679f4878636a10bba13fe83deb1dbc20fa67d9bd0a4a59b8791b93"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/0013_job_v1_id_unit_v1_id_word_v1_id.py",
+   "SPDXID": "SPDXRef-File-...0013-job-v1-id-unit-v1-id-word-v1-id.py-9b7b959e88171265",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "349e39027e583f4e413e37977732671878bd6b2f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "33dd8522b1c2fb44ea851131acccb15990746757fa79c6f3503b90ba0ca5e9f2"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/migrations/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-migrations---init--.py-07f555c53567203a",
+   "fileTypes": [
+    "OTHER"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0000000000000000000000000000000000000000"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/models/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-models---init--.py-950bf4e1f71a2409",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "690f34d1949473494e200bbe2b6be7675f587801"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d065a607da99c9119d9147c651216a830cb62890e98e1deb6f767cce54d5a1ba"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/models/job.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-models-job.py-6949acb8f0b2954a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e60f11e0c32dee249ce5c164ad472a6ae23da2d9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7ea70d3cc3494478fc7c4301271c9c063e704870c72afe7bcf829257b9bfe8a0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/models/static.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-models-static.py-3aad0846edfb21f1",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6db9e2ca877c84177514caaed26d78f965b40112"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2a88b938b50472ec1e5a5513caaa8ff9aff6f1a9b6b38122381729200157f0b9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/models/unit.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-models-unit.py-3de8500216a3070f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ce26539601521921c3037549c572ee4cd4dfdaa5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "707fe9d883a70eaffbc8efeb33c9d0c5ce92827e5a5ce98394d93f33ec4fc3c4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/models/word.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-models-word.py-ea7e369bafc20f02",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3f7508726d34d0d316a79a95e9576cb232794071"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ea1cceaec7e72e42d1e329d48ee83f096e6973fd8251fde961074819f9afb47b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/templates/admin/unitword_generate_image.html",
+   "SPDXID": "SPDXRef-File-...admin-unitword-generate-image.html-d9431b3d3ccf014f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "10b671805616069c84082bb946f1e275088ccd34"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "442c97bbb83d73ab6a49dcb6335062db92626ceb2023fa8d74a406a122603a94"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/templates/admin/word_generate_audio.html",
+   "SPDXID": "SPDXRef-File-...admin-word-generate-audio.html-971e7a12e3537419",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "204f8239f404d0f47e542e7535efb32bec9ad1a9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "61512ac8bc4d29dfffc6067f6b459d97bc8a76b72d35301959352b18f85a230f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/templates/admin/word_generate_image.html",
+   "SPDXID": "SPDXRef-File-...admin-word-generate-image.html-4851ff76f6b43168",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "eb1e9207e4f543206ea2134b67b6b7cc8bf6ce73"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a63021672bb9ec98beb9c58602027131b4f63dfef46d0dd27470c4576f41b7f9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-urls.py-990ba8eac5e4dca4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a156ae7bf4304f255e99087653950a7bdda2e2a4"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "57d509074d2cb605f55452a1e8f717625823e7737133233875edaf5e5b8a4da9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/utils.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-utils.py-59f7f630769013b7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "95074e212359a5c5c349ec07b32eaf9345e20cd1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "687ce66f11836b0ebb702f1b1170953baeed0df0d59f193200ccc1c06672a63b"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/validators.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-validators.py-bbce3c51d468b841",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2e6bea0166d051ade6bd299c8e92174693a27484"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ac0e5c2cf08991a5ce1382d02d893c6c567bd6f413b75f32314ad0f0fbdddbbd"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-cmsv2-views---init--.py-d9a79b9c42b74e73",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ac79edd114520b37a9f5b4795b4b3bfb1f3e312b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "6ce2e053d565cb7a51c61dc94e11ed6cc80c32f8290c492a93035a501f5bf194"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/generate_image.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-generate-image.py-14c7615aea0df4fd",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "c2a876edc6846b04ccb376c88b1fcdff15d6e9b7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0bba2c540c8f950fc432ca62ccd304e6009d8e1c054f63e47aa9397e135723f5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/unitword_generate_image.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-unitword-generate-image.py-13beb870a63a251f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "45a2e7cd50b7a196fddbef8a0ff03460bdd431e5"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5eede0ffb5919c5cb5f36a211182b0f9f79f50b19df0d1507aff9d344490e745"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_job_icon.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-update-job-icon.py-d0edfad43680ab89",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0d82dcfd2659b992a8b46e47ab7ea1e3c1f8b6fb"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9b64a9d4760dfc99c5bc2a30aa08cd2950f5556e574cd2eec6bb162cc05704e9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_unit_icon.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-update-unit-icon.py-ea05f19393a2f0b7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8af0a50211b80de32da24f7045662c344b17907b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3fdb7b358cbec29aa14a5089f741627705cbbcb877e7ea7eca9e9ba5c21f80a8"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_unitword_image.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-update-unitword-image.py-185b3f9afa704421",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b2a51f893bd69d22337b9f2cdf12e038959f2f00"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d7bfd59e69ce81a133bc34b19cddebaa0de2a034686d788064119b743a54180d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_unitword_image_check_status.py",
+   "SPDXID": "SPDXRef-File-...update-unitword-image-check-status.py-520d506d9c74fb67",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0ae87bd36f48c88c46c4154d920734a1af84ff7a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "db4d4a07a3bd2c6890c504cce51a33a5afad361752d8a1c0056383305d8221d7"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_word_audio.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-update-word-audio.py-62321f769d4d4a23",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ebcf6305e01d251ba1ea265aeb9903b4fe123f66"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "263a9f7f4def4d0304d24876cfdfee511119916a9f212ec9ccbfc4b946fd704e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_word_audio_check_status.py",
+   "SPDXID": "SPDXRef-File-...update-word-audio-check-status.py-f8387966793fe142",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "57f78ddb1508bfc9ab9c86a896372162bef966f0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "85807509d912f9634ca4e5aac15ec51f59c523eaf97e35803fa05a3e2ff1332e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_word_image.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-update-word-image.py-178147ed2ece6c3c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "82bd50097fdbccd78b912c610f7ae6be4cd044ea"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e357f31f00b75b376ef3de1a7b7d467fb9642faf26c0bc1c8f2ec0921cf40c02"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/update_word_image_check_status.py",
+   "SPDXID": "SPDXRef-File-...update-word-image-check-status.py-c44a57e7bacf5865",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2c9b868e61d02d41f629e9f5105850eabcf81285"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "d31080157ab5150ee948a9592fc94ba346dbc8a8225bbde3c08b932305e66f6d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/word_generate_audio.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-word-generate-audio.py-4849de54b58b48f0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e74479bd59b456c741ee873158ced2a8b72b51e6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "829388b5a3028da9a7a3cf6cc6ef411a1d8336862199a188310d49385336dc74"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/cmsv2/views/word_generate_image.py",
+   "SPDXID": "SPDXRef-File-...cmsv2-views-word-generate-image.py-dff52aa424353552",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2d14108dc537b4a7ea84ed56bfb12b4e5800ff47"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ba8664f990991849533f93d93e5c2c04038a6b6e1a7ee8a1c90d684f76fb83e5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core---init--.py-c9c91069846ac0b0",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a6798c951305c66f231a9fa954e9e77b3b36a6a2"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "24dbf2e85b7efb0c63d8b00385cbd69b0f445c2649f912221d669dfd2a8cca15"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/__pycache__/__init__.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-4960ae799a02d296",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "b81ee045b12446910e5a5b86a543cf96fe9a3c90"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "492cbe5962a6695e1903ae74a656f7abd20bbdfd5969fddc4224e74933f44ad4"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/__pycache__/logging_formatter.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...logging-formatter.cpython-313.pyc-805e63f30791116d",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "cb6b4402f915c9aa126d47ba1b11c74cdfc94aa3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0772aa82bc4974a22534a093471179d9d79d0869b3bebeaa27b4d8548675e6fc"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/__pycache__/settings.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache---settings.cpython-313.pyc-a55771f6eea0453f",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3dfb48fc9c17e4d3f71a2f597398d3159cd0ccfa"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "12462b2513b597f6dc4cf42d1dcdf5c8717f687b53754399d754ff9a3d48bfbf"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/__pycache__/utils.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...core---pycache---utils.cpython-313.pyc-bbce9c3326b927dc",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "2d96cca9119714d9855eb17c37762ae566883b72"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "676e6160f7dd5563b475acb90e3a88eadad899e78635b8ffa4b9206ec130cb38"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/context_processors.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core-context-processors.py-229a671e09512ac4",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "89191643d1a3ac3df4b26948fe7144ca545c5db0"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "706d1cfe4bea3e1f317959f5328a0722e0bdf58907921e08140de6028e4e76f0"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/logging_formatter.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core-logging-formatter.py-ad70da26953f19ba",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "aa874ef180669fe922fc3c5f9cba8e345207e5f6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8400c0599c0b38305fb1bc83ba139eec03dba718db546814f42365608a6f762d"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/settings.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core-settings.py-af56008c49ce2ff7",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "0751e2d87b2bb4f67288112af1c218c798458ed7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "c80643f6dc209957319eec26ca5e9235a9d0f5b3a2a5d3912764a4a20bfa45da"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core-urls.py-6c562945feb54363",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d1278054a28cd5fec7ca0a6fbd699cebf4ab62ab"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "24b7a6aef8414ba53dc04cb2d4b75126516d2888018035e1eba9d6b8e6e03c93"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/utils.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core-utils.py-18b7c0bebea9f791",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7460e71761eb45db7c12cb8602a0bc2a1cf88daf"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "31fef3a68ccf806da001e28f5e42f1b5f90f9f45299640db57eea5bd99bdfd48"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/core/wsgi.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-core-wsgi.py-4299e483c25efce9",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3955a794d914482816f4e7a702af722272983692"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "e2c45f5c71fc79f38bcd4f179b315756b0d30b98fada1ec3476c1822bc230b13"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/db.sqlite3",
+   "SPDXID": "SPDXRef-File-lunes-cms-db.sqlite3-12d41603074b8deb",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "acb18f5f01c76916cf5b92660ce1781adb0f7070"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1a27d3172940dc266a38d6a29a541f71fb4e8b86635a8538898332964b0b8282"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-help---init--.py-d8cfa706ccdd2df8",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "a2499b31570c22355bca9acdf006d2bd1c2957b8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4bc1dcba4f13c4b5f0fdc3e604eebe106e707c8ae324fea03223f3428c5ef7c9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/__pycache__/__init__.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-89d11985ef56aac1",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "6d50155152e0c63ea5b777eb386d5935c19a7e17"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5c7926c08ea912779ed926b12cc3d0d439ae19e8b15515eb21239e534021f250"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/__pycache__/apps.cpython-313.pyc",
+   "SPDXID": "SPDXRef-File-...help---pycache---apps.cpython-313.pyc-4708f642c91aaa8c",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "81864d5bda48a90d2cf32d55e3aa790bf973e20f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "278a54c1cb4ca044fc1732c50a8566e6cfcbd5931d63ff0d75029db3592c8e1c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/apps.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-help-apps.py-18b2cfaf37486bfd",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "eeaa0408e70173378ee209231be3e8273ce9b4a7"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "65927c4559bddfb54d8757f14f437852bc16698277034df8bd01522b2e774103"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/templates/public_upload.html",
+   "SPDXID": "SPDXRef-File-...help-templates-public-upload.html-076cbf1d4ff2d4f6",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e1ab5e29b28845e30c499eb58d3dfafaf6c64422"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b318027b8e0fa28fd7247ce7d08a5364dc8f593bf9cab91800d2db63621c3a5a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/urls.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-help-urls.py-cfc7d2284359acf2",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "eb1a4afc383ff9dfd1f35a3c6f65f2e0560bda77"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "0e9ada7c84327c311568d8c7b51a7e334c50e20114bfdf0706d253ba883c5333"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/views/__init__.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-help-views---init--.py-821322455404d5b3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "17d4f3f0bcf7a1f4643fa0ab60529bc856977d91"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "14a4ee746f0c53b6cc4b8f32e6f1c585a05c248c6ce04d94dd07f5924ff588df"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/help/views/public_upload.py",
+   "SPDXID": "SPDXRef-File-lunes-cms-help-views-public-upload.py-f80f97db6f072452",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "cfb111ab9740d603740d88d44e514d94300ed350"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7add03b8281302ff05fef37058e9f8ea9f789d71c9cff5235ffdd76ae61cb021"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/locale/de/LC_MESSAGES/django.mo",
+   "SPDXID": "SPDXRef-File-...locale-de-LC-MESSAGES-django.mo-77fee147e3bcba9e",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "160412a8793809465f22a18c258ffb0675eb6d45"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4f7f25c9539184de1ee366fd54d0d65d945d7adf43f92ab2f7cb29b93cf7459e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/locale/de/LC_MESSAGES/djangojs.mo",
+   "SPDXID": "SPDXRef-File-...locale-de-LC-MESSAGES-djangojs.mo-545b378b68748bcd",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "dbe2775d41cfe6d911d42ffce55fab981b80e7d3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "1f889310dda6e3b4ed8470f3c1cc557c7abe634a907f7327f856e29015051542"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/lunes-cms-cli",
+   "SPDXID": "SPDXRef-File-lunes-cms-lunes-cms-cli-ceab96d380b37b1e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "cfa789ca0171c340102e358c000f756fa35ef9e8"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "669257f7263e123802ff674e2556c1fec5fa7c9e1eec6a228eae3069108f011e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/bootstrap/css/bootstrap.min.css",
+   "SPDXID": "SPDXRef-File-...static-bootstrap-css-bootstrap.min.css-95d7f5a9d87a0922",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "035bc5f737b56907170a1fee69478c079746efbc"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "dde876bca02d090c75a743916348a7e4ddc1ea978fc129f38f636877290290ab"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/css/asset_manager.css",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-css-asset-manager.css-f91581b88c3c5ffe",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "310d4789c25b5e85a991e9797d4326a2675d95c1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ef4611c776336d9e4497c0f37e664beec9685699f59ce0db88ac011935921cd1"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/css/audio_player.css",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-css-audio-player.css-c1693714865de0b3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "15efc8fe31ee526cc0c438be81fe3765ce05f0c9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "3ff45093dc8889d566f03b38e610532355b8bbe41b9d2094caebaff3fd18096e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/css/corporate_identity.css",
+   "SPDXID": "SPDXRef-File-...static-css-corporate-identity.css-239ab815ee0b5140",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "875479de3b28222f54163d9daf6c31c4898ae15c"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "4c1d52bc8c6522e61d6e2a160ca7526fa08d0f1462b9ab63ea93e6f0722e7de9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/css/document_form.css",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-css-document-form.css-f6a489762867faf3",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "06ffe4f76bd98b405f60572994fa68aad2d89e73"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "79d50a6d0e2a4b8204b759df96d80ac93f91799a86047e7459ee81f8cccb56eb"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/css/feedback.css",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-css-feedback.css-9a676e0364cd9209",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3a98565d452691cb97c12dbf6e3f0f59f4205119"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "88c97d5be7b93d6b79a8acf9d1204be1c2f2b88e4d76fce64bb110023db9004f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/css/overlay.css",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-css-overlay.css-6b487e920c8c68ba",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e78fa034f7976c4fb537a5dbd40aa2f971b925a1"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b11707dd0e6270c4859d3675f2dca9f076cd4585955830f41d672f07aacf0b07"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/guidelines/fotoguide.pdf",
+   "SPDXID": "SPDXRef-File-...static-guidelines-fotoguide.pdf-f29ca44756abff0b",
+   "fileTypes": [
+    "APPLICATION"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1836b0777d61fe0a28b1d3ccce79f1477cd5a841"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ffea5da2ba0a93246149aa0874c4dab1ee38ca8ea391752915e480bd4ca8b794"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/images/fallback-icon.svg",
+   "SPDXID": "SPDXRef-File-...static-images-fallback-icon.svg-26f8ec5165c23320",
+   "fileTypes": [
+    "IMAGE"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ab5abf600f2ec0925f8d8ba41878ad08c73b4392"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9db375a9ce7de22b1854a313bd9ae977d73172bbc54dc780c06bad3c193ed08a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/images/logo-lunes-dark.svg",
+   "SPDXID": "SPDXRef-File-...static-images-logo-lunes-dark.svg-96a921564249b511",
+   "fileTypes": [
+    "IMAGE"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "85d4f49f7df1958ae6ef934c140cd6b60effd276"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "b05f5f66c2434d3d1ef794c13cd020fdc4a75798a22fc04d7bf346bbb49487c9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/images/logo-lunes.svg",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-images-logo-lunes.svg-a8f653edc9adb5bd",
+   "fileTypes": [
+    "IMAGE"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "bbbf691195f509d659b24fce707f94319aaee1d6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "2314f5e53780ac6886e1b4d651ef0d911ae3f66debe6ed2b0c2f1cd5244fa8aa"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/images/logo.svg",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-images-logo.svg-f6e589673322099e",
+   "fileTypes": [
+    "IMAGE"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "d67e68ed086a5b8d2dbc99e8e81e4c600c1510f9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "db7fd4266817b33ac2836360a5360623a91f8cf55645f61d15e93316c2120b62"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/asset_manager.js",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-js-asset-manager.js-2a9aec1691ed5a1c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "fe1c338bbd1f9cabd8e7474d2a609c4bac3e2304"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "a86b51a715ce0cdfe3442b49a787f9110bd60d30cc18c9cc9cc2dddc0fd5d42c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/audio_asset_manager.js",
+   "SPDXID": "SPDXRef-File-...static-js-audio-asset-manager.js-34ff74c0fabaa59b",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "4301f43090436099f878181a400f0779e78615d3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "8f59205b0e6ec75f5f3278a2c2ee7bc915d446b1772cb734cb994cefa62f278e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/audio_check_status_update.js",
+   "SPDXID": "SPDXRef-File-...static-js-audio-check-status-update.js-a3178e058f57b4dc",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ce0c2e5dd43a8619373eebe5a4d0131418788e89"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "697db9e88c7f2cf9d9e8216aaf8ceca2eba73a7c823678013d4dfb18a3c78aef"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/audio_player.js",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-js-audio-player.js-67483dcc97eb263d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "17ae6bcddc6a130fdee1ccc3da80546849d8e388"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "75cd24d55c29e11055ecf0b1e5d390fa5e031dc6e8e3c593f3ee53b092e4888c"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/color_unread_feedback.js",
+   "SPDXID": "SPDXRef-File-...static-js-color-unread-feedback.js-8229ab020b1c532e",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "e49ebd717745d5beb0f8c5165c6486539f5372e6"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "7fba3dd5eb3d760e7563b54f1cc7c56b81bd67af98dff9eddd2de4b7467574f3"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/corporate_identity.js",
+   "SPDXID": "SPDXRef-File-...static-js-corporate-identity.js-73e0bf42a1d0c13a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "1fdc7ed72d823c9af62e98e911b821fdd641eb38"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9963072c5f96a93383e71a53461ca7ef7de6377328ff1391dfbd9af14a92bfc9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/image_check_status_update.js",
+   "SPDXID": "SPDXRef-File-...static-js-image-check-status-update.js-323dec4ed22773fe",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3680a33d46fdade452d317ce63cd0151bf7dab4d"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f5a0f3290d0efa9738bc1a55ae192484ddbd1957140af0ae384531337d34a094"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/image_preview.js",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-js-image-preview.js-0fe43a6b9745a30f",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "64a1984ac34acb4e767b38ae90dbf5aabee648bd"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5883346ff0d876114e3abb4e31484e6b908545704e684eb9beea2ea99d4de62a"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/job_icon_asset_config.js",
+   "SPDXID": "SPDXRef-File-...static-js-job-icon-asset-config.js-453c7e9784378b35",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ec0df6391ef8a59553f2a334bf0a1e70f04dfbca"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "9345b38d426354a96e0fef75383c631a9b1735a80d92239296484686f523313e"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/manytomany_overlay.js",
+   "SPDXID": "SPDXRef-File-...static-js-manytomany-overlay.js-164d4ed372b16b3a",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7216b69958defdb78b1bb7f10f6b6377d380e39b"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "dbde636e9627a482c511661e125ea81efce3cbe128f3937dc6cd736aabdd109f"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/overlay.js",
+   "SPDXID": "SPDXRef-File-lunes-cms-static-js-overlay.js-2027b8f04eee0ade",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "ae249347026ea0930d695845eab74ed824e551f9"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "5f4fe1e9268072076e1d83bdbdbc5d721bcf33992669a668b17fc1fecadc0091"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/toggle_document_form_fields.js",
+   "SPDXID": "SPDXRef-File-...js-toggle-document-form-fields.js-f973dba06a5ba46c",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "f7c38f99e2a6cecdf5bf925ab8e4b03b01ceb400"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "ce06260018eeba8469e6e8493c2a5a3fe2dcf53f6ce430bcbcbe8cd894c81975"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/unit_icon_asset_config.js",
+   "SPDXID": "SPDXRef-File-...static-js-unit-icon-asset-config.js-759ebf427cef5751",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "fef73343d90c7f84d244c42c0c89a02f25d9c9ab"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "de257f71c567e0748238fc1d66f991fc67c06faf8ddccaec81ca6c8d7066f6ea"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/unitword_image_asset_config.js",
+   "SPDXID": "SPDXRef-File-...js-unitword-image-asset-config.js-2bd1b2ecb70c308d",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "8f9e87a3a174b31de8bea7a298a54cbf0dce71f3"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "fd07c9049eb7672764fb64cca6b55b5105d5cf4dcdaa7838868d18436c9f51e5"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/word_audio_asset_config.js",
+   "SPDXID": "SPDXRef-File-...static-js-word-audio-asset-config.js-b95caa5f4d68ae43",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "3d7a0a74cefca92d4345cd63cbada4f43ec4a5c4"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "865f627e5527cc702ffe090a50aa33e3ae06d323584da2128b717ff08b516576"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "lunes_cms/static/js/word_image_asset_config.js",
+   "SPDXID": "SPDXRef-File-...static-js-word-image-asset-config.js-ff43060b49e1de16",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "59ba26e5c3adfcd9316c417f189c905594d2ff82"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "46a68d6b9ff0aad5304ea3d39bf93bea1aa24a196aa72b75dc4596883f8edbb9"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "src/Vocabulary_Trainer.egg-info/PKG-INFO",
+   "SPDXID": "SPDXRef-File-...Vocabulary-Trainer.egg-info-PKG-INFO-58a65d0118f0aa53",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "dc3d52fd54c6ecf544e7d03fc3ffe18b98ea262f"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "df2bfe6e202792e6eec1a52497f69da288c6a42f02a266f05ae482f337b18800"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  },
+  {
+   "fileName": "src/Vocabulary_Trainer.egg-info/top_level.txt",
+   "SPDXID": "SPDXRef-File-...top-level.txt-9fe80fbe1b3ea8ee",
+   "fileTypes": [
+    "TEXT"
+   ],
+   "checksums": [
+    {
+     "algorithm": "SHA1",
+     "checksumValue": "7dfdd4b86b076c6e83fd9e25cc53454903ea910a"
+    },
+    {
+     "algorithm": "SHA256",
+     "checksumValue": "f605c380b5364ab5cd4f0c265daa0ac0fd961f2547c20ddd5e4d7eeaaeec3cc6"
+    }
+   ],
+   "licenseConcluded": "NOASSERTION",
+   "licenseInfoInFiles": [
+    "NOASSERTION"
+   ],
+   "copyrightText": "NOASSERTION"
+  }
+ ],
+ "hasExtractedLicensingInfos": [
+  {
+   "licenseId": "LicenseRef-Apache-2.0",
+   "extractedText": "NOASSERTION",
+   "name": "Apache 2.0"
+  },
+  {
+   "licenseId": "LicenseRef-Apache-License--Version-2.0",
+   "extractedText": "NOASSERTION",
+   "name": "Apache License, Version 2.0"
+  },
+  {
+   "licenseId": "LicenseRef-BSD",
+   "extractedText": "NOASSERTION",
+   "name": "BSD"
+  },
+  {
+   "licenseId": "LicenseRef-BSD-3-Clause-OR-Apache-2.0",
+   "extractedText": "NOASSERTION",
+   "name": "BSD 3-Clause OR Apache-2.0"
+  },
+  {
+   "licenseId": "LicenseRef-BSD-3-clause",
+   "extractedText": "NOASSERTION",
+   "name": "BSD 3-clause"
+  },
+  {
+   "licenseId": "LicenseRef-ISC-license",
+   "extractedText": "NOASSERTION",
+   "name": "ISC license"
+  },
+  {
+   "licenseId": "LicenseRef-LGPL-with-exceptions",
+   "extractedText": "NOASSERTION",
+   "name": "LGPL with exceptions"
+  },
+  {
+   "licenseId": "LicenseRef-MIT-License",
+   "extractedText": "NOASSERTION",
+   "name": "MIT License"
+  },
+  {
+   "licenseId": "LicenseRef-UNKNOWN",
+   "extractedText": "NOASSERTION",
+   "name": "UNKNOWN"
+  }
+ ],
+ "relationships": [
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-widgets.py-017336f979fb0237",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-document-viewset.py-02e82163d5526286",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-validators.py-05e6ec31f835944f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...help-templates-public-upload.html-076cbf1d4ff2d4f6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-migrations---init--.py-07f555c53567203a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-models-alternative-word.py-08e7eaf7cb925870",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-utils.py-0cab86024d169367",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...migrations-0002-modify-group-model.py-0db56c83b42941db",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-admins-discipline-admin.py-0e607e7fbd574cfe",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-document.py-0f1a3ea70ef4537d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-js-image-preview.js-0fe43a6b9745a30f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-admin.py-101415a4dc328e81",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms---pycache---apps.cpython-313.pyc-108a00fa2a74b234",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v2-views---init--.py-10aecb93ce7d12e4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-db.sqlite3-12d41603074b8deb",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-unitword-generate-image.py-13beb870a63a251f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-generate-image.py-14c7615aea0df4fd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-manytomany-overlay.js-164d4ed372b16b3a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0014-add-plural-field-and-plural-article.py-165f39629be1f7b4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-update-word-image.py-178147ed2ece6c3c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-update-unitword-image.py-185b3f9afa704421",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-help-apps.py-18b2cfaf37486bfd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core-utils.py-18b7c0bebea9f791",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v2-views-word-viewset.py-19f69feae7c61fe3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...alternative-word-serializer.py-1cc8f3999aa95a08",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-1d91800d7f45278d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-js-overlay.js-2027b8f04eee0ade",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...v1-views-training-set-by-id-viewset.py-217fe952163c6af8",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core-context-processors.py-229a671e09512ac4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0003-remove-documentimage-name.py-22a1730d3a5e62cc",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-css-corporate-identity.css-239ab815ee0b5140",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0012-add-additional-field.py-24fc5a4be501b7de",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-images-fallback-icon.svg-26f8ec5165c23320",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v2-views-job-viewset.py-28bce07ed1d49e9d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-js-asset-manager.js-2a9aec1691ed5a1c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...js-unitword-image-asset-config.js-2bd1b2ecb70c308d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-admins-base.py-2bfc1c2cc6c2e6a0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-group.py-2ccbe4e393116324",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-document-by-id-viewset.py-2dfaa5648bf786a1",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-apps.py-2f4d5ad718399cb9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-image-check-status-update.js-323dec4ed22773fe",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...admin-delete-confirmation.html-32fe7a7fa111fea6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-audio-asset-manager.js-34ff74c0fabaa59b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-training-set-viewset.py-36ce3a51ebdfb5a3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...unit-word-relation-serializer.py-37e54445ad4ebd04",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-migrations-0001-initial.py-3893a6dacfb17d63",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-migrations-0004-feedback.py-3a69969cf1e46dd2",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-models-static.py-3aad0846edfb21f1",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...admin-object-delete-summary.html-3b099481a396fe5e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-models-unit.py-3de8500216a3070f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...document-image-serializer.py-3f7fd50004a3d913",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-apps.py-417dc6d8c2157366",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core-wsgi.py-4299e483c25efce9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v1-views-word-viewset.py-4330a15d1506369a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0008-unitwordrelation-unit-words.py-4401f367430a1686",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-job-icon-asset-config.js-453c7e9784378b35",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api---pycache---apps.cpython-313.pyc-46bae4bb73979856",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-admins---init--.py-46f7a343107c2d27",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...help---pycache---apps.cpython-313.pyc-4708f642c91aaa8c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms---init--.py-4741dcd4e971b997",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-word-generate-audio.py-4849de54b58b48f0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...admin-word-generate-image.html-4851ff76f6b43168",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-content-type.py-487cf638ed32a84f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-permissions.py-48a6ae643918303f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-4960ae799a02d296",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v1-views---init--.py-4a55066f7fb319d9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2---init--.py-4a7b864f63173605",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-admin.py-4a7fc304a39685d0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...update-unitword-image-check-status.py-520d506d9c74fb67",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-templates-admin-base.html-531e907678b80dd5",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...locale-de-LC-MESSAGES-djangojs.mo-545b378b68748bcd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0002-alter-job-options-alter-unit-options-and-more.py-548bf2138703d4ff",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-group-viewset.py-54bab187fe42ee47",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-group-api-key.py-5596947447d97815",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-migrations-0010-sponsor-url.py-56c3f2aa689a85b8",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0011-unitwordrelation-image-check-status-and-more.py-58e5402f4fb80e1b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-feedback-viewset.py-590b367c78d4eee9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-discipline.py-5992d6c393ad06ce",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-utils.py-59f7f630769013b7",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-admins-job-admin.py-5e7edfb2fe973181",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-admins-document-image-admin.py-5e7fb7d49d08df43",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-5eb23c8ae310de7f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms---init--.py-5f6252aca2035fb0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-admins-sponsor-admin.py-6037cddffc43490f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-update-word-audio.py-62321f769d4d4a23",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-training-set.py-63ba6fa0f764a0c0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-utils.py-63f5e9448686385a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-admins-document-admin.py-6442c6ea2e8e8673",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...serializers-training-set-serializer.py-6487def6869989cd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0003-alter-job-created-by-alter-unit-created-by-and-more.py-6596d7a7c766cbf9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0006-convert-group-api-key.py-65d746060d6aba74",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-js-audio-player.js-67483dcc97eb263d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-models-job.py-6949acb8f0b2954a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0005-alter-job-icon-alter-unit-icon-alter-word-audio.py-6ac45bfcafdd4a37",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-admins-document-resource.py-6aed99f133cb2d6c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-css-overlay.css-6b487e920c8c68ba",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core-urls.py-6c562945feb54363",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v2-views-unit-words-viewset.py-6ec942c245be16d9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-admins-feedback-admin.py-7110642436af5973",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...serializers-discipline-serializer.py-7131f20a3eadfa1a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0009-word-audio-check-status-and-more.py-71fef902f8ee0f37",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-corporate-identity.js-73e0bf42a1d0c13a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-unit-icon-asset-config.js-759ebf427cef5751",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-75a68313392aa7d8",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...locale-de-LC-MESSAGES-django.mo-77fee147e3bcba9e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v1---init--.py-7cb799de1df5382f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...fallback-icon-serializer.py-7dda7a2e652ef552",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...delete-selected-confirmation.html-7e0186f7d3ed92fd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...logging-formatter.cpython-313.pyc-805e63f30791116d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-serializers-group-serializer.py-8143901ea2deaa0d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-help-views---init--.py-821322455404d5b3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-color-unread-feedback.js-8229ab020b1c532e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-forms.py-82f1b20696b06c7c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0011-document-example-sentence.py-83ca30e4e0d841d6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-list-filter.py-862a1ee4a8a6e257",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v2---init--.py-869a4a3ddfc42fde",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-admins---init--.py-86b68b38cd67f874",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-889fe823bbf2cfbd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-admins-training-set-admin.py-88b5ae55a41fb398",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...migrations-0007-remove-unit-words.py-88fadad8c7c7f652",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache-----init--.cpython-313.pyc-89d11985ef56aac1",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0012-alter-unitwordrelation-image-check-status-and-more.py-8aba7f7b98acfa8b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-templatetags---init--.py-8b24b3b62ed85f1a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-urls.py-8ceb24e3eef93db3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0008-add-numerals-adverbs-and-pronouns-as-word-types.py-8f1fdf0b1a38e4fd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-static.py-92a83638cc9c6fb4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-admins-group-api-key-admin.py-9408a35f62ea7797",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...views-discipline-filtered-viewset.py-949719fac81cd0c3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-exception-handler.py-94f99bf4c9c3bc15",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-models---init--.py-950bf4e1f71a2409",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-sponsor.py-95cbe5c25b2e55d0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-bootstrap-css-bootstrap.min.css-95d7f5a9d87a0922",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2---pycache---apps.cpython-313.pyc-95f4bdc19e3543c8",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-images-logo-lunes-dark.svg-96a921564249b511",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-admins-unit-admin.py-96d8c352009cb1ca",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...admin-word-generate-audio.html-971e7a12e3537419",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-urls.py-990ba8eac5e4dca4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-css-feedback.css-9a676e0364cd9209",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0013-job-v1-id-unit-v1-id-word-v1-id.py-9b7b959e88171265",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-README.md-9c6b61a95bead74a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v1-urls.py-9e2d323ec386c7ca",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-templatetags-admin-filter-tags.py-a02eef458ea37a82",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-feedback-filter.py-a17beea54507c344",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-apps.py-a30f6ea27ffbfa9a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-audio-check-status-update.js-a3178e058f57b4dc",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache---settings.cpython-313.pyc-a55771f6eea0453f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-images-logo-lunes.svg-a8f653edc9adb5bd",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-urls.py-a91da67ad694984a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models---init--.py-a98f92edd05e3c5d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api-v2-urls.py-acaed70d5c76ffd0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...migrations-0013-add-plural-field.py-ad3a2e7efad564b6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core-logging-formatter.py-ad70da26953f19ba",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-migrations---init--.py-ae1ff7943539c067",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0010-alter-word-audio-check-status.py-af2d4f37b765ad81",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core-settings.py-af56008c49ce2ff7",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v2-serializers-word-serializer.py-b037199aba4e2d15",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-serializers---init--.py-b2c34769a09156b3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-admins-word-admin.py-b3b7b7b76b23863d",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-migrations-0009-sponsor.py-b561a1ae9cc37764",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-word-audio-asset-config.js-b95caa5f4d68ae43",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...--pycache---utils.cpython-313.pyc-ba8a1991379b32ab",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-validators.py-bbce3c51d468b841",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...core---pycache---utils.cpython-313.pyc-bbce9c3326b927dc",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v2-serializers-unit-serializer.py-bf399f3bbbd5ca9f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-document-image.py-c0e26273db9e9051",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-api---init--.py-c14f85accff35a7f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-css-audio-player.css-c1693714865de0b3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...update-word-image-check-status.py-c44a57e7bacf5865",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-admins-alternative-word-admin.py-c73f85acef2c990f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-core---init--.py-c9c91069846ac0b0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...document-image-list-serializer.py-ca5b1afd04be85ea",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-lunes-cms-cli-ceab96d380b37b1e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-help-urls.py-cfc7d2284359acf2",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0004-rename-title-job-name.py-d05544c2fc9cb60c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-update-job-icon.py-d0edfad43680ab89",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-templates-swagger-ui.html-d27b60011c9c53b5",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-migrations-0001-initial.py-d43a2348df7f446a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-help---init--.py-d8cfa706ccdd2df8",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...admin-unitword-generate-image.html-d9431b3d3ccf014f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-views---init--.py-d9a79b9c42b74e73",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...v1-serializers-feedback-serializer.py-da5bd5b5e4c59314",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cms-models-feedback.py-daec96dd0a253a40",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0007-document-created-by-link.py-dd4c4a7bfa011eab",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-word-generate-image.py-dff52aa424353552",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cms-migrations-0005-auto-create-id.py-e4718401fa196708",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-discipline-viewset.py-e531b0ca923b18b7",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...0015-add-grammatical-gender-fields.py-e7140b4b0dab779f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-migrations-0006-word-image.py-e9d16c1bd780f506",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...cmsv2-views-update-unit-icon.py-ea05f19393a2f0b7",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-cmsv2-models-word.py-ea7e369bafc20f02",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...v1-serializers-sponsor-serializer.py-ebdc2ae6f70804f7",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v2-serializers---init--.py-ef377bd8a2365ba4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-guidelines-fotoguide.pdf-f29ca44756abff0b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v1-views-sponsors-viewset.py-f4e35d2d219532f6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...v1-serializers-document-serializer.py-f4f022b549326e91",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v2-views-job-units-viewset.py-f5dab3ebf821a97e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-css-document-form.css-f6a489762867faf3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-images-logo.svg-f6e589673322099e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-help-views-public-upload.py-f80f97db6f072452",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...update-word-audio-check-status.py-f8387966793fe142",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms-static-css-asset-manager.css-f91581b88c3c5ffe",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...js-toggle-document-form-fields.js-f973dba06a5ba46c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...templates-admin-discipline-filter.html-fac9fd3606c5c487",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...api-v2-serializers-job-serializer.py-ff3c6931251eb7f7",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...static-js-word-image-asset-config.js-ff43060b49e1de16",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pillow-01b8b61581f6a2e5",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jiter-01ec1bc0a6d5319b",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-decorator-020ed8d0f8c69ea9",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sqlparse-0535a323d8c5515b",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tqdm-0a069a66b5941349",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-inspection-0aa3fd5cf879490c",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relatedSpdxElement": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-psycopg2-127e95f45199e153",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-jazzmin-1457ffa6ce3386c2",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relatedSpdxElement": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-js-asset-269f112427c6751a",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-mptt-9bfe76c4b9ce3f1c",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-core-2a3bd733f665f52f",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relatedSpdxElement": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-pygments-lexers-89eb775af3dc7e6e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-rpds-py-346354dc3b719d2c",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-rpds-py-346354dc3b719d2c",
+   "relatedSpdxElement": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-matplotlib-inline-36ab3770d1c8da4b",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relatedSpdxElement": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relatedSpdxElement": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-parso-425b83e4d9560860",
+   "relatedSpdxElement": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pyyaml-4979bc836022c4b6",
+   "relatedSpdxElement": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-segno-4c50a64427c78b15",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ptyprocess-4df83817440496d5",
+   "relatedSpdxElement": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-h11-532967227a5a6258",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydub-59f16a6341fa43c6",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "relatedSpdxElement": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "relatedSpdxElement": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pure-eval-6a837dddcf51590b",
+   "relatedSpdxElement": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-wcwidth-83749aeb76d031a0",
+   "relatedSpdxElement": "SPDXRef-Package-python-prompt-toolkit-368848b58a66b4c3",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "relatedSpdxElement": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "relatedSpdxElement": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-pygments-lexers-89eb775af3dc7e6e",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-mptt-9bfe76c4b9ce3f1c",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relatedSpdxElement": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-jazzmin-1457ffa6ce3386c2",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-js-asset-269f112427c6751a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-annotated-types-a6b5d180efe61a19",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asgiref-acd7e572b8ab722a",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-inflection-b21cbbca91c9455c",
+   "relatedSpdxElement": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-specifications-efb9708363f3ab7b",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-uritemplate-c187d2c8320503c2",
+   "relatedSpdxElement": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "relatedSpdxElement": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-typing-inspection-0aa3fd5cf879490c",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-core-2a3bd733f665f52f",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-annotated-types-a6b5d180efe61a19",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-distro-defc489bccf4fa26",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-diff-match-patch-e8b58cf67ba36766",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-traitlets-e8c2bdc7c55ae62c",
+   "relatedSpdxElement": "SPDXRef-Package-python-matplotlib-inline-36ab3770d1c8da4b",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-traitlets-e8c2bdc7c55ae62c",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jsonschema-specifications-efb9708363f3ab7b",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relatedSpdxElement": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "DEPENDENCY_OF"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pillow-01b8b61581f6a2e5",
+   "relatedSpdxElement": "SPDXRef-File-...pillow-12.0.0.dist-info-METADATA-5064ef1c54462ee1",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pillow-01b8b61581f6a2e5",
+   "relatedSpdxElement": "SPDXRef-File-...pillow-12.0.0.dist-info-top-level.txt-6c1e5e4217086bf7",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pillow-01b8b61581f6a2e5",
+   "relatedSpdxElement": "SPDXRef-File-...pillow-12.0.0.dist-info-RECORD-8aec256b8cc7bc53",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jiter-01ec1bc0a6d5319b",
+   "relatedSpdxElement": "SPDXRef-File-...jiter-0.11.1.dist-info-RECORD-207eaca6d6136257",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jiter-01ec1bc0a6d5319b",
+   "relatedSpdxElement": "SPDXRef-File-...jiter-0.11.1.dist-info-METADATA-47e38a5814d862b8",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-decorator-020ed8d0f8c69ea9",
+   "relatedSpdxElement": "SPDXRef-File-...decorator-5.2.1.dist-info-METADATA-15857040c0aa335d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-decorator-020ed8d0f8c69ea9",
+   "relatedSpdxElement": "SPDXRef-File-...decorator-5.2.1.dist-info-RECORD-7bcc0dbdeb378d9d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-decorator-020ed8d0f8c69ea9",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-c1c55f57e84f1f5d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sqlparse-0535a323d8c5515b",
+   "relatedSpdxElement": "SPDXRef-File-...sqlparse-0.5.3.dist-info-RECORD-b32a862113014605",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sqlparse-0535a323d8c5515b",
+   "relatedSpdxElement": "SPDXRef-File-...sqlparse-0.5.3.dist-info-METADATA-c5aa3bcb409aaeb9",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "relatedSpdxElement": "SPDXRef-File-...certifi-2025.10.5.dist-info-METADATA-e30b61ecf8fcde67",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-e704e80eb06cee6c",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "relatedSpdxElement": "SPDXRef-File-...certifi-2025.10.5.dist-info-RECORD-ebd4eecc63c9d687",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tqdm-0a069a66b5941349",
+   "relatedSpdxElement": "SPDXRef-File-...tqdm-4.67.1.dist-info-RECORD-8d316a3c679a71c6",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tqdm-0a069a66b5941349",
+   "relatedSpdxElement": "SPDXRef-File-...tqdm-4.67.1.dist-info-top-level.txt-ada67eb0d739c627",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tqdm-0a069a66b5941349",
+   "relatedSpdxElement": "SPDXRef-File-...tqdm-4.67.1.dist-info-METADATA-c5abad2d5baf5df3",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-inspection-0aa3fd5cf879490c",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-db4978372b0f05ca",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-inspection-0aa3fd5cf879490c",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-ee3aeb6b1f7b6ed3",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relatedSpdxElement": "SPDXRef-File-...django-qr-code-4.2.0.dist-info-RECORD-2f3e6690cdebbd86",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-6e3b654fb725bc59",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-762a7829e057951e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-09b9097296c40322",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relatedSpdxElement": "SPDXRef-File-...executing-2.2.1.dist-info-METADATA-2cbcb88f2e390284",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relatedSpdxElement": "SPDXRef-File-...executing-2.2.1.dist-info-RECORD-71b303f8e407752d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-psycopg2-127e95f45199e153",
+   "relatedSpdxElement": "SPDXRef-File-...psycopg2-2.9.11.dist-info-RECORD-2d5885058117afb7",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-psycopg2-127e95f45199e153",
+   "relatedSpdxElement": "SPDXRef-File-...psycopg2-2.9.11.dist-info-METADATA-3d791ee7dbd32e4d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-psycopg2-127e95f45199e153",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-fa2f716c9a81cf17",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-jazzmin-1457ffa6ce3386c2",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-069ae4b3e0452970",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-jazzmin-1457ffa6ce3386c2",
+   "relatedSpdxElement": "SPDXRef-File-...django-jazzmin-3.0.1.dist-info-RECORD-32073f4f06e0a849",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relatedSpdxElement": "SPDXRef-File-...openai-2.6.1.dist-info-RECORD-9177565be8486f08",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relatedSpdxElement": "SPDXRef-File-...openai-2.6.1.dist-info-METADATA-de6cddc0a3db3450",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relatedSpdxElement": "SPDXRef-File-...jsonschema-4.25.1.dist-info-METADATA-559d4dee68de9c77",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relatedSpdxElement": "SPDXRef-File-...jsonschema-4.25.1.dist-info-RECORD-ec7ffe94495145a2",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relatedSpdxElement": "SPDXRef-File-...httpcore-1.0.9.dist-info-RECORD-06f81504e0ab14af",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relatedSpdxElement": "SPDXRef-File-...httpcore-1.0.9.dist-info-METADATA-7ce46233e5dc9720",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-js-asset-269f112427c6751a",
+   "relatedSpdxElement": "SPDXRef-File-...django-js-asset-3.1.2.dist-info-RECORD-12cadbed23c34453",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-js-asset-269f112427c6751a",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-819e7b21eff44d7e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-80021d507067fea5",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-c6b10abd5e86c6aa",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-f4b4520645b720b4",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-core-2a3bd733f665f52f",
+   "relatedSpdxElement": "SPDXRef-File-...pydantic-core-2.41.4.dist-info-RECORD-74eb392fcf79c86e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-core-2a3bd733f665f52f",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-fd9dac09da539e0b",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relatedSpdxElement": "SPDXRef-File-...pygments-2.19.2.dist-info-RECORD-0bdedfb16dd50dbe",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relatedSpdxElement": "SPDXRef-File-...pygments-2.19.2.dist-info-METADATA-5d3944500090b4e3",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...lunes-cms-2025.10.9a0.dist-info-RECORD-14981702d25d3f44",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-7d7d25e79d299fe7",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-941ae1cfd39e5b31",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relatedSpdxElement": "SPDXRef-File-...direct-url.json-e22cf8a484d2bae2",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-rpds-py-346354dc3b719d2c",
+   "relatedSpdxElement": "SPDXRef-File-...rpds-py-0.28.0.dist-info-METADATA-cf1d85aeb4b5c7d5",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-rpds-py-346354dc3b719d2c",
+   "relatedSpdxElement": "SPDXRef-File-...rpds-py-0.28.0.dist-info-RECORD-d3957c4e59f0e283",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-prompt-toolkit-368848b58a66b4c3",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-1374bc864264b724",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-prompt-toolkit-368848b58a66b4c3",
+   "relatedSpdxElement": "SPDXRef-File-...prompt-toolkit-3.0.52.dist-info-RECORD-313a5fa5505c8124",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-prompt-toolkit-368848b58a66b4c3",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-4a912a496e256ad9",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-matplotlib-inline-36ab3770d1c8da4b",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-0ea4cf70a6f9310a",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-matplotlib-inline-36ab3770d1c8da4b",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-3d945d03d5f17cb8",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relatedSpdxElement": "SPDXRef-File-...idna-3.11.dist-info-RECORD-692b765886f9f9ec",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relatedSpdxElement": "SPDXRef-File-...idna-3.11.dist-info-METADATA-bf3f14eab9c293f4",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-parso-425b83e4d9560860",
+   "relatedSpdxElement": "SPDXRef-File-...parso-0.8.5.dist-info-RECORD-4a28590ba140011e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-parso-425b83e4d9560860",
+   "relatedSpdxElement": "SPDXRef-File-...parso-0.8.5.dist-info-METADATA-b03638925c191d99",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-parso-425b83e4d9560860",
+   "relatedSpdxElement": "SPDXRef-File-...parso-0.8.5.dist-info-top-level.txt-e1fa6895745462be",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pyyaml-4979bc836022c4b6",
+   "relatedSpdxElement": "SPDXRef-File-...pyyaml-6.0.3.dist-info-top-level.txt-0ed225bb40e7dbd1",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pyyaml-4979bc836022c4b6",
+   "relatedSpdxElement": "SPDXRef-File-...pyyaml-6.0.3.dist-info-RECORD-aef4f0f37b857a9a",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pyyaml-4979bc836022c4b6",
+   "relatedSpdxElement": "SPDXRef-File-...pyyaml-6.0.3.dist-info-METADATA-dee5877627fb8f77",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-segno-4c50a64427c78b15",
+   "relatedSpdxElement": "SPDXRef-File-...segno-1.6.6.dist-info-RECORD-7e8aad7e57a5480a",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-segno-4c50a64427c78b15",
+   "relatedSpdxElement": "SPDXRef-File-...segno-1.6.6.dist-info-METADATA-cbe78c73022c187b",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ptyprocess-4df83817440496d5",
+   "relatedSpdxElement": "SPDXRef-File-...ptyprocess-0.7.0.dist-info-METADATA-68634241d3f42d31",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ptyprocess-4df83817440496d5",
+   "relatedSpdxElement": "SPDXRef-File-...ptyprocess-0.7.0.dist-info-RECORD-7b120a5947b0c21d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-h11-532967227a5a6258",
+   "relatedSpdxElement": "SPDXRef-File-...h11-0.16.0.dist-info-RECORD-8aa5144cb3e8617b",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-h11-532967227a5a6258",
+   "relatedSpdxElement": "SPDXRef-File-...h11-0.16.0.dist-info-top-level.txt-f75c0caa9a460d2d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-h11-532967227a5a6258",
+   "relatedSpdxElement": "SPDXRef-File-...h11-0.16.0.dist-info-METADATA-ffc4d796fa93621a",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-0857beaaee2e54ef",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relatedSpdxElement": "SPDXRef-File-...stack-data-0.6.3.dist-info-METADATA-1c662725f04fb5a2",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relatedSpdxElement": "SPDXRef-File-...stack-data-0.6.3.dist-info-RECORD-f69e11a96c2e7907",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "relatedSpdxElement": "SPDXRef-File-...pexpect-4.9.0.dist-info-top-level.txt-68ae51c98aeca1c5",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "relatedSpdxElement": "SPDXRef-File-...pexpect-4.9.0.dist-info-RECORD-7a4c7b81619c0adc",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "relatedSpdxElement": "SPDXRef-File-...pexpect-4.9.0.dist-info-METADATA-fd3b266c7b50031f",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydub-59f16a6341fa43c6",
+   "relatedSpdxElement": "SPDXRef-File-...pydub-0.25.1.dist-info-top-level.txt-7eaa0393c9e214e3",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydub-59f16a6341fa43c6",
+   "relatedSpdxElement": "SPDXRef-File-...pydub-0.25.1.dist-info-RECORD-85bb811980246831",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydub-59f16a6341fa43c6",
+   "relatedSpdxElement": "SPDXRef-File-...pydub-0.25.1.dist-info-METADATA-992d0cf0d292c3ac",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "relatedSpdxElement": "SPDXRef-File-...asttokens-3.0.0.dist-info-RECORD-668ad3e7d2ccd2ec",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-7054ecf31f7fb1da",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "relatedSpdxElement": "SPDXRef-File-...asttokens-3.0.0.dist-info-METADATA-e56f89dfa94844c4",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pip-606c9e4a58298897",
+   "relatedSpdxElement": "SPDXRef-File-...pip-25.1.1.dist-info-METADATA-401d82b643527256",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pip-606c9e4a58298897",
+   "relatedSpdxElement": "SPDXRef-File-...pip-25.1.1.dist-info-RECORD-a679af0b926125ad",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pip-606c9e4a58298897",
+   "relatedSpdxElement": "SPDXRef-File-...pip-25.1.1.dist-info-top-level.txt-e95b6d3e4a6f322f",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relatedSpdxElement": "SPDXRef-File-...anyio-4.11.0.dist-info-RECORD-80db395e87979e9e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relatedSpdxElement": "SPDXRef-File-...anyio-4.11.0.dist-info-top-level.txt-9a0b3adb70ec5011",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relatedSpdxElement": "SPDXRef-File-...anyio-4.11.0.dist-info-METADATA-d20e30483566949e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pure-eval-6a837dddcf51590b",
+   "relatedSpdxElement": "SPDXRef-File-...pure-eval-0.2.3.dist-info-METADATA-62c4e4149ad79ea6",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pure-eval-6a837dddcf51590b",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-7f8568b014c88714",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pure-eval-6a837dddcf51590b",
+   "relatedSpdxElement": "SPDXRef-File-...pure-eval-0.2.3.dist-info-RECORD-d3c040c918707639",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "relatedSpdxElement": "SPDXRef-File-...tablib-3.9.0.dist-info-METADATA-21d79beab506fd12",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "relatedSpdxElement": "SPDXRef-File-...tablib-3.9.0.dist-info-RECORD-83f4c940ae280943",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "relatedSpdxElement": "SPDXRef-File-...tablib-3.9.0.dist-info-top-level.txt-d0e93bbd3a259780",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-wcwidth-83749aeb76d031a0",
+   "relatedSpdxElement": "SPDXRef-File-...wcwidth-0.2.14.dist-info-RECORD-1879c4deb3037871",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-wcwidth-83749aeb76d031a0",
+   "relatedSpdxElement": "SPDXRef-File-...wcwidth-0.2.14.dist-info-METADATA-410ac0524505acf6",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-wcwidth-83749aeb76d031a0",
+   "relatedSpdxElement": "SPDXRef-File-...wcwidth-0.2.14.dist-info-top-level.txt-a965915f79ad5901",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "relatedSpdxElement": "SPDXRef-File-...attrs-25.4.0.dist-info-RECORD-7a575e54b8713c68",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "relatedSpdxElement": "SPDXRef-File-...attrs-25.4.0.dist-info-METADATA-e70fa87e19aee285",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-pygments-lexers-89eb775af3dc7e6e",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-bdc80593e814dd5a",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-pygments-lexers-89eb775af3dc7e6e",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-da2136468e4c387f",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-mptt-9bfe76c4b9ce3f1c",
+   "relatedSpdxElement": "SPDXRef-File-...django-mptt-0.18.0.dist-info-RECORD-4a20946224b974b6",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-mptt-9bfe76c4b9ce3f1c",
+   "relatedSpdxElement": "SPDXRef-File-...django-mptt-0.18.0.dist-info-METADATA-96af7192787c2868",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-1e0a680bf8c3056d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-734660a9a7d8c784",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-cefd19f681996755",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-File-...django-5.2.7.dist-info-METADATA-240bf42a42cae009",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-File-...django-5.2.7.dist-info-top-level.txt-2fc835bb9b654e30",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relatedSpdxElement": "SPDXRef-File-...django-5.2.7.dist-info-RECORD-deac26504bc1bf67",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-a654bc1ff904c0f1",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms.egg-info-top-level.txt-b3ef667a33538fb0",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-lunes-cms-a654bc1ff904c0f1",
+   "relatedSpdxElement": "SPDXRef-File-lunes-cms.egg-info-PKG-INFO-caaa47a98ed7d475",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-annotated-types-a6b5d180efe61a19",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-40ac67d5665956dd",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-annotated-types-a6b5d180efe61a19",
+   "relatedSpdxElement": "SPDXRef-File-...annotated-types-0.7.0.dist-info-RECORD-bf79e9940b6bb24e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relatedSpdxElement": "SPDXRef-File-...pydantic-2.12.3.dist-info-RECORD-00d868b3788eaad2",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relatedSpdxElement": "SPDXRef-File-...pydantic-2.12.3.dist-info-METADATA-26a588bcc1cdea4c",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asgiref-acd7e572b8ab722a",
+   "relatedSpdxElement": "SPDXRef-File-...asgiref-3.10.0.dist-info-RECORD-28f304b560223e58",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asgiref-acd7e572b8ab722a",
+   "relatedSpdxElement": "SPDXRef-File-...asgiref-3.10.0.dist-info-METADATA-407d131b3be207eb",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-asgiref-acd7e572b8ab722a",
+   "relatedSpdxElement": "SPDXRef-File-...asgiref-3.10.0.dist-info-top-level.txt-9714f182246972a9",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-inflection-b21cbbca91c9455c",
+   "relatedSpdxElement": "SPDXRef-File-...inflection-0.5.1.dist-info-METADATA-94a7b73b3d9d0b5f",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-inflection-b21cbbca91c9455c",
+   "relatedSpdxElement": "SPDXRef-File-...inflection-0.5.1.dist-info-RECORD-d4792dac9d4e51b6",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-inflection-b21cbbca91c9455c",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-d8c34255d1ff5612",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-0c4c58437e2e3398",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-ba30bf832a008ec0",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-c6644d9d14da1be3",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relatedSpdxElement": "SPDXRef-File-...referencing-0.37.0.dist-info-METADATA-448975660e03be42",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relatedSpdxElement": "SPDXRef-File-...referencing-0.37.0.dist-info-RECORD-dfcfefd716752686",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-uritemplate-c187d2c8320503c2",
+   "relatedSpdxElement": "SPDXRef-File-...uritemplate-4.2.0.dist-info-RECORD-4ed3088fba4c44cf",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-uritemplate-c187d2c8320503c2",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-a5fa9d65217433b6",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-uritemplate-c187d2c8320503c2",
+   "relatedSpdxElement": "SPDXRef-File-...uritemplate-4.2.0.dist-info-METADATA-d6c54fae11a06a72",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "relatedSpdxElement": "SPDXRef-File-...sniffio-1.3.1.dist-info-METADATA-5ad7ea3731fa3037",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "relatedSpdxElement": "SPDXRef-File-...sniffio-1.3.1.dist-info-RECORD-92408a715ad34356",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "relatedSpdxElement": "SPDXRef-File-...sniffio-1.3.1.dist-info-top-level.txt-f37a93c6063a6311",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-0dbfc72f069d4ae5",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-94abd28d867f3c7d",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-vocabulary-trainer-d4d44e04c67d3313",
+   "relatedSpdxElement": "SPDXRef-File-...Vocabulary-Trainer.egg-info-PKG-INFO-58a65d0118f0aa53",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-vocabulary-trainer-d4d44e04c67d3313",
+   "relatedSpdxElement": "SPDXRef-File-...top-level.txt-9fe80fbe1b3ea8ee",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relatedSpdxElement": "SPDXRef-File-...httpx-0.28.1.dist-info-METADATA-dd425c3ff8c0cac5",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relatedSpdxElement": "SPDXRef-File-...httpx-0.28.1.dist-info-RECORD-fd750fb0141b1724",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-distro-defc489bccf4fa26",
+   "relatedSpdxElement": "SPDXRef-File-...distro-1.9.0.dist-info-top-level.txt-0c3d92328a186adb",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-distro-defc489bccf4fa26",
+   "relatedSpdxElement": "SPDXRef-File-...distro-1.9.0.dist-info-METADATA-33705d47f1690b00",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-distro-defc489bccf4fa26",
+   "relatedSpdxElement": "SPDXRef-File-...distro-1.9.0.dist-info-RECORD-3a728df9ce6331ee",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-diff-match-patch-e8b58cf67ba36766",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-49bd2b4697ee9773",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-diff-match-patch-e8b58cf67ba36766",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-d542947701df956c",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-traitlets-e8c2bdc7c55ae62c",
+   "relatedSpdxElement": "SPDXRef-File-...traitlets-5.14.3.dist-info-RECORD-43410095b4ba205e",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-traitlets-e8c2bdc7c55ae62c",
+   "relatedSpdxElement": "SPDXRef-File-...traitlets-5.14.3.dist-info-METADATA-b5bedc01ebd87a75",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jsonschema-specifications-efb9708363f3ab7b",
+   "relatedSpdxElement": "SPDXRef-File-...RECORD-418de5b73c7a9a90",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jsonschema-specifications-efb9708363f3ab7b",
+   "relatedSpdxElement": "SPDXRef-File-...METADATA-872d4c695a6dc872",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relatedSpdxElement": "SPDXRef-File-...ipython-9.6.0.dist-info-METADATA-340ae984800cc366",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relatedSpdxElement": "SPDXRef-File-...ipython-9.6.0.dist-info-top-level.txt-939452ecb20d1e7a",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relatedSpdxElement": "SPDXRef-File-...ipython-9.6.0.dist-info-RECORD-b17052ac665cb127",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relatedSpdxElement": "SPDXRef-File-...jedi-0.19.2.dist-info-METADATA-3bbc4a79684f4456",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relatedSpdxElement": "SPDXRef-File-...jedi-0.19.2.dist-info-top-level.txt-536c0c34040d068b",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relatedSpdxElement": "SPDXRef-File-...jedi-0.19.2.dist-info-RECORD-d1e2f6c779da458b",
+   "relationshipType": "OTHER",
+   "comment": "evident-by: indicates the package's existence is evident by the given file"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-annotated-types-a6b5d180efe61a19",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-anyio-680dea5af6ea988f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-asgiref-acd7e572b8ab722a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-asttokens-5e3d87705262d338",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-attrs-85a5a54e2cd4fa0b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-certifi-0616f05d3e1a4491",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-decorator-020ed8d0f8c69ea9",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-diff-match-patch-e8b58cf67ba36766",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-distro-defc489bccf4fa26",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-a578ab1da0c27709",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-import-export-b45796ba52016bf4",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-jazzmin-1457ffa6ce3386c2",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-js-asset-269f112427c6751a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-mptt-9bfe76c4b9ce3f1c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-django-qr-code-0c643028d439852f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-djangorestframework-a01ac7147d009b8a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-drf-spectacular-282f5f7fa1126b41",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-executing-0e5ec074b031bc73",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-h11-532967227a5a6258",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpcore-22e96650bb058091",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-httpx-d6b2c99a46c05034",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-idna-37b4eb6624fb2155",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-inflection-b21cbbca91c9455c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-f405cc773fdc172e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-ipython-pygments-lexers-89eb775af3dc7e6e",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-jedi-f6800a36349105be",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-jiter-01ec1bc0a6d5319b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-1a028e1d1ec217b3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-jsonschema-specifications-efb9708363f3ab7b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-31ea18529e8bf076",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-lunes-cms-a654bc1ff904c0f1",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-matplotlib-inline-36ab3770d1c8da4b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-openai-1a00bed90887f92a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-parso-425b83e4d9560860",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pexpect-56ced55792cdb33c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pillow-01b8b61581f6a2e5",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pip-606c9e4a58298897",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-prompt-toolkit-368848b58a66b4c3",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-psycopg2-127e95f45199e153",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-ptyprocess-4df83817440496d5",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pure-eval-6a837dddcf51590b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-a7cdcf69cce6a884",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydantic-core-2a3bd733f665f52f",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pydub-59f16a6341fa43c6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pygments-2abf81252d4b770c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-pyyaml-4979bc836022c4b6",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-referencing-b51cc3b728b7c6e2",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-rpds-py-346354dc3b719d2c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-segno-4c50a64427c78b15",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-sniffio-ced5d4d3e2746c5a",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-sqlparse-0535a323d8c5515b",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-stack-data-55b3788e67e2e8f1",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-tablib-6d411c1efa92d690",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-tqdm-0a069a66b5941349",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-traitlets-e8c2bdc7c55ae62c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-typing-extensions-d3b68940e5429f50",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-typing-inspection-0aa3fd5cf879490c",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-uritemplate-c187d2c8320503c2",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-vocabulary-trainer-d4d44e04c67d3313",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relatedSpdxElement": "SPDXRef-Package-python-wcwidth-83749aeb76d031a0",
+   "relationshipType": "CONTAINS"
+  },
+  {
+   "spdxElementId": "SPDXRef-DOCUMENT",
+   "relatedSpdxElement": "SPDXRef-DocumentRoot-Directory-lunes-cms",
+   "relationshipType": "DESCRIBES"
+  }
+ ]
+}


### PR DESCRIPTION
### Short description
Use Syft for generating SBOM. Syft can also fetch license information for used Python packages.

### Proposed changes
 
- Replace sbom-tool with syft.

### Side effects
- We need to test the pipeline again.


### Faithfulness to issue description and design
:rocket: 


### How to test
Run the pipeline ... or commands in your shell.
```bash
curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
export SYFT_SOURCE_VERSION=$(python3 -c "import lunes_cms; print(lunes_cms.__version__)")
export SYFT_SOURCE_NAME="lunes-cms"
export SYFT_FORMAT_SPDX_JSON_PRETTY=true
syft scan . -o spdx-json=lunes_cms/_manifest/spdx_2.2/manifest.spdx.json
```
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
