### PR TITLE
646: Add staff overview for expert mode

### DIFF
--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
 
-from .admins import FeedbackAdmin, JobAdmin, UnitAdmin, WordAdmin
-from .models import Feedback, Job, Unit, Word
+from .admins import FeedbackAdmin, JobAdmin, ReviewAdmin, UnitAdmin, WordAdmin
+from .models import Feedback, Job, Unit, UnitWordRelation, Word
 
 admin.site.register(Job, JobAdmin)
 admin.site.register(Unit, UnitAdmin)
 admin.site.register(Word, WordAdmin)
 admin.site.register(Feedback, FeedbackAdmin)
+admin.site.register(UnitWordRelation, ReviewAdmin)

--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -8,8 +8,8 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.auth.models import User
 
-from .admins import FeedbackAdmin, JobAdmin, LunesUserAdmin, UnitAdmin, WordAdmin
-from .models import Feedback, Job, Unit, Word
+from .admins import FeedbackAdmin, JobAdmin, ReviewAdmin, LunesUserAdmin, UnitAdmin, WordAdmin
+from .models import Feedback, Job, Unit, UnitWordRelation, Word
 
 admin.site.register(Job, JobAdmin)
 admin.site.register(Unit, UnitAdmin)
@@ -17,3 +17,4 @@ admin.site.register(Word, WordAdmin)
 admin.site.register(Feedback, FeedbackAdmin)
 admin.site.unregister(User)
 admin.site.register(User, LunesUserAdmin)
+admin.site.register(UnitWordRelation, ReviewAdmin)

--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -8,7 +8,14 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.auth.models import User
 
-from .admins import FeedbackAdmin, JobAdmin, ReviewAdmin, LunesUserAdmin, UnitAdmin, WordAdmin
+from .admins import (
+    FeedbackAdmin,
+    JobAdmin,
+    LunesUserAdmin,
+    ReviewAdmin,
+    UnitAdmin,
+    WordAdmin,
+)
 from .models import Feedback, Job, Unit, UnitWordRelation, Word
 
 admin.site.register(Job, JobAdmin)

--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -16,7 +16,7 @@ from .admins import (
     UnitAdmin,
     WordAdmin,
 )
-from .models import Feedback, Job, Unit, UnitWordRelation, Word
+from .models import Feedback, ImageReviewSummary, Job, Unit, Word
 
 admin.site.register(Job, JobAdmin)
 admin.site.register(Unit, UnitAdmin)
@@ -24,4 +24,4 @@ admin.site.register(Word, WordAdmin)
 admin.site.register(Feedback, FeedbackAdmin)
 admin.site.unregister(User)
 admin.site.register(User, LunesUserAdmin)
-admin.site.register(UnitWordRelation, ReviewAdmin)
+admin.site.register(ImageReviewSummary, ReviewAdmin)

--- a/lunes_cms/cmsv2/admins/__init__.py
+++ b/lunes_cms/cmsv2/admins/__init__.py
@@ -1,7 +1,8 @@
 from .feedback_admin import FeedbackAdmin
 from .job_admin import JobAdmin
+from .review_admin import ReviewAdmin
 from .unit_admin import UnitAdmin
 from .user_admin import LunesUserAdmin
 from .word_admin import WordAdmin
 
-__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "LunesUserAdmin"]
+__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "LunesUserAdmin", "ReviewAdmin"]

--- a/lunes_cms/cmsv2/admins/__init__.py
+++ b/lunes_cms/cmsv2/admins/__init__.py
@@ -5,4 +5,11 @@ from .unit_admin import UnitAdmin
 from .user_admin import LunesUserAdmin
 from .word_admin import WordAdmin
 
-__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "LunesUserAdmin", "ReviewAdmin"]
+__all__ = [
+    "JobAdmin",
+    "WordAdmin",
+    "UnitAdmin",
+    "FeedbackAdmin",
+    "LunesUserAdmin",
+    "ReviewAdmin",
+]

--- a/lunes_cms/cmsv2/admins/__init__.py
+++ b/lunes_cms/cmsv2/admins/__init__.py
@@ -1,6 +1,7 @@
 from .feedback_admin import FeedbackAdmin
 from .job_admin import JobAdmin
+from .review_admin import ReviewAdmin
 from .unit_admin import UnitAdmin
 from .word_admin import WordAdmin
 
-__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin"]
+__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "ReviewAdmin"]

--- a/lunes_cms/cmsv2/admins/review_admin.py
+++ b/lunes_cms/cmsv2/admins/review_admin.py
@@ -1,0 +1,80 @@
+from django.contrib import admin
+from django.db.models import Count, Q
+from django.http import HttpResponseRedirect
+from django.urls import path, reverse
+from django.utils.html import format_html
+from django.utils.translation import gettext_lazy as _
+
+from ..models import UnitWordRelation
+
+
+class ReviewAdmin(admin.ModelAdmin):
+    """
+    Admin interface for managing reviews of unit-word relations
+    """
+
+    list_display = ["word", "unit", "approval_count", "rejection_count", "more_options"]
+    search_fields = ["word__word", "unit__title"]
+
+    def has_add_permission(self, request):
+        """
+        Disables `add` button in the admin interface
+        """
+        return False
+
+    def get_queryset(self, request):
+        """
+        Queryset with annotated counts of approved and pending image reviews for each unit-word relation.
+        """
+        queryset = super().get_queryset(request)
+        return queryset.annotate(
+            approval_count=Count(
+                "image_reviews", filter=Q(image_reviews__status="APPROVED")
+            ),
+            rejection_count=Count(
+                "image_reviews", filter=Q(image_reviews__status="PENDING")
+            ),
+        )
+
+    def get_urls(self):
+        """
+        Get Url for button to confirm image in the admin interface
+        """
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<int:pk>/confirm-image/",
+                self.admin_site.admin_view(self.confirm_image_view),
+                name="cmsv2_unitwordrelation_confirm_image",
+            ),
+        ]
+        return custom_urls + urls
+
+    def confirm_image_view(self, request, pk):
+        """
+        Method to confirm image
+        """
+        UnitWordRelation.objects.filter(pk=pk).update(image_check_status="CONFIRMED")
+        unitword = UnitWordRelation.objects.get(pk=pk)
+        self.message_user(
+            request, _(f"Image '{unitword.word}' was marked as confirmed.")
+        )
+        return HttpResponseRedirect(reverse("admin:cmsv2_unitwordrelation_changelist"))
+
+    @admin.display(description=_("Approvals"), ordering="approval_count")
+    def approval_count(self, obj):
+        """Returns the number of approvals for the unit-word relation."""
+        return obj.approval_count
+
+    @admin.display(description=_("Rejections"), ordering="rejection_count")
+    def rejection_count(self, obj):
+        """Returns the number of rejections for the unit-word relation."""
+        return obj.rejection_count
+
+    @admin.display(description=_("actions"))
+    def more_options(self, obj):
+        """Returns a button to confirm the image if there are approvals and no rejections, and possible more options in the future."""
+        if obj.approval_count > 1 and obj.rejection_count == 0:
+            url = reverse("admin:cmsv2_unitwordrelation_confirm_image", args=[obj.pk])
+            return format_html('<a class="button" href="{}">Image bestätigen</a>', url)
+        return ""

--- a/lunes_cms/cmsv2/admins/review_admin.py
+++ b/lunes_cms/cmsv2/admins/review_admin.py
@@ -1,8 +1,5 @@
 from django.contrib import admin
 from django.db.models import Count, Q
-from django.http import HttpResponseRedirect
-from django.urls import path, reverse
-from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from ..models import UnitWordRelation
@@ -10,71 +7,41 @@ from ..models import UnitWordRelation
 
 class ReviewAdmin(admin.ModelAdmin):
     """
-    Admin interface for managing reviews of unit-word relations
+    Admin interface showing aggregated image review counts per unit-word relation.
     """
 
-    list_display = ["word", "unit", "approval_count", "rejection_count", "more_options"]
+    list_display = ["word", "unit", "approval_count", "rejection_count"]
+    list_display_links = None
     search_fields = ["word__word", "unit__title"]
-
-    def has_add_permission(self, request):
-        """
-        Disables `add` button in the admin interface
-        """
-        return False
+    ordering = ["word__word"]
 
     def get_queryset(self, request):
-        """
-        Queryset with annotated counts of approved and pending image reviews for each unit-word relation.
-        """
-        queryset = super().get_queryset(request)
-        return queryset.annotate(
-            approval_count=Count(
-                "image_reviews", filter=Q(image_reviews__status="APPROVED")
-            ),
-            rejection_count=Count(
-                "image_reviews", filter=Q(image_reviews__status="PENDING")
-            ),
+        return (
+            UnitWordRelation.objects.filter(image_reviews__isnull=False)
+            .distinct()
+            .annotate(
+                approval_count=Count(
+                    "image_reviews", filter=Q(image_reviews__status="APPROVED")
+                ),
+                rejection_count=Count(
+                    "image_reviews", filter=Q(image_reviews__status="PENDING")
+                ),
+            )
+            .select_related("word", "unit")
         )
 
-    def get_urls(self):
-        """
-        Get Url for button to confirm image in the admin interface
-        """
-        urls = super().get_urls()
-        custom_urls = [
-            path(
-                "<int:pk>/confirm-image/",
-                self.admin_site.admin_view(self.confirm_image_view),
-                name="cmsv2_unitwordrelation_confirm_image",
-            ),
-        ]
-        return custom_urls + urls
+    def has_add_permission(self, _request):
+        return False
 
-    def confirm_image_view(self, request, pk):
-        """
-        Method to confirm image
-        """
-        UnitWordRelation.objects.filter(pk=pk).update(image_check_status="CONFIRMED")
-        unitword = UnitWordRelation.objects.get(pk=pk)
-        self.message_user(
-            request, _(f"Image '{unitword.word}' was marked as confirmed.")
-        )
-        return HttpResponseRedirect(reverse("admin:cmsv2_unitwordrelation_changelist"))
+    def has_change_permission(self, _request, _obj=None):
+        return False
 
     @admin.display(description=_("Approvals"), ordering="approval_count")
     def approval_count(self, obj):
-        """Returns the number of approvals for the unit-word relation."""
+        """Returns the number of approved reviews for this unit-word relation."""
         return obj.approval_count
 
     @admin.display(description=_("Rejections"), ordering="rejection_count")
     def rejection_count(self, obj):
-        """Returns the number of rejections for the unit-word relation."""
+        """Returns the number of rejected reviews for this unit-word relation."""
         return obj.rejection_count
-
-    @admin.display(description=_("actions"))
-    def more_options(self, obj):
-        """Returns a button to confirm the image if there are approvals and no rejections, and possible more options in the future."""
-        if obj.approval_count > 1 and obj.rejection_count == 0:
-            url = reverse("admin:cmsv2_unitwordrelation_confirm_image", args=[obj.pk])
-            return format_html('<a class="button" href="{}">Image bestätigen</a>', url)
-        return ""

--- a/lunes_cms/cmsv2/migrations/0023_add_imagereviewsummary.py
+++ b/lunes_cms/cmsv2/migrations/0023_add_imagereviewsummary.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Creates a proxy model for showing aggregated image review counts per unit-word relation in admin."""
+
+    dependencies = [
+        ("cmsv2", "0022_alter_imagereview_options"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ImageReviewSummary",
+            fields=[],
+            options={
+                "verbose_name": "Image Review",
+                "verbose_name_plural": "Image Reviews",
+                "proxy": True,
+                "indexes": [],
+                "constraints": [],
+            },
+            bases=("cmsv2.unitwordrelation",),
+        ),
+    ]

--- a/lunes_cms/cmsv2/models/__init__.py
+++ b/lunes_cms/cmsv2/models/__init__.py
@@ -1,6 +1,6 @@
 from .feedback import Feedback
 from .job import Job
-from .review import ImageReview, ReviewAssignment
+from .review import ImageReview, ImageReviewSummary, ReviewAssignment
 from .static import Static
 from .unit import Unit, UnitWordRelation
 from .word import Word

--- a/lunes_cms/cmsv2/models/review.py
+++ b/lunes_cms/cmsv2/models/review.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from ..utils import create_resource_path
 from .static import REVIEW_STATUS_CHOICES
+from .unit import UnitWordRelation
 
 
 def upload_review_suggestions(instance, filename):
@@ -139,3 +140,14 @@ class ImageReview(models.Model):
         if self.is_unit_specific_image:
             return self.unit_word_relation.image
         return self.unit_word_relation.word.image
+
+
+class ImageReviewSummary(UnitWordRelation):
+    """Proxy model for showing aggregated image review counts per unit-word relation in admin."""
+
+    class Meta:
+        """Meta class for ImageReviewSummary proxy model."""
+
+        proxy = True
+        verbose_name = _("Image Review")
+        verbose_name_plural = _("Image Reviews")

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -507,6 +507,7 @@ JAZZMIN_SETTINGS = {
         "cmsv2.Unit": "fas fa-book",
         "cmsv2.Word": "fab fa-amilia",
         "cmsv2.Feedback": "fas fa-comment",
+        "cmsv2.Reviews": "fas fa-tasks",
     },
 }
 

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 14:54+0000\n"
+"POT-Creation-Date: 2026-04-17 16:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -700,6 +700,23 @@ msgstr "Alle Vokabeln dieser Berufe als CSV exportieren"
 #: cmsv2/admins/job_admin.py:221
 msgid "Import"
 msgstr "Import"
+
+#: cmsv2/admins/review_admin.py:60
+#, python-brace-format
+msgid "Image '{unitword.word}' was marked as confirmed."
+msgstr "Bild '{unitword.word}' wurde als bestätigt markiert."
+
+#: cmsv2/admins/review_admin.py:64
+msgid "Approvals"
+msgstr "Freigaben"
+
+#: cmsv2/admins/review_admin.py:69
+msgid "Rejections"
+msgstr "Ablehnungen"
+
+#: cmsv2/admins/review_admin.py:74
+msgid "actions"
+msgstr "Aktionen"
 
 #: cmsv2/admins/unit_admin.py:132
 msgid "jobs"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-11 19:28+0000\n"
+"POT-Creation-Date: 2026-05-11 19:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -710,11 +710,7 @@ msgstr "Die ausgewählten Berufe wurden erfolgreich dupliziert."
 msgid "Import"
 msgstr "Import"
 
-#: cmsv2/admins/review_admin.py:60
-msgid "Image '{unitword.word}' was marked as confirmed."
-msgstr "Bild '{unitword.word}' wurde als bestätigt markiert."
-
-#: cmsv2/admins/review_admin.py:64
+#: cmsv2/admins/review_admin.py:39
 msgid "Approvals"
 msgstr "Freigaben"
 
@@ -1107,12 +1103,11 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 msgid "help"
 msgstr "Hilfe"
 
-#~ msgid "Rejected"
-#~ msgstr "Ablehnungen"
-
-#, python-brace-format
 #~ msgid "Image '{unitword.word}' was marked as confirmed."
 #~ msgstr "Bild '{unitword.word}' wurde als bestätigt markiert."
+
+#~ msgid "Rejected"
+#~ msgstr "Ablehnungen"
 
 #, python-format
 #~ msgid "%(name)s (New)"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-11 14:13+0000\n"
+"POT-Creation-Date: 2026-05-11 19:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -709,6 +709,22 @@ msgstr "Die ausgewählten Berufe wurden erfolgreich dupliziert."
 #: cmsv2/admins/job_admin.py:235
 msgid "Import"
 msgstr "Import"
+
+#: cmsv2/admins/review_admin.py:60
+msgid "Image '{unitword.word}' was marked as confirmed."
+msgstr "Bild '{unitword.word}' wurde als bestätigt markiert."
+
+#: cmsv2/admins/review_admin.py:64
+msgid "Approvals"
+msgstr "Freigaben"
+
+#: cmsv2/admins/review_admin.py:69
+msgid "Rejections"
+msgstr "Ablehnungen"
+
+#: cmsv2/admins/review_admin.py:74
+msgid "actions"
+msgstr "Aktionen"
 
 #: cmsv2/admins/unit_admin.py:50
 msgid "assigned user"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -441,7 +441,7 @@ msgid "refers to"
 msgstr "bezieht sich auf"
 
 #: cms/models/feedback.py:35 cmsv2/models/feedback.py:34
-#: cmsv2/models/review.py:94
+#: cmsv2/models/review.py:95
 msgid "comment"
 msgstr "Kommentar"
 
@@ -685,7 +685,7 @@ msgid "units"
 msgstr "Einheiten"
 
 #: cmsv2/admins/job_admin.py:144 cmsv2/admins/unit_admin.py:254
-#: cmsv2/models/job.py:34 cmsv2/models/review.py:102 cmsv2/models/unit.py:327
+#: cmsv2/models/job.py:34 cmsv2/models/review.py:103 cmsv2/models/unit.py:327
 msgid "created at"
 msgstr "Erstellt"
 
@@ -718,13 +718,9 @@ msgstr "Bild '{unitword.word}' wurde als bestätigt markiert."
 msgid "Approvals"
 msgstr "Freigaben"
 
-#: cmsv2/admins/review_admin.py:69
+#: cmsv2/admins/review_admin.py:44
 msgid "Rejections"
 msgstr "Ablehnungen"
-
-#: cmsv2/admins/review_admin.py:74
-msgid "actions"
-msgstr "Aktionen"
 
 #: cmsv2/admins/unit_admin.py:50
 msgid "assigned user"
@@ -865,69 +861,69 @@ msgstr "Beruf"
 msgid "Jobs"
 msgstr "Berufe"
 
-#: cmsv2/models/review.py:26 cmsv2/models/unit.py:311
+#: cmsv2/models/review.py:27 cmsv2/models/unit.py:311
 msgid "unit"
 msgstr "Einheit"
 
-#: cmsv2/models/review.py:32 cmsv2/models/review.py:86
+#: cmsv2/models/review.py:33 cmsv2/models/review.py:87
 msgid "reviewer"
 msgstr "Kontrolleur:in"
 
-#: cmsv2/models/review.py:39
+#: cmsv2/models/review.py:40
 msgid "assigned by"
 msgstr "Zugewiesen von"
 
-#: cmsv2/models/review.py:41
+#: cmsv2/models/review.py:42
 msgid "assigned at"
 msgstr "Zuwiesen am"
 
-#: cmsv2/models/review.py:43
+#: cmsv2/models/review.py:44
 msgid "completed at"
 msgstr "Erstellt am"
 
-#: cmsv2/models/review.py:56
+#: cmsv2/models/review.py:57
 msgid "Review Assignment"
 msgstr "Kontroll Zuweisung"
 
-#: cmsv2/models/review.py:57
+#: cmsv2/models/review.py:58
 msgid "Review Assignments"
 msgstr "Kontroll Zuweisungen"
 
-#: cmsv2/models/review.py:73
+#: cmsv2/models/review.py:74
 msgid "unit-word relation"
 msgstr "Einheit-Wort Beziehung"
 
-#: cmsv2/models/review.py:77
+#: cmsv2/models/review.py:78
 msgid "unit-specific image"
 msgstr "Einheit spezifisches Bild"
 
-#: cmsv2/models/review.py:79
+#: cmsv2/models/review.py:80
 msgid "True if reviewing UnitWordRelation.image, False if reviewing Word.image"
 msgstr ""
 "Wahr, wenn ein Bild aus der Einheit-Wort-Relation kontrolliert wird, Falsch "
 "wenn ein Bild aus dem Wort kontrolliert wird"
 
-#: cmsv2/models/review.py:92
+#: cmsv2/models/review.py:93
 msgid "status"
 msgstr "Status"
 
-#: cmsv2/models/review.py:99
+#: cmsv2/models/review.py:100
 msgid "suggested image"
 msgstr "Vorgeschlagenes Bild"
 
-#: cmsv2/models/review.py:100
+#: cmsv2/models/review.py:101
 msgid "Alternative image suggested by reviewer"
 msgstr "Alternatives Bild von der:dem Kontrolleur:in vorgschlagen"
 
-#: cmsv2/models/review.py:103
+#: cmsv2/models/review.py:104
 msgid "updated at"
 msgstr "Erstellt am"
 
-#: cmsv2/models/review.py:119
+#: cmsv2/models/review.py:120 cmsv2/models/review.py:152
 msgid "Image Review"
 msgstr "Bild Kontrolle"
 
-#: cmsv2/models/review.py:120
+#: cmsv2/models/review.py:121 cmsv2/models/review.py:153
 msgid "Image Reviews"
 msgstr "Bild Kontrollen"
 
@@ -1110,6 +1106,13 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
+
+#~ msgid "Rejected"
+#~ msgstr "Ablehnungen"
+
+#, python-brace-format
+#~ msgid "Image '{unitword.word}' was marked as confirmed."
+#~ msgstr "Bild '{unitword.word}' wurde als bestätigt markiert."
 
 #, python-format
 #~ msgid "%(name)s (New)"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds the staff overview for reviewed images.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add overview for word-unit-relations
- Add button to approve images

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #646 
