### PR TITLE
Basic request tracking in Matomo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/src/ref/
 docs/src/changelog.rst
 lunes_cms/lunes-cms.log
 .python-version
+.env.local

--- a/lunes_cms/api/v2/matomo_tracking.py
+++ b/lunes_cms/api/v2/matomo_tracking.py
@@ -1,0 +1,167 @@
+"""
+Matomo tracking decorator for API v2 endpoints.
+
+This module provides a decorator to track API requests to Matomo asynchronously,
+without blocking the main request/response cycle.
+"""
+
+import atexit
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Callable, Optional
+from urllib import error, parse
+from urllib import request as urllib_request
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+# Module-level thread pool executor for Matomo tracking requests.
+# Reuses threads instead of creating new ones for each request.
+_executor = ThreadPoolExecutor(max_workers=10, thread_name_prefix="matomo_tracking")
+
+# Ensure clean shutdown of the thread pool when the application exits
+atexit.register(_executor.shutdown, wait=False)
+
+
+@dataclass
+class MatomoTrackingData:  # pylint: disable=too-many-instance-attributes
+    """Data class to hold Matomo tracking information."""
+
+    matomo_url: str
+    site_id: str
+    token: str
+    action_name: str
+    category: str
+    request_url: str
+    user_agent: str
+    os: Optional[str] = None
+    os_version: Optional[str] = None
+    app_version: Optional[str] = None
+    resource_id: Optional[str] = None
+
+
+def send_matomo_tracking(tracking_data: MatomoTrackingData) -> None:
+    """
+    Send tracking data to Matomo API.
+
+    This function is designed to be called in a separate thread
+    to avoid blocking the main request.
+
+    :param tracking_data: MatomoTrackingData instance containing all tracking info
+    """
+    data = {
+        "idsite": tracking_data.site_id,
+        "rec": 1,
+        "apiv": 1,
+        "url": tracking_data.request_url,
+        "ua": tracking_data.user_agent,
+        "action_name": tracking_data.category + "/" + tracking_data.action_name,
+    }
+
+    # Add authentication token if provided
+    if tracking_data.token:
+        data["token_auth"] = tracking_data.token
+
+    # Add custom dimensions
+    if tracking_data.os:
+        data["dimension1"] = tracking_data.os
+    if tracking_data.os_version:
+        data["dimension2"] = tracking_data.os_version
+    if tracking_data.app_version:
+        data["dimension3"] = tracking_data.app_version
+    if tracking_data.resource_id:
+        data["dimension4"] = tracking_data.resource_id
+
+    data_str = parse.urlencode(data)
+    url = f"{tracking_data.matomo_url}/matomo.php?{data_str}"
+
+    try:
+        req = urllib_request.Request(url)
+        with urllib_request.urlopen(req, timeout=10):
+            pass
+        logger.debug(
+            "Matomo tracking sent successfully for action: %s",
+            tracking_data.action_name,
+        )
+    except error.HTTPError as e:
+        # Mask the token in logs for security
+        safe_url = url
+        if tracking_data.token:
+            safe_url = url.replace(
+                f"token_auth={tracking_data.token}", "token_auth=********"
+            )
+        logger.error(
+            "Matomo tracking API request failed with HTTP error %s: %s - URL: %s",
+            e.code,
+            e.reason,
+            safe_url,
+        )
+    except error.URLError as e:
+        logger.error("Matomo tracking API request failed: %s", e.reason)
+    except (OSError, TimeoutError) as e:
+        logger.error("Unexpected error during Matomo tracking: %s", str(e))
+
+
+def matomo_tracking(
+    action_name: str,
+    category: str = "API",
+    resource_id: Optional[str] = None,
+) -> Callable:
+    """
+    Decorator for tracking API endpoint access in Matomo.
+
+    This decorator wraps DRF ViewSet action methods to send tracking data
+    asynchronously to Matomo without blocking the original request.
+
+    :param action_name: Name of the action to track (sent as action_name to Matomo)
+    :param category: Category of the event (default: "API")
+    :param resource_id: Optional URL kwarg key to extract as "id" dimension
+                        (e.g., "pk", "job_id", "unit_id")
+    :return: Decorated function
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(self, http_request, *args: Any, **kwargs: Any):
+            # Execute the original function first
+            response = func(self, http_request, *args, **kwargs)
+
+            # Skip tracking if Matomo is not configured or not enabled
+            if (
+                not settings.MATOMO_TRACKING
+                or not settings.MATOMO_URL
+                or not settings.MATOMO_SITE_ID
+            ):
+                return response
+
+            # Extract id from URL kwargs if specified
+            tracking_id = None
+            if resource_id and resource_id in kwargs:
+                tracking_id = str(kwargs[resource_id])
+
+            # Create tracking data object
+            tracking_data = MatomoTrackingData(
+                matomo_url=settings.MATOMO_URL,
+                site_id=settings.MATOMO_SITE_ID,
+                token=settings.MATOMO_TOKEN,
+                action_name=action_name,
+                category=category,
+                request_url=http_request.build_absolute_uri(),
+                user_agent=http_request.META.get("HTTP_USER_AGENT", "unknown"),
+                os=http_request.META.get("HTTP_X_OS"),
+                os_version=http_request.META.get("HTTP_X_OS_VERSION"),
+                app_version=http_request.META.get("HTTP_X_APP_VERSION"),
+                resource_id=tracking_id,
+            )
+
+            # Send tracking request asynchronously using the thread pool
+            _executor.submit(send_matomo_tracking, tracking_data)
+
+            return response
+
+        return wrapper
+
+    return decorator

--- a/lunes_cms/api/v2/views/job_units_viewset.py
+++ b/lunes_cms/api/v2/views/job_units_viewset.py
@@ -2,6 +2,7 @@ from django.db.models import Q, Count
 from rest_framework import viewsets
 from rest_framework.exceptions import PermissionDenied
 
+from ..matomo_tracking import matomo_tracking
 from ..serializers import UnitSerializer
 from ....cmsv2.models import Unit, Job
 
@@ -14,6 +15,16 @@ class JobUnitsViewSet(viewsets.ModelViewSet):
     serializer_class = UnitSerializer
     http_method_names = ["get"]
 
+    @matomo_tracking(action_name="All units of job", resource_id="job_id")
+    def list(self, request, *args, **kwargs):
+        """List all units of a job with Matomo tracking."""
+        return super().list(request, *args, **kwargs)
+
+    @matomo_tracking(action_name="Unit", resource_id="pk")
+    def retrieve(self, request, *args, **kwargs):
+        """Retrieve a single unit with Matomo tracking."""
+        return super().retrieve(request, *args, **kwargs)
+
     def get_queryset(self):
         """
         Get the queryset of all released units of a job
@@ -25,14 +36,16 @@ class JobUnitsViewSet(viewsets.ModelViewSet):
             return Unit.objects.none()
 
         try:
-            job = Job.objects.get(id=self.kwargs["job_id"])
+            job = Job.objects.get(resource_id=self.kwargs["job_id"])
         except Job.DoesNotExist as e:
             raise PermissionDenied() from e
 
         if not job.released:
             raise PermissionDenied()
 
-        queryset = Unit.objects.filter(jobs__id=job.id, released=True).annotate(
+        queryset = Unit.objects.filter(
+            jobs__resource_id=job.id, released=True
+        ).annotate(
             number_words=Count(
                 "unit_word_relations",
                 filter=Q(

--- a/lunes_cms/api/v2/views/job_viewset.py
+++ b/lunes_cms/api/v2/views/job_viewset.py
@@ -1,8 +1,9 @@
 from django.db.models import Count, Q
 from rest_framework import viewsets
 
-from ....cmsv2.models import Job
+from ..matomo_tracking import matomo_tracking
 from ..serializers import JobSerializer
+from ....cmsv2.models import Job
 
 
 class JobViewSet(viewsets.ModelViewSet):
@@ -12,6 +13,11 @@ class JobViewSet(viewsets.ModelViewSet):
 
     serializer_class = JobSerializer
     http_method_names = ["get"]
+
+    @matomo_tracking(action_name="All jobs")
+    def list(self, request, *args, **kwargs):
+        """List all jobs with Matomo tracking."""
+        return super().list(request, *args, **kwargs)
 
     def get_queryset(self):
         """

--- a/lunes_cms/api/v2/views/job_words_viewset.py
+++ b/lunes_cms/api/v2/views/job_words_viewset.py
@@ -2,8 +2,9 @@ from django.db.models import Q, OuterRef, Prefetch, Exists
 from rest_framework import viewsets
 from rest_framework.exceptions import PermissionDenied
 
-from ....cmsv2.models import Job, Word
+from ..matomo_tracking import matomo_tracking
 from ..serializers import WordSerializer
+from ....cmsv2.models import Job, Word
 from ....cmsv2.models.unit import UnitWordRelation
 
 
@@ -19,6 +20,16 @@ class JobWordsViewSet(viewsets.ModelViewSet):
     serializer_class = WordSerializer
     http_method_names = ["get"]
 
+    @matomo_tracking(action_name="All words of job", resource_id="job_id")
+    def list(self, request, *args, **kwargs):
+        """List all words of a job with Matomo tracking."""
+        return super().list(request, *args, **kwargs)
+
+    @matomo_tracking(action_name="Word", resource_id="pk")
+    def retrieve(self, request, *args, **kwargs):
+        """Retrieve a single word with Matomo tracking."""
+        return super().retrieve(request, *args, **kwargs)
+
     def get_queryset(self):
         """
         Get the queryset of words
@@ -30,7 +41,7 @@ class JobWordsViewSet(viewsets.ModelViewSet):
             return Word.objects.none()
 
         try:
-            job = Job.objects.get(id=self.kwargs["job_id"])
+            job = Job.objects.get(resource_id=self.kwargs["job_id"])
         except Job.DoesNotExist as e:
             raise PermissionDenied() from e
 
@@ -47,7 +58,7 @@ class JobWordsViewSet(viewsets.ModelViewSet):
         )
         queryset = (
             Word.objects.filter(
-                Exists(unit_word_relations.filter(word__id=OuterRef("id")))
+                Exists(unit_word_relations.filter(word__resource_id=OuterRef("id")))
             )
             .prefetch_related(
                 Prefetch(

--- a/lunes_cms/api/v2/views/unit_words_viewset.py
+++ b/lunes_cms/api/v2/views/unit_words_viewset.py
@@ -2,8 +2,9 @@ from django.db.models import Q
 from rest_framework import viewsets
 from rest_framework.exceptions import PermissionDenied
 
-from ....cmsv2.models import Unit
+from ..matomo_tracking import matomo_tracking
 from ..serializers import UnitWordRelationSerializer
+from ....cmsv2.models import Unit
 from ....cmsv2.models.unit import UnitWordRelation
 
 
@@ -14,6 +15,16 @@ class UnitWordViewSet(viewsets.ModelViewSet):
 
     serializer_class = UnitWordRelationSerializer
     http_method_names = ["get"]
+
+    @matomo_tracking(action_name="All words of unit", resource_id="unit_id")
+    def list(self, request, *args, **kwargs):
+        """List all words of a unit with Matomo tracking."""
+        return super().list(request, *args, **kwargs)
+
+    @matomo_tracking(action_name="Word", resource_id="pk")
+    def retrieve(self, request, *args, **kwargs):
+        """Retrieve a single word with Matomo tracking."""
+        return super().retrieve(request, *args, **kwargs)
 
     def get_queryset(self):
         """
@@ -26,7 +37,7 @@ class UnitWordViewSet(viewsets.ModelViewSet):
             return UnitWordRelation.objects.none()
 
         units = Unit.objects.filter(
-            id=self.kwargs["unit_id"], released=True, jobs__released=True
+            resource_id=self.kwargs["unit_id"], released=True, jobs__released=True
         ).distinct()
         if len(units) != 1:
             raise PermissionDenied()

--- a/lunes_cms/api/v2/views/word_viewset.py
+++ b/lunes_cms/api/v2/views/word_viewset.py
@@ -1,7 +1,8 @@
 from rest_framework import viewsets
 
-from ....cmsv2.models import Word
+from ..matomo_tracking import matomo_tracking
 from ..serializers import WordSerializer
+from ....cmsv2.models import Word
 
 
 class WordViewSet(viewsets.ModelViewSet):
@@ -11,6 +12,16 @@ class WordViewSet(viewsets.ModelViewSet):
 
     serializer_class = WordSerializer
     http_method_names = ["get"]
+
+    @matomo_tracking(action_name="All words")
+    def list(self, request, *args, **kwargs):
+        """List all words with Matomo tracking."""
+        return super().list(request, *args, **kwargs)
+
+    @matomo_tracking(action_name="Word", resource_id="pk")
+    def retrieve(self, request, *args, **kwargs):
+        """Retrieve a single word with Matomo tracking."""
+        return super().retrieve(request, *args, **kwargs)
 
     def get_queryset(self):
         """

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -31,6 +31,22 @@ TRAININGSET_MIN_DOCS = int(os.environ.get("LUNES_CMS_TRAININGSET_MIN_DOCS", 4))
 #: API Key for OpenAI
 OPENAI_API_KEY = os.environ.get("LUNES_CMS_OPENAI_API_KEY")
 
+###################
+# MATOMO TRACKING #
+###################
+
+#: Whether Matomo tracking is enabled
+MATOMO_TRACKING = bool(strtobool(os.environ.get("LUNES_CMS_MATOMO_ENABLED", "False")))
+
+#: URL of the Matomo instance (e.g., "https://matomo.example.com")
+MATOMO_URL = os.environ.get("LUNES_CMS_MATOMO_URL", "")
+
+#: Site ID in Matomo
+MATOMO_SITE_ID = os.environ.get("LUNES_CMS_MATOMO_SITE_ID", "")
+
+#: Authentication token for Matomo API
+MATOMO_TOKEN = os.environ.get("LUNES_CMS_MATOMO_TOKEN", "")
+
 ########################
 # DJANGO CORE SETTINGS #
 ########################

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-18 15:51+0000\n"
+"POT-Creation-Date: 2026-02-23 12:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -823,19 +823,19 @@ msgstr "Vokabel"
 msgid "Generate Audio"
 msgstr "Audio generieren"
 
-#: core/settings.py:211
+#: core/settings.py:227
 msgid "English"
 msgstr "Englisch"
 
-#: core/settings.py:212
+#: core/settings.py:228
 msgid "German"
 msgstr "Deutsch"
 
-#: core/settings.py:468 core/settings.py:469 core/settings.py:471
+#: core/settings.py:484 core/settings.py:485 core/settings.py:487
 msgid "Lunes Administration"
 msgstr "Lunes-Verwaltung"
 
-#: core/settings.py:470
+#: core/settings.py:486
 msgid "Welcome to the vocabulary management of Lunes!"
 msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 


### PR DESCRIPTION
- Added Matomo configuration via environment variables (`LUNES_CMS_MATOMO_ENABLED`, `LUNES_CMS_MATOMO_URL`, `LUNES_CMS_MATOMO_SITE_ID`, `LUNES_CMS_MATOMO_TOKEN`) following the existing project pattern
- Created `@matomo_tracking` decorator that sends tracking data asynchronously using a ThreadPoolExecutor (10 workers), ensuring API responses are not blocked by tracking requests
- Tracking includes custom dimensions: dimension1 (OS), dimension2 (OS version), dimension3 (app version), dimension4 (resource ID) - extracted from the X-os, X-os-version, X-app-version headers
- Applied tracking to API v2 endpoints: `/jobs/`, `/jobs/{id}/units/`, `/jobs/{id}/words/`, `/units/{id}/words/`, `/words/` with appropriate action names like "All jobs", "All units of job", "Word", etc.
- Error handling with logging: Tracking failures are logged but never impact the API response; auth tokens are masked in error logs for security