### PR TITLE
Release 2025.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#632](https://github.com/digitalfabrik/lunes-cms/pull/632) ] Indicate in API and CMS if a job, unit or word was migrated from the old data model
+
 
 2025.11.0
 ---------

--- a/lunes_cms/api/v2/serializers/job_serializer.py
+++ b/lunes_cms/api/v2/serializers/job_serializer.py
@@ -1,3 +1,5 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ....cmsv2.models import Job
@@ -9,6 +11,12 @@ class JobSerializer(serializers.ModelSerializer):
     """
 
     number_units = serializers.IntegerField()
+    migrated = serializers.SerializerMethodField()
+
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_migrated(self, obj):
+        """Return True if the job was migrated from the old data model"""
+        return obj.v1_id is not None
 
     class Meta:
         """
@@ -16,4 +24,4 @@ class JobSerializer(serializers.ModelSerializer):
         """
 
         model = Job
-        fields = ("id", "name", "icon", "number_units")
+        fields = ("id", "name", "icon", "number_units", "migrated")

--- a/lunes_cms/api/v2/serializers/unit_serializer.py
+++ b/lunes_cms/api/v2/serializers/unit_serializer.py
@@ -1,3 +1,5 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ....cmsv2.models import Unit
@@ -9,6 +11,12 @@ class UnitSerializer(serializers.ModelSerializer):
     """
 
     number_words = serializers.IntegerField()
+    migrated = serializers.SerializerMethodField()
+
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_migrated(self, obj):
+        """Return True if the unit was migrated from the old data model."""
+        return obj.v1_id is not None
 
     class Meta:
         """
@@ -22,4 +30,5 @@ class UnitSerializer(serializers.ModelSerializer):
             "description",
             "icon",
             "number_words",
+            "migrated",
         )

--- a/lunes_cms/api/v2/serializers/word_serializer.py
+++ b/lunes_cms/api/v2/serializers/word_serializer.py
@@ -1,3 +1,5 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ....cmsv2.models import Word
@@ -13,10 +15,16 @@ class WordSerializer(serializers.ModelSerializer):
         child=serializers.ImageField(), source="images_for_api"
     )
     example_sentence = serializers.SerializerMethodField()
+    migrated = serializers.SerializerMethodField()
 
     def get_example_sentence(self, obj):
         """Return None for empty example sentences instead of empty string."""
         return obj.example_sentence if obj.example_sentence else None
+
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_migrated(self, obj):
+        """Return True if the word was migrated from the old data model"""
+        return obj.v1_id is not None
 
     class Meta:
         """
@@ -32,4 +40,5 @@ class WordSerializer(serializers.ModelSerializer):
             "audio",
             "example_sentence",
             "example_sentence_audio",
+            "migrated",
         )

--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from .base import BaseAdmin
@@ -18,6 +19,46 @@ class UnitInline(admin.TabularInline):
     extra = 1
 
 
+class MigratedFilter(admin.SimpleListFilter):
+    """
+    Admin filter for migration status.
+
+    Allows filtering jobs by whether they were migrated from v1 or created in v2.
+    """
+
+    title = _("migration status")
+    parameter_name = "migrated"
+
+    def lookups(self, request, model_admin):
+        """
+        Return the filter options.
+
+        Returns:
+            list: A list of tuples containing (value, label) pairs for the filter options
+        """
+        return [
+            ("yes", _("Migrated from old data model")),
+            ("no", _("Not migrated from old data model")),
+        ]
+
+    def queryset(self, request, queryset):
+        """
+        Filter the queryset based on the selected option.
+
+        Args:
+            request: The HTTP request
+            queryset: The queryset to filter
+
+        Returns:
+            QuerySet: The filtered queryset
+        """
+        if self.value() == "yes":
+            return queryset.filter(v1_id__isnull=False)
+        if self.value() == "no":
+            return queryset.filter(v1_id__isnull=True)
+        return queryset
+
+
 class JobAdmin(BaseAdmin):
     """
     Admin interface for the Job model.
@@ -28,23 +69,25 @@ class JobAdmin(BaseAdmin):
 
     fields = [
         "name",
+        "migrated_status",
         "icon",
         "image_tag",
         "created_by",
         "released",
     ]
-    readonly_fields = ["created_by", "image_tag"]
+    readonly_fields = ["created_by", "image_tag", "migrated_status"]
     inlines = [UnitInline]
     search_fields = ["name"]
     list_display = [
         "name",
+        "migrated_status",
         "released",
         "list_icon",
         "created_by",
         "created_at_date",
     ]
     list_display_links = ["name"]
-    list_filter = ["released"]
+    list_filter = ["released", MigratedFilter]
     list_per_page = 25
     ordering = ["name"]
 
@@ -86,3 +129,25 @@ class JobAdmin(BaseAdmin):
         return obj.created_at.date()
 
     created_at_date.short_description = _("created at")
+
+    def migrated_status(self, obj):
+        """
+        Display a badge indicating whether the job was migrated from v1 or created in v2.
+
+        Args:
+            obj: The job object
+
+        Returns:
+            str: HTML formatted badge showing migration status
+        """
+        if obj.v1_id is not None:
+            return format_html(
+                '<span style="background-color: #28a745; color: white; padding: 3px 8px; '
+                'border-radius: 3px; font-size: 13px; font-weight: 500;">Migrated</span>'
+            )
+        return format_html(
+            '<span style="background-color: #007bff; color: white; padding: 3px 8px; '
+            'border-radius: 3px; font-size: 13px; font-weight: 500;">New</span>'
+        )
+
+    migrated_status.short_description = _("migrated")

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -105,6 +105,46 @@ class HasCompleteExampleSentenceFilter(admin.SimpleListFilter):
         return queryset
 
 
+class MigratedFilter(admin.SimpleListFilter):
+    """
+    Admin filter for migration status.
+
+    Allows filtering words by whether they were migrated from v1 or created in v2.
+    """
+
+    title = _("migration status")
+    parameter_name = "migrated"
+
+    def lookups(self, request, model_admin):
+        """
+        Return the filter options.
+
+        Returns:
+            list: A list of tuples containing (value, label) pairs for the filter options
+        """
+        return [
+            ("yes", _("Migrated from old data model")),
+            ("no", _("Not migrated from old data model")),
+        ]
+
+    def queryset(self, request, queryset):
+        """
+        Filter the queryset based on the selected option.
+
+        Args:
+            request: The HTTP request
+            queryset: The queryset to filter
+
+        Returns:
+            QuerySet: The filtered queryset
+        """
+        if self.value() == "yes":
+            return queryset.filter(v1_id__isnull=False)
+        if self.value() == "no":
+            return queryset.filter(v1_id__isnull=True)
+        return queryset
+
+
 class UnitInline(admin.TabularInline):
     """
     Inline admin for UnitWordRelation model.
@@ -149,6 +189,7 @@ class WordAdmin(BaseAdmin):
                     "word",
                     "plural_article",
                     "plural",
+                    "migrated_status",
                 )
             },
         ),
@@ -205,12 +246,14 @@ class WordAdmin(BaseAdmin):
         "created_by",
         "image_generate",
         "image_tag",
+        "migrated_status",
     )
     search_fields = ["word"]
     ordering = ["word", "creation_date"]
     inlines = [UnitInline]
     list_display = (
         "word",
+        "migrated_status",
         "word_type",
         "singular_article_display",
         "list_audio",
@@ -225,6 +268,7 @@ class WordAdmin(BaseAdmin):
         HasImageFilter,
         UnitOrJobDropdownFilter,
         HasCompleteExampleSentenceFilter,
+        MigratedFilter,
     ]
     list_per_page = 25
 
@@ -639,6 +683,28 @@ class WordAdmin(BaseAdmin):
         return obj.creation_date.date()
 
     creation_date_display.short_description = _("creation date")
+
+    def migrated_status(self, obj):
+        """
+        Display a badge indicating whether the word was migrated from v1 or created in v2.
+
+        Args:
+            obj: The word object
+
+        Returns:
+            str: HTML formatted badge showing migration status
+        """
+        if obj.v1_id is not None:
+            return format_html(
+                '<span style="background-color: #28a745; color: white; padding: 3px 8px; '
+                'border-radius: 3px; font-size: 13px; font-weight: 500;">Migrated</span>'
+            )
+        return format_html(
+            '<span style="background-color: #007bff; color: white; padding: 3px 8px; '
+            'border-radius: 3px; font-size: 13px; font-weight: 500;">New</span>'
+        )
+
+    migrated_status.short_description = _("migrated")
 
     def audio_check_status_display(self, obj):
         """

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-04 13:18+0000\n"
+"POT-Creation-Date: 2025-11-22 08:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -109,8 +109,8 @@ msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
 #: cms/admins/discipline_admin.py:387 cms/admins/document_admin.py:179
-#: cms/admins/training_set_admin.py:378 cmsv2/admins/unit_admin.py:108
-#: cmsv2/admins/word_admin.py:386
+#: cms/admins/training_set_admin.py:378 cmsv2/admins/unit_admin.py:151
+#: cmsv2/admins/word_admin.py:430
 msgid "creator group"
 msgstr "Besitzergruppe"
 
@@ -120,7 +120,7 @@ msgid "training set"
 msgstr "Modul"
 
 #: cms/admins/document_admin.py:196 cms/models/document.py:66
-#: cmsv2/admins/word_admin.py:453 cmsv2/models/word.py:64
+#: cmsv2/admins/word_admin.py:497 cmsv2/models/word.py:64
 msgid "audio"
 msgstr "Audio"
 
@@ -130,7 +130,7 @@ msgid "image"
 msgstr "Bild"
 
 #: cms/admins/document_admin.py:231 cms/models/alternative_word.py:24
-#: cms/models/document.py:43 cmsv2/admins/word_admin.py:627
+#: cms/models/document.py:43 cmsv2/admins/word_admin.py:671
 #: cmsv2/models/word.py:41
 msgid "singular article"
 msgstr "Singular-Artikel"
@@ -398,7 +398,7 @@ msgid "example sentence"
 msgstr "Beispielsatz"
 
 #: cms/models/document.py:70 cms/models/group_api_key.py:65
-#: cmsv2/admins/word_admin.py:641 cmsv2/models/word.py:99
+#: cmsv2/admins/word_admin.py:685 cmsv2/models/word.py:99
 msgid "creation date"
 msgstr "Erstellt am"
 
@@ -661,16 +661,36 @@ msgstr "Datei zu groß! Max. 5 MB"
 msgid "Only use one file extension!"
 msgstr "Nur maximal ein Dateityp erlaubt!"
 
-#: cmsv2/admins/job_admin.py:74
+#: cmsv2/admins/job_admin.py:29 cmsv2/admins/unit_admin.py:42
+#: cmsv2/admins/word_admin.py:115
+msgid "migration status"
+msgstr "Ablaufdatum"
+
+#: cmsv2/admins/job_admin.py:40 cmsv2/admins/unit_admin.py:53
+#: cmsv2/admins/word_admin.py:126
+msgid "Migrated from old data model"
+msgstr "Migriert aus altem Datenmodell"
+
+#: cmsv2/admins/job_admin.py:41 cmsv2/admins/unit_admin.py:54
+#: cmsv2/admins/word_admin.py:127
+msgid "Not migrated from old data model"
+msgstr "Nicht migriert aus altem Datenmodell"
+
+#: cmsv2/admins/job_admin.py:117
 msgid "units"
 msgstr "Einheiten"
 
-#: cmsv2/admins/job_admin.py:88 cmsv2/admins/unit_admin.py:122
+#: cmsv2/admins/job_admin.py:131 cmsv2/admins/unit_admin.py:165
 #: cmsv2/models/job.py:34 cmsv2/models/unit.py:315
 msgid "created at"
 msgstr "Erstellt"
 
-#: cmsv2/admins/unit_admin.py:89
+#: cmsv2/admins/job_admin.py:153 cmsv2/admins/unit_admin.py:187
+#: cmsv2/admins/word_admin.py:707
+msgid "migrated"
+msgstr "Migriert"
+
+#: cmsv2/admins/unit_admin.py:132
 msgid "jobs"
 msgstr "Berufe"
 
@@ -686,36 +706,36 @@ msgstr "Einheit oder Job"
 msgid "Has Complete Example Sentence"
 msgstr "Hat vollständigen Beispielsatz"
 
-#: cmsv2/admins/word_admin.py:143
+#: cmsv2/admins/word_admin.py:183
 msgid "Word Information"
 msgstr "Wort Informationen"
 
-#: cmsv2/admins/word_admin.py:156
+#: cmsv2/admins/word_admin.py:197
 msgid "Audio"
 msgstr "Audio"
 
-#: cmsv2/admins/word_admin.py:167 cmsv2/admins/word_admin.py:613
+#: cmsv2/admins/word_admin.py:208 cmsv2/admins/word_admin.py:657
 #: cmsv2/models/unit.py:146 cmsv2/models/unit.py:254
 msgid "Image"
 msgstr "Bilder"
 
-#: cmsv2/admins/word_admin.py:178
+#: cmsv2/admins/word_admin.py:219
 msgid "Example Sentence"
 msgstr "Beispielsatz"
 
-#: cmsv2/admins/word_admin.py:190
+#: cmsv2/admins/word_admin.py:231
 msgid "Miscellaneous"
 msgstr "Verschiedene"
 
-#: cmsv2/admins/word_admin.py:350
+#: cmsv2/admins/word_admin.py:394
 msgid "Image Preview"
 msgstr "Bild Vorschau"
 
-#: cmsv2/admins/word_admin.py:655 cmsv2/models/word.py:70
+#: cmsv2/admins/word_admin.py:721 cmsv2/models/word.py:70
 msgid "audio check status"
 msgstr "Audio Prüfstatus"
 
-#: cmsv2/admins/word_admin.py:670 cmsv2/models/unit.py:42
+#: cmsv2/admins/word_admin.py:736 cmsv2/models/unit.py:42
 #: cmsv2/models/word.py:136
 msgid "image check status"
 msgstr "Bild Prüfstatus"


### PR DESCRIPTION
* [ [#632](https://github.com/digitalfabrik/lunes-cms/pull/632) ] Indicate in API and CMS if a job, unit or word was migrated from the old data model