### PR TITLE
467: Add csv import and export

### DIFF
--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -1,11 +1,20 @@
 from __future__ import absolute_import, unicode_literals
 
+import io
+from zipfile import ZipFile
+
 from django.contrib import admin
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+from tablib import Dataset
 
-from ..models import Unit
+from ..models import Unit, Word
+from ..utils import make_safe_filename
 from .base import BaseAdmin
+from .word_export_resource import WordExportResource
 
 
 class UnitInline(admin.TabularInline):
@@ -74,8 +83,9 @@ class JobAdmin(BaseAdmin):
         "image_tag",
         "created_by",
         "released",
+        "import_csv_link",
     ]
-    readonly_fields = ["created_by", "image_tag", "migrated_status"]
+    readonly_fields = ["created_by", "image_tag", "migrated_status", "import_csv_link"]
     inlines = [UnitInline]
     search_fields = ["name"]
     list_display = [
@@ -88,8 +98,11 @@ class JobAdmin(BaseAdmin):
     ]
     list_display_links = ["name"]
     list_filter = ["released", MigratedFilter]
+    actions = ["export_to_csv"]
     list_per_page = 25
     ordering = ["name"]
+    change_list_template = "admin/cmsv2/import_csv_button.html"
+    change_form_template = "admin/cmsv2/save_and_import_button.html"
 
     class Media:
         """
@@ -151,3 +164,58 @@ class JobAdmin(BaseAdmin):
         )
 
     migrated_status.short_description = _("migrated")  # type: ignore[attr-defined]
+
+    @admin.action(description=_("Export all vocabulary for these jobs to CSV"))
+    def export_to_csv(self, request, queryset):
+        """
+        Export the words of the selected jobs.
+
+        :param request: current user request
+        :type request: django.http.request
+        :param queryset: current queryset
+        :type queryset: QuerySet
+        """
+        csvs = {}
+
+        for profession in queryset:
+            resource = WordExportResource()
+            units = Unit.objects.filter(jobs=profession)
+            words = Word.objects.filter(units__in=units).distinct()
+
+            dataset = Dataset(
+                *(resource.export_resource(word) for word in words),
+                headers=resource.export().headers,
+            )
+
+            csvs[profession] = dataset.csv
+
+        zip_buffer = io.BytesIO()
+
+        with ZipFile(zip_buffer, "w") as zipfile:
+            for profession, csv in csvs.items():
+                zipfile.writestr(f"{make_safe_filename(profession.name)}.csv", csv)
+
+        response = HttpResponse(zip_buffer.getvalue(), content_type="application/zip")
+        response["Content-Disposition"] = 'attachment; filename="Lunes_vocabulary.zip"'
+        return response
+
+    def response_add(self, request, obj, post_url_continue=None):
+        if "_save_and_import" in request.POST:
+            return redirect(reverse("cmsv2:import_csv_for_job", args=[obj.pk]))
+        return super().response_add(request, obj, post_url_continue)
+
+    def response_change(self, request, obj):
+        if "_save_and_import" in request.POST:
+            return redirect(reverse("cmsv2:import_csv_for_job", args=[obj.pk]))
+        return super().response_change(request, obj)
+
+    def import_csv_link(self, obj) -> str:
+        """
+        Add link/button for importing csv files from job list view
+        """
+        if obj.pk:
+            url = reverse("cmsv2:import_csv_for_job", args=[obj.pk])
+            return format_html('<a class="button" href="{}">Import CSV</a>', url)
+        return "—"
+
+    import_csv_link.short_description = _("Import")  # type: ignore[attr-defined]

--- a/lunes_cms/cmsv2/admins/word_export_resource.py
+++ b/lunes_cms/cmsv2/admins/word_export_resource.py
@@ -1,0 +1,108 @@
+from django.utils.translation import gettext_lazy as _
+from import_export import fields, resources
+from import_export.admin import ExportActionMixin
+
+from ..models import Word
+from ..models.static import Static
+
+
+class WordExportResource(resources.ModelResource):
+    """
+    Resource to export words from the job view.
+    """
+
+    # pylint: disable=pointless-statement
+    ExportActionMixin.export_admin_action
+
+    # pylint: disable=super-init-not-called
+    def __init__(self, for_profession=None):
+        self.for_profession = for_profession
+        self.relevant_units = (
+            for_profession.get_nested_units() if for_profession else None
+        )
+
+    word = fields.Field(column_name=_("Word"), attribute="word")
+
+    word_type = fields.Field(column_name=_("Word type"), attribute="word_type")
+
+    singular_article = fields.Field(
+        column_name=_("Singular Article"),
+        attribute="singular_article",
+    )
+
+    def dehydrate_singular_article(self, word):
+        """
+        Method to show the actual singular article and not their integer.
+        """
+        for article_choice in Static.singular_article_choices:
+            if article_choice[0] == word.singular_article:
+                return article_choice[1]
+        return "-"
+
+    plural_article = fields.Field(
+        column_name=_("Plural Article"),
+        attribute="plural_article_choices",
+    )
+
+    def dehydrate_plural_article(self, word):
+        """
+        Method to show the actual plural article and not their integer.
+        """
+        for article_choice in Static.plural_article_choices:
+            if article_choice[0] == word.plural_article:
+                return article_choice[1]
+        return "-"
+
+    has_audio = fields.Field(column_name=_("Has audio?"), attribute="word")
+
+    def dehydrate_has_audio(self, word):
+        """
+        Returns yes if audio exists and no if it doesn't.
+        """
+        if word.audio:
+            return _("Yes")
+        return _("No")
+
+    example_sentence = fields.Field(
+        column_name=_("Example sentence"), attribute="example_sentence"
+    )
+
+    creation_date = fields.Field(
+        column_name=_("Creation date"), attribute="creation_date"
+    )
+
+    def dehydrate_creation_date(self, word):
+        """
+        Only show first 16 characters of date (date, and hours & minutes).
+        """
+        return word.creation_date.strftime("%d.%m.%Y %H:%M")
+
+    units = fields.Field(column_name=_("Units"), attribute="units")
+
+    def dehydrate_units(self, word):
+        """
+        Method to get relevant units.
+        """
+        relevant_units = (
+            self.relevant_units
+            if self.relevant_units
+            else word.units.values_list("id", flat=True)
+        )
+        return " | ".join([t.title for t in word.units.filter(id__in=relevant_units)])
+
+    class Meta:
+        """
+        Meta class of word resource
+        """
+
+        model = Word
+        fields = (
+            "word",
+            "word_type",
+            "singular_article",
+            "plural_article",
+            "has_audio",
+            "example_sentence",
+            "creation_date",
+            "units",
+        )

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -1,0 +1,228 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from django.utils.translation import gettext_lazy as _
+from tablib import Dataset
+
+from ..models import Job, Static, Unit, Word
+
+logger = logging.getLogger(__name__)
+
+
+COLUMN_MAPPING: dict[str, str] = {
+    "Einheit": "unit",
+    "Sinneinheit": "unit",
+    "Sinneseinheit": "unit",
+    "Fachbegriff": "word",
+    "Begriff": "word",
+    "Vokabel": "word",
+    "Artikel": "article",
+    "Beispielsatz": "example",
+}
+
+
+@dataclass(frozen=True)
+class ParsedRow:
+    """
+    Cleaned data for a single row
+    """
+
+    unit: str
+    word: str
+    article: str
+    example: str = ""
+
+
+class InvalidRowError(ValueError):
+    """
+    Error for rows that are invalid
+    """
+
+    pass  # pylint: disable=unnecessary-pass
+
+
+@dataclass
+class RowResult:
+    """
+    Return object of a single row.
+    """
+
+    created: int = 0
+    updated: int = 0
+    error: Optional[str] = None
+
+
+def map_article_to_int(article: str) -> int:
+    """
+    Converts article string to article int in DB.
+    """
+    ARTICLE_MAP: dict[str, int] = {
+        label.lower(): value for value, label in Static.singular_article_choices
+    } | {"": 0}
+    return ARTICLE_MAP.get(article, 0)
+
+
+def create_unit(unit_title: str, job: Job) -> Unit:
+    """
+    Create a new unit - even if one already exists with the same title.
+    """
+    unit = Unit.objects.create(title=unit_title)
+    unit.jobs.add(job)
+    return unit
+
+
+def create_word(word_text: str, singular_article: int) -> Word:
+    """
+    Creates a new word object.
+    """
+    return Word.objects.create(word=word_text, singular_article=singular_article)
+
+
+def update_or_add_example_sentence(word_obj: Word, word_defaults: dict) -> None:
+    """
+    Adds or edits example sentence to word object.
+    """
+    if word_obj.example_sentence != word_defaults["example_sentence"]:
+        word_obj.example_sentence = word_defaults["example_sentence"]
+        word_obj.save(update_fields=["example_sentence"])
+
+
+def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
+    """
+    Parses a single row and returns either a ParsedRow or a RowResult (error).
+    """
+    try:
+        mapped = {
+            COLUMN_MAPPING[key.strip()]: (
+                value.strip() if isinstance(value, str) else value
+            )
+            for key, value in raw_row.items()
+            if key and COLUMN_MAPPING.get(key.strip())
+        }
+
+        if not mapped:
+            raise InvalidRowError(
+                _("Row %(n)s: No recognised columns – row will be skipped.")
+                % {"n": row_number}
+            )
+
+        unknown_keys = {
+            k.strip() for k in raw_row.keys() if k and not COLUMN_MAPPING.get(k.strip())
+        }
+        if unknown_keys:
+            logger.info(
+                "Row %s contains unexpected columns: %s",
+                row_number,
+                ", ".join(sorted(unknown_keys)),
+            )
+
+        unit = mapped.get("unit", "")
+        if not unit:
+            return RowResult(
+                error=_("Row %(n)s: Unit column is empty, row will be skipped.")
+                % {"n": row_number}
+            )
+
+        word = mapped.get("word", "")
+        if not word:
+            return RowResult(
+                error=_("Row %(n)s: Vocabulary column is empty, row will be skipped.")
+                % {"n": row_number}
+            )
+
+        article = mapped.get("article", "").lower()
+        example = mapped.get("example", "")
+
+        return ParsedRow(unit=unit, word=word, article=article, example=example)
+
+    except (AttributeError, TypeError) as exc:
+        logger.warning("Row %s – malformed column data: %s", row_number, exc)
+        return RowResult(
+            error=_("Row %(n)s: Malformed column data – %(e)s")
+            % {"n": row_number, "e": exc}
+        )
+    except InvalidRowError as exc:
+        logger.info("Row %s skipped: %s", row_number, exc)
+        return RowResult(error=str(exc))
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.exception("Unexpected error while parsing row %s", row_number)
+        return RowResult(
+            error=_("Row %(n)s: Unexpected parsing error – %(e)s")
+            % {"n": row_number, "e": exc}
+        )
+
+
+def process_row(
+    parsed: ParsedRow,
+    job: Job,
+    created_units: Dict[str, Unit],
+) -> RowResult:
+    """
+    Processes a single parsed row.
+
+    If unit is not yet in ``created_units`` cache, a new unit gets created, even if there is already one in the system with the same name.
+    If there is a unit in the cache, use that one
+    Update example sentence
+    Add word to newly created unit
+    """
+    created = 0
+    updated = 0
+
+    unit = created_units.get(parsed.unit)
+    if unit is None:
+        unit = create_unit(parsed.unit, job)
+        created_units[parsed.unit] = unit
+        created += 1
+    else:
+        if not unit.jobs.filter(pk=job.pk).exists():
+            unit.jobs.add(job)
+
+    article_int = map_article_to_int(parsed.article)
+    word = create_word(parsed.word, article_int)
+    created += 1
+
+    update_or_add_example_sentence(word, {"example_sentence": parsed.example})
+
+    unit.words.add(word)
+
+    return RowResult(created=created, updated=updated)
+
+
+def import_words_from_csv(dataset: Dataset, job: Job) -> Tuple[int, int, list[str]]:
+    """
+    Imports the entire csv dataset to a job.
+    Returns a tuple of created_count, updated_count, error_messages
+
+    Important: During the import there is a local cache ``created_units`` because of the following scenario:
+    In the CSV file there are ten words for the unit "tools"
+    There is already a unit called "tools" in the system
+    What we want to happen is: a second unit "tools" is created, distinct from the one that already exists. All words
+    in the CSV file gets imported into that second instance of "tools".
+    """
+    total_created = 0
+    total_updated = 0
+    error_messages: list[str] = []
+
+    created_units: Dict[str, Unit] = {}
+
+    for row_number, raw_row in enumerate(dataset.dict, start=1):
+        parsed_or_error = parse_row(raw_row, row_number)
+
+        if isinstance(parsed_or_error, RowResult):
+            if parsed_or_error.error:
+                error_messages.append(parsed_or_error.error)
+            continue
+
+        result = process_row(parsed_or_error, job, created_units)
+
+        if result.error:
+            error_messages.append(
+                _("Row %(n)s: %(msg)s") % {"n": row_number, "msg": result.error}
+            )
+            continue
+
+        total_created += result.created
+        total_updated += result.updated
+
+    return total_created, total_updated, error_messages

--- a/lunes_cms/cmsv2/models/__init__.py
+++ b/lunes_cms/cmsv2/models/__init__.py
@@ -1,4 +1,5 @@
 from .feedback import Feedback
 from .job import Job
+from .static import Static
 from .unit import Unit
 from .word import Word

--- a/lunes_cms/cmsv2/templates/admin/cmsv2/import_csv_button.html
+++ b/lunes_cms/cmsv2/templates/admin/cmsv2/import_csv_button.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    <a href="{% url 'cmsv2:import_csv' %}" class="btn {{ jazzmin_ui.button_classes.success }} float-right">
+        <i class="fa fa-file-import"></i> &nbsp; {% trans "Import CSV" %}
+    </a>
+{% endblock %}

--- a/lunes_cms/cmsv2/templates/admin/cmsv2/save_and_import_button.html
+++ b/lunes_cms/cmsv2/templates/admin/cmsv2/save_and_import_button.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block submit_buttons_bottom %}
+    {{ block.super }}
+    <div class="{% if not job %}mt-3{% endif %} form-group">
+        <input
+            type="submit"
+            class="btn {{ jazzmin_ui.button_classes.info }} form-control"
+            value="{% trans 'Save and import words' %}"
+            name="_save_and_import"
+        >
+    </div>
+{% endblock %}

--- a/lunes_cms/cmsv2/templates/admin/csv_form.html
+++ b/lunes_cms/cmsv2/templates/admin/csv_form.html
@@ -1,0 +1,68 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block title %}{% trans "Import CSV" %}{% endblock %}
+
+{% block breadcrumbs %}
+<ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'admin:cmsv2_job_changelist' %}">{% trans 'Jobs' %}</a></li>
+    {% if job %}
+    <li class="breadcrumb-item"><a href="{% url 'admin:cmsv2_job_change' job.pk %}">{{ job.name }}</a></li>
+    {% endif %}
+    <li class="breadcrumb-item active">{% trans "Import CSV" %}</li>
+</ol>
+{% endblock %}
+
+{% block content_title %}{% trans "Import CSV" %}{% endblock %}
+
+{% block content %}
+<div id="content-main" class="col-12">
+    <form method="post" enctype="multipart/form-data" action="{{ import_csv_url }}">
+        {% csrf_token %}
+        <div class="row">
+            <div class="col-12 col-lg-9">
+                <div class="card">
+                    <div class="card-body">
+                        {% for field in form %}
+                        <div class="form-group">
+                            {{ field.label_tag }}
+                            {% if forloop.first and job %}
+                            <b>{{ job.name }}</b>
+                            {% endif %}
+                            {{ field }}
+                            {% if field.help_text %}
+                            <small class="form-text text-muted">{{ field.help_text }}</small>
+                            {% endif %}
+                            {% for error in field.errors %}
+                            <div class="alert alert-danger">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-3">
+                <div class="{{ jazzmin_ui.actions_classes }}">
+                    <div class="form-group">
+                        <button type="submit" class="btn {{ jazzmin_ui.button_classes.success }} form-control">
+                            {% trans "Start import" %}
+                        </button>
+                    </div>
+                    <div class="form-group">
+                        {% if job %}
+                        <a href="{% url 'admin:cmsv2_job_change' job.pk %}" class="btn {{ jazzmin_ui.button_classes.danger }} form-control">
+                            {% trans "Cancel" %}
+                        </a>
+                        {% else %}
+                        <a href="{% url 'admin:cmsv2_job_changelist' %}" class="btn {{ jazzmin_ui.button_classes.danger }} form-control">
+                            {% trans "Cancel" %}
+                        </a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/lunes_cms/cmsv2/urls.py
+++ b/lunes_cms/cmsv2/urls.py
@@ -5,6 +5,12 @@ from . import views
 app_name = "cmsv2"
 
 urlpatterns = [
+    path("jobs/import-csv/", views.import_from_csv, name="import_csv"),
+    path(
+        "jobs/<int:job_id>/import-csv/",
+        views.import_from_csv,
+        name="import_csv_for_job",
+    ),
     path(
         "jobs/<int:job_id>/update-icon/", views.update_job_icon, name="update_job_icon"
     ),

--- a/lunes_cms/cmsv2/utils.py
+++ b/lunes_cms/cmsv2/utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pathlib
+import re
 import string
 import uuid
 import warnings
@@ -190,3 +191,10 @@ def is_not_blank(s):
     Checks if s is not an empty string.
     """
     return s is not None and s.strip() != ""
+
+
+def make_safe_filename(unsafe):
+    """
+    Method to create a safe filename with regex.
+    """
+    return re.sub(r"[^a-zA-Z0-9.äöüÄÖÜ]+", "_", unsafe)

--- a/lunes_cms/cmsv2/views/__init__.py
+++ b/lunes_cms/cmsv2/views/__init__.py
@@ -1,4 +1,5 @@
 from .generate_image import generate_image_via_openai
+from .import_csv_view import import_from_csv
 from .unitword_generate_example_sentence_audio import (
     unitword_generate_example_sentence_audio,
     unitword_generate_example_sentence_audio_via_openai,
@@ -32,6 +33,7 @@ from .word_generate_image import (
 )
 
 __all__ = [
+    "import_from_csv",
     "generate_image_via_openai",
     "unitword_generate_image",
     "unitword_store_generated_image_permanently",

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -1,0 +1,118 @@
+from django import forms
+from django.contrib import admin, messages
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from tablib import Dataset
+from tablib.exceptions import InvalidDimensions
+
+from ..admins.word_import_resource import import_words_from_csv
+from ..models import Job
+
+
+class ImportCSVForm(forms.Form):
+    """
+    Form for importing a CSV file.
+    """
+
+    job = forms.ModelChoiceField(
+        queryset=Job.objects.all().order_by("name"),
+        label=_("Job"),
+        required=True,
+    )
+    csv_file = forms.FileField(
+        label=_("Select CSV file"),
+        help_text=_(
+            'The file should contain the columns "Einheit", "Artikel", "Vokabel" and "Beispielsatz".'
+        ),
+    )
+
+
+def _build_context(
+    request: HttpRequest, form: ImportCSVForm, job: Job | None, job_id: int | None
+) -> dict:
+    """
+    Method to build the context for the admin view.
+    """
+    import_url = (
+        reverse("cmsv2:import_csv_for_job", args=[job_id])
+        if job_id
+        else reverse("cmsv2:import_csv")
+    )
+    return {
+        **admin.site.each_context(request),
+        "form": form,
+        "job": job,
+        "title": _("CSV import for vocabulary"),
+        "import_csv_url": import_url,
+    }
+
+
+@staff_member_required
+def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResponse:
+    """
+    Method for importing vocabularies for a job from csv
+    """
+    job = get_object_or_404(Job, pk=job_id) if job_id else None
+
+    if request.method != "POST":
+        initial = {"job": job} if job else {}
+        form = ImportCSVForm(initial=initial)
+        if job:
+            form.fields["job"].widget = forms.HiddenInput()
+        return render(
+            request, "admin/csv_form.html", _build_context(request, form, job, job_id)
+        )
+
+    form = ImportCSVForm(request.POST, request.FILES)
+    if job:
+        form.fields["job"].widget = forms.HiddenInput()
+
+    if not form.is_valid():
+        return render(
+            request, "admin/csv_form.html", _build_context(request, form, job, job_id)
+        )
+
+    csv_file = form.cleaned_data["csv_file"]
+    selected_job = form.cleaned_data["job"]
+    try:
+        data = Dataset()
+        data.load(csv_file.read().decode("utf-8"), format="csv")
+        created_count, updated_count, errors = import_words_from_csv(data, selected_job)
+
+        if errors:
+            error_summary = " | ".join(errors[:5])
+            messages.warning(
+                request,
+                _("Import completed with warnings: %(summary)s")
+                % {"summary": error_summary},
+            )
+        else:
+            messages.success(
+                request,
+                _("Import successful! %(created)s new entries, %(updated)s updated.")
+                % {"created": created_count, "updated": updated_count},
+            )
+        return redirect(reverse("admin:cmsv2_job_change", args=[selected_job.pk]))
+
+    except InvalidDimensions:
+        messages.error(
+            request,
+            _(
+                "Import failed. The size of the column or row doesn't fit the table dimensions. Please adjust your table and try again."
+            ),
+        )
+        return render(
+            request, "admin/csv_form.html", _build_context(request, form, job, job_id)
+        )
+    except (AttributeError, TypeError, ValueError) as e:
+        messages.error(
+            request,
+            _("Import failed: %(e)s") % {"e": e},
+        )
+
+        return render(
+            request, "admin/csv_form.html", _build_context(request, form, job, job_id)
+        )

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-04 13:25+0000\n"
+"POT-Creation-Date: 2026-03-12 11:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -94,7 +94,7 @@ msgstr "Ausgewählte Modulgruppen zurückhalten"
 
 #: cms/admins/discipline_admin.py:284
 msgid "Export all vocabulary for this discipline to CSV"
-msgstr "Alle Vokabeln dieser Modulgruppe als CSV exportieren"
+msgstr "Alle Vokabeln dieser Modulgruppe aus CSV importieren"
 
 #: cms/admins/discipline_admin.py:324
 msgid "released modules"
@@ -135,41 +135,42 @@ msgstr "Bild"
 msgid "singular article"
 msgstr "Singular-Artikel"
 
-#: cms/admins/document_resource.py:24 cmsv2/models/word.py:291
+#: cms/admins/document_resource.py:24 cmsv2/admins/word_export_resource.py:24
+#: cmsv2/models/word.py:291
 msgid "Word"
 msgstr "Vokabel"
 
-#: cms/admins/document_resource.py:26
+#: cms/admins/document_resource.py:26 cmsv2/admins/word_export_resource.py:26
 msgid "Word type"
 msgstr "Wortart"
 
-#: cms/admins/document_resource.py:29
+#: cms/admins/document_resource.py:29 cmsv2/admins/word_export_resource.py:29
 msgid "Singular Article"
 msgstr "Singular Artikel"
 
-#: cms/admins/document_resource.py:43
+#: cms/admins/document_resource.py:43 cmsv2/admins/word_export_resource.py:43
 msgid "Plural Article"
 msgstr "Plural Artikel"
 
-#: cms/admins/document_resource.py:56
+#: cms/admins/document_resource.py:56 cmsv2/admins/word_export_resource.py:56
 msgid "Has audio?"
 msgstr "Audio"
 
 #: cms/admins/document_resource.py:63 cmsv2/admins/word_admin.py:25
-#: cmsv2/admins/word_admin.py:75
+#: cmsv2/admins/word_admin.py:75 cmsv2/admins/word_export_resource.py:63
 msgid "Yes"
 msgstr "Ja"
 
 #: cms/admins/document_resource.py:64 cmsv2/admins/word_admin.py:26
-#: cmsv2/admins/word_admin.py:76
+#: cmsv2/admins/word_admin.py:76 cmsv2/admins/word_export_resource.py:64
 msgid "No"
 msgstr "Nein"
 
-#: cms/admins/document_resource.py:67
+#: cms/admins/document_resource.py:67 cmsv2/admins/word_export_resource.py:67
 msgid "Example sentence"
 msgstr "Beispielsatz"
 
-#: cms/admins/document_resource.py:71
+#: cms/admins/document_resource.py:71 cmsv2/admins/word_export_resource.py:71
 msgid "Creation date"
 msgstr "Erstellt am"
 
@@ -561,6 +562,7 @@ msgstr ""
 
 #: cms/templates/admin/delete_confirmation.html:16
 #: cms/templates/admin/delete_selected_confirmation.html:15
+#: cmsv2/templates/admin/csv_form.html:8
 #: cmsv2/templates/admin/generate_audio_base.html:9
 #: cmsv2/templates/admin/generate_image_base.html:9
 msgid "Home"
@@ -645,7 +647,7 @@ msgstr "Zusammenfassung"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: cms/utils.py:164 cmsv2/utils.py:149
+#: cms/utils.py:164 cmsv2/utils.py:150
 msgid "and"
 msgstr "und"
 
@@ -661,34 +663,42 @@ msgstr "Datei zu groß! Max. 5 MB"
 msgid "Only use one file extension!"
 msgstr "Nur maximal ein Dateityp erlaubt!"
 
-#: cmsv2/admins/job_admin.py:29 cmsv2/admins/unit_admin.py:42
+#: cmsv2/admins/job_admin.py:38 cmsv2/admins/unit_admin.py:42
 #: cmsv2/admins/word_admin.py:115
 msgid "migration status"
 msgstr "Ablaufdatum"
 
-#: cmsv2/admins/job_admin.py:40 cmsv2/admins/unit_admin.py:53
+#: cmsv2/admins/job_admin.py:49 cmsv2/admins/unit_admin.py:53
 #: cmsv2/admins/word_admin.py:126
 msgid "Migrated from old data model"
 msgstr "Migriert aus altem Datenmodell"
 
-#: cmsv2/admins/job_admin.py:41 cmsv2/admins/unit_admin.py:54
+#: cmsv2/admins/job_admin.py:50 cmsv2/admins/unit_admin.py:54
 #: cmsv2/admins/word_admin.py:127
 msgid "Not migrated from old data model"
 msgstr "Nicht migriert aus altem Datenmodell"
 
-#: cmsv2/admins/job_admin.py:117
+#: cmsv2/admins/job_admin.py:130
 msgid "units"
 msgstr "Einheiten"
 
-#: cmsv2/admins/job_admin.py:131 cmsv2/admins/unit_admin.py:165
+#: cmsv2/admins/job_admin.py:144 cmsv2/admins/unit_admin.py:165
 #: cmsv2/models/job.py:34 cmsv2/models/unit.py:313
 msgid "created at"
 msgstr "Erstellt"
 
-#: cmsv2/admins/job_admin.py:153 cmsv2/admins/unit_admin.py:187
+#: cmsv2/admins/job_admin.py:166 cmsv2/admins/unit_admin.py:187
 #: cmsv2/admins/word_admin.py:711
 msgid "migrated"
 msgstr "Migriert"
+
+#: cmsv2/admins/job_admin.py:168
+msgid "Export all vocabulary for these jobs to CSV"
+msgstr "Alle Vokabeln dieser Berufe als CSV exportieren"
+
+#: cmsv2/admins/job_admin.py:221
+msgid "Import"
+msgstr "Import"
 
 #: cmsv2/admins/unit_admin.py:132
 msgid "jobs"
@@ -740,6 +750,40 @@ msgstr "Audio Prüfstatus"
 msgid "image check status"
 msgstr "Bild Prüfstatus"
 
+#: cmsv2/admins/word_export_resource.py:80 cmsv2/models/unit.py:391
+msgid "Units"
+msgstr "Einheit"
+
+#: cmsv2/admins/word_import_resource.py:106
+#, python-format
+msgid "Row %(n)s: No recognised columns – row will be skipped."
+msgstr "Zeile %(n)s: Die Spalte Einheit ist leer, wird übersprungen."
+
+#: cmsv2/admins/word_import_resource.py:123
+#, python-format
+msgid "Row %(n)s: Unit column is empty, row will be skipped."
+msgstr "Zeile %(n)s: Die Spalte Einheit ist leer, wird übersprungen."
+
+#: cmsv2/admins/word_import_resource.py:130
+#, python-format
+msgid "Row %(n)s: Vocabulary column is empty, row will be skipped."
+msgstr "Zeile %(n)s: Die Spalte Vokabel ist leer, wird übersprungen."
+
+#: cmsv2/admins/word_import_resource.py:142
+#, python-format
+msgid "Row %(n)s: Malformed column data – %(e)s"
+msgstr "Zeile %(n)s: Fehlerhafte Spaltendaten – %(e)s"
+
+#: cmsv2/admins/word_import_resource.py:151
+#, python-format
+msgid "Row %(n)s: Unexpected parsing error – %(e)s"
+msgstr "Zeile %(n)s: Unerwarteter Fehler - %(e)s"
+
+#: cmsv2/admins/word_import_resource.py:221
+#, python-format
+msgid "Row %(n)s: %(msg)s"
+msgstr "Zeile %(n)s: %(msg)s"
+
 #: cmsv2/apps.py:14 cmsv2/templates/admin/generate_audio_base.html:10
 #: cmsv2/templates/admin/generate_image_base.html:10
 msgid "Vocabulary Management v2"
@@ -757,11 +801,11 @@ msgstr "zuletzt geändert"
 msgid "Icon"
 msgstr "Icon"
 
-#: cmsv2/models/job.py:104
+#: cmsv2/models/job.py:104 cmsv2/views/import_csv_view.py:22
 msgid "Job"
 msgstr "Beruf"
 
-#: cmsv2/models/job.py:105
+#: cmsv2/models/job.py:105 cmsv2/templates/admin/csv_form.html:9
 msgid "Jobs"
 msgstr "Berufe"
 
@@ -804,10 +848,6 @@ msgstr "Einheit"
 msgid "Unit"
 msgstr "Einheit"
 
-#: cmsv2/models/unit.py:391
-msgid "Units"
-msgstr "Einheit"
-
 #: cmsv2/models/word.py:77
 msgid "audio checked identifier"
 msgstr "Audio Checked Identifier"
@@ -818,10 +858,70 @@ msgstr "Audio Checked Identifier"
 msgid "Words"
 msgstr "Vokabel"
 
+#: cmsv2/templates/admin/cmsv2/import_csv_button.html:7
+#: cmsv2/templates/admin/csv_form.html:4 cmsv2/templates/admin/csv_form.html:13
+#: cmsv2/templates/admin/csv_form.html:17
+msgid "Import CSV"
+msgstr "CSV importieren"
+
+#: cmsv2/templates/admin/cmsv2/save_and_import_button.html:10
+msgid "Save and import words"
+msgstr "Sichern und Wörter importieren"
+
+#: cmsv2/templates/admin/csv_form.html:49
+msgid "Start import"
+msgstr "Import starten"
+
+#: cmsv2/templates/admin/csv_form.html:55
+#: cmsv2/templates/admin/csv_form.html:59
+msgid "Cancel"
+msgstr "Abbrechen"
+
 #: cmsv2/templates/admin/generate_audio_base.html:16
 #: cmsv2/templates/admin/word_generate_audio.html:9
 msgid "Generate Audio"
 msgstr "Audio generieren"
+
+#: cmsv2/views/import_csv_view.py:26
+msgid "Select CSV file"
+msgstr "CSV Datei auswählen"
+
+#: cmsv2/views/import_csv_view.py:28
+msgid ""
+"The file should contain the columns \"Einheit\", \"Artikel\", \"Vokabel\" "
+"and \"Beispielsatz\"."
+msgstr ""
+"Die Datei sollte die Spalten \"Einheit\", \"Artikel\", \"Vokabel\" und "
+"\"Beispielsatz\" enthalten."
+
+#: cmsv2/views/import_csv_view.py:48
+msgid "CSV import for vocabulary"
+msgstr "CSV Import für Vokabeln"
+
+#: cmsv2/views/import_csv_view.py:89
+#, python-format
+msgid "Import completed with warnings: %(summary)s"
+msgstr "Import mit folgenden Warnungen abgeschlossen: %(summary)s"
+
+#: cmsv2/views/import_csv_view.py:95
+#, python-format
+msgid "Import successful! %(created)s new entries, %(updated)s updated."
+msgstr ""
+"Import erfolgreich! %(created)s neue Einträge, %(updated)s wurden "
+"aktualisiert."
+
+#: cmsv2/views/import_csv_view.py:104
+msgid ""
+"Import failed. The size of the column or row doesn't fit the table "
+"dimensions. Please adjust your table and try again."
+msgstr ""
+"Der Import ist fehlgeschlagen. Die Anzahl der Spalten oder Zeilen passen "
+"nicht zur Tabelle. Bitte passe die Tabelle an und versuche es erneut."
+
+#: cmsv2/views/import_csv_view.py:113
+#, python-format
+msgid "Import failed: %(e)s"
+msgstr "Import fehlgeschlagen: %(e)s"
 
 #: core/settings.py:227
 msgid "English"
@@ -843,13 +943,21 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 msgid "help"
 msgstr "Hilfe"
 
-#~ msgid "Start import"
-#~ msgstr "Import starten"
+#, python-format
+#~ msgid "Unexpected error - %(e)s"
+#~ msgstr "Unerwarteter Fehler - %(e)s"
 
-#~ msgid "Import vocabulary for this discipline from CSV"
-#~ msgstr "Alle Vokabeln dieser Modulgruppe aus CSV importieren"
+#, python-format
+#~ msgid "Importing vocabulary for \"%(job_name)s\""
+#~ msgstr "Vokabeln für \"%(job_name)s\" importieren"
 
-#~ msgid "Import was successful!"
+#~ msgid "Expected CSV columns:"
+#~ msgstr "Erwartete CSV Spalten:"
+
+#~ msgid "Import CSV file"
+#~ msgstr "CSV Datei importieren"
+
+#~ msgid "Import was successful"
 #~ msgstr "Import war erfolgreich"
 
 #~ msgid "Import csv file"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds the option to import vocabularies for a job from a csv and export them to a csv (as has been possible in v1).

### Proposed changes
<!-- Describe this PR in more detail. -->

- Copy and adapt CSV export from v1
- Add option to import from CSV either during creation of new job or for existing jobs from the job list

### How to test
Download some of the csv files "Vokabellisten" and try to import them

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #467 
