### PR TITLE
Update black to 26.1.0 to fit the version in the CI/CD pipeline

### DIFF
--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -10,7 +10,6 @@ from django.contrib import admin
 from .admins import JobAdmin, WordAdmin, UnitAdmin, FeedbackAdmin
 from .models import Job, Word, Unit, Feedback
 
-
 admin.site.register(Job, JobAdmin)
 admin.site.register(Unit, UnitAdmin)
 admin.site.register(Word, WordAdmin)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ pinned = [
 
 ]
 dev-pinned = [
-	"black==25.12.0",
+	"black==26.1.0",
     "build<=1.4.0",
 	"bumpver==2025.1131",
 	"pre-commit==4.5.1",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Our pipeline currently uses 26.1.0. I don't fully understand why, but for a quick fix, I decided to match the version in the pyproject.toml

### Proposed changes
<!-- Describe this PR in more detail. -->

- Update to 26.1.0

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /
