### PR TITLE
Fix example sentence serialization error

### DIFF
--- a/lunes_cms/api/v2/serializers/word_serializer.py
+++ b/lunes_cms/api/v2/serializers/word_serializer.py
@@ -39,7 +39,11 @@ class WordSerializer(serializers.ModelSerializer):
             and obj.example_sentence
             and obj.example_sentence_check_status == "CONFIRMED"
         ):
-            return obj.example_sentence_audio
+            return (
+                obj.example_sentence_audio.url
+                if hasattr(obj.example_sentence_audio, "url")
+                else obj.example_sentence_audio
+            )
         return None
 
     @extend_schema_field(OpenApiTypes.BOOL)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
When using `SerializerMethodField` the return value should be something that can be serialized with `json.dumps`, which is not the case for djangos `FileField`.
The fix just copies the code from `unit_word_relation_serializer` which tries to return the url of the file field as str.

Discovered in https://github.com/digitalfabrik/lunes-app/pull/1173#pullrequestreview-3697389367

### Proposed changes
<!-- Describe this PR in more detail. -->

- Return the url as str if possible

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /
