### PR TITLE
Return absolute url for example sentence audio in api v2

### DIFF
--- a/lunes_cms/api/utils.py
+++ b/lunes_cms/api/utils.py
@@ -160,6 +160,19 @@ def check_group_object_permissions(request, group_id):
         raise PermissionDenied()
 
 
+def build_absolute_url(context, url):
+    """
+    Convert a relative URL to an absolute URL using the request from serializer context.
+
+    :param context: Serializer context dict (typically self.context)
+    :param url: Relative URL string or None
+    :return: Absolute URL if request available, otherwise the original URL
+    """
+    if url and (request := context.get("request")):
+        return request.build_absolute_uri(url)
+    return url
+
+
 def find_duplicates_for_word(request, word):
     """
     Function to find existing words that match the input in the "word" field of document

--- a/lunes_cms/api/v2/serializers/unit_word_relation_serializer.py
+++ b/lunes_cms/api/v2/serializers/unit_word_relation_serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from ...utils import build_absolute_url
 from ....cmsv2.models.unit import UnitWordRelation
 
 
@@ -47,31 +48,32 @@ class UnitWordRelationSerializer(serializers.ModelSerializer):
         Return the example sentence audio from the relation if it exists with sentence and confirmed status,
         otherwise fallback to the word's example sentence audio with the same requirements.
         """
+        url = None
+
         # Check relation's example sentence audio
         if (
             obj.example_sentence
             and obj.example_sentence_audio
             and obj.example_sentence_check_status == "CONFIRMED"
         ):
-            return (
+            url = (
                 obj.example_sentence_audio.url
                 if hasattr(obj.example_sentence_audio, "url")
                 else obj.example_sentence_audio
             )
-
         # Fallback to word's example sentence audio
-        if (
+        elif (
             obj.word.example_sentence
             and obj.word.example_sentence_audio
             and obj.word.example_sentence_check_status == "CONFIRMED"
         ):
-            return (
+            url = (
                 obj.word.example_sentence_audio.url
                 if hasattr(obj.word.example_sentence_audio, "url")
                 else obj.word.example_sentence_audio
             )
 
-        return None
+        return build_absolute_url(self.context, url)
 
     class Meta:
         """

--- a/lunes_cms/api/v2/serializers/word_serializer.py
+++ b/lunes_cms/api/v2/serializers/word_serializer.py
@@ -2,6 +2,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from ...utils import build_absolute_url
 from ....cmsv2.models import Word
 
 
@@ -39,11 +40,12 @@ class WordSerializer(serializers.ModelSerializer):
             and obj.example_sentence
             and obj.example_sentence_check_status == "CONFIRMED"
         ):
-            return (
+            url = (
                 obj.example_sentence_audio.url
                 if hasattr(obj.example_sentence_audio, "url")
                 else obj.example_sentence_audio
             )
+            return build_absolute_url(self.context, url)
         return None
 
     @extend_schema_field(OpenApiTypes.BOOL)

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-10 10:10+0000\n"
+"POT-Creation-Date: 2026-02-16 22:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,27 +21,27 @@ msgstr ""
 msgid "API"
 msgstr "API"
 
-#: api/utils.py:179
+#: api/utils.py:192
 msgid "This word is assigned to no training set."
 msgstr "Das word ist zu keinem Modul zugeordnet."
 
-#: api/utils.py:186
+#: api/utils.py:199
 msgid "This word is already registered in the system."
 msgstr "Das Wort ist schon im System hinterlegt."
 
-#: api/utils.py:189 api/utils.py:191
+#: api/utils.py:202 api/utils.py:204
 msgid "Definition: "
 msgstr "Definition: "
 
-#: api/utils.py:191
+#: api/utils.py:204
 msgid "No definition is provided for this word."
 msgstr "Für dieses Wort ist keine Definition hinterlegt."
 
-#: api/utils.py:193
+#: api/utils.py:206
 msgid "Training sets: "
 msgstr "Module: "
 
-#: api/utils.py:197
+#: api/utils.py:210
 msgid "This word is not yet registered in the system"
 msgstr "Das Wort ist noch nicht im System hinterlegt."
 


### PR DESCRIPTION
- Utility function to centralize absolute URL building logic
- `WordSerializer` and `UnitWordRelationSerializer`: use the new utility for `example_sentence_audio` field