### PR TITLE
Add pylint to precommits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,12 @@ repos:
         entry: tools/check_translations.sh
         language: script
         pass_filenames: false
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint (custom script)
+        entry: ./tools/pylint.sh
+        args: [ "--as-precommit" ]
+        types_or: [ "python", "pyi" ]
+        language: script
+        pass_filenames: true


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I'm using pre-commits and noticed that Pylint is missing there. This PR adds pylint to the pre-commits

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add pylint to pre-commits

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /
