### PR TITLE
643: Assignment view

### DIFF
--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -6,11 +6,14 @@ specify autocomplete_fields, search_fields and nested modules
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
+from django.contrib.auth.models import User
 
-from .admins import FeedbackAdmin, JobAdmin, UnitAdmin, WordAdmin
+from .admins import FeedbackAdmin, JobAdmin, LunesUserAdmin, UnitAdmin, WordAdmin
 from .models import Feedback, Job, Unit, Word
 
 admin.site.register(Job, JobAdmin)
 admin.site.register(Unit, UnitAdmin)
 admin.site.register(Word, WordAdmin)
 admin.site.register(Feedback, FeedbackAdmin)
+admin.site.unregister(User)
+admin.site.register(User, LunesUserAdmin)

--- a/lunes_cms/cmsv2/admins/__init__.py
+++ b/lunes_cms/cmsv2/admins/__init__.py
@@ -1,6 +1,7 @@
 from .feedback_admin import FeedbackAdmin
 from .job_admin import JobAdmin
 from .unit_admin import UnitAdmin
+from .user_admin import LunesUserAdmin
 from .word_admin import WordAdmin
 
-__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin"]
+__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "LunesUserAdmin"]

--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
+from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
+from django.template.response import TemplateResponse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from lunes_cms.cmsv2.admins.base import BaseAdmin
+from lunes_cms.cmsv2.models.review import ReviewAssignment
 from lunes_cms.cmsv2.models.unit import UnitWordRelation
 
 
@@ -30,6 +34,30 @@ class WordInline(admin.TabularInline):
     def get_formset(self, request, obj=None, **kwargs):
         formset = super().get_formset(request, obj, **kwargs)
         return formset
+
+
+class ReviewAssignmentInline(admin.TabularInline):
+    """
+    Inline admin for ReviewAssignment.
+    """
+
+    model = ReviewAssignment
+    fk_name = "unit"
+    extra = 0
+    fields = ["reviewer", "assigned_by", "assigned_at"]
+    readonly_fields = ["assigned_by", "assigned_at"]
+    autocomplete_fields = ["reviewer"]
+    verbose_name = _("assigned user")
+    verbose_name_plural = _("assigned users")
+
+    def has_add_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):
+        return request.user.is_superuser
 
 
 class MigratedFilter(admin.SimpleListFilter):
@@ -91,7 +119,7 @@ class UnitAdmin(BaseAdmin):
         "released",
     ]
     readonly_fields = ["created_by", "image_tag", "migrated_status"]
-    inlines = [WordInline]
+    inlines = [WordInline, ReviewAssignmentInline]
     search_fields = ["title"]
     list_display = [
         "title",
@@ -105,6 +133,7 @@ class UnitAdmin(BaseAdmin):
     list_display_links = ["title"]
     list_filter = ["released", MigratedFilter, "jobs"]
     list_per_page = 25
+    actions = ["assign_to_user"]
 
     class Media:
         """
@@ -116,6 +145,66 @@ class UnitAdmin(BaseAdmin):
 
         js = ["js/unit_icon_asset_config.js", "js/asset_manager.js"]
         css = {"all": ["css/asset_manager.css"]}
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is ReviewAssignment:
+            instances = formset.save(commit=False)
+            for obj in formset.deleted_objects:
+                obj.delete()
+            for instance in instances:
+                if instance.assigned_by_id is None:
+                    instance.assigned_by = request.user
+                instance.save()
+            formset.save_m2m()
+        else:
+            super().save_formset(request, form, formset, change)
+
+    @admin.action(description=_("Assign selected units to user"))
+    def assign_to_user(self, request, queryset):
+        """
+        Bulk-create ReviewAssignments linking each selected unit to a chosen
+        user. Superusers only. Units already assigned to the target user are
+        silently skipped via the (unit, reviewer) unique constraint.
+        """
+        if not request.user.is_superuser:
+            raise PermissionDenied
+
+        if "apply" not in request.POST:
+            return TemplateResponse(
+                request,
+                "admin/cmsv2/assign_units_to_user.html",
+                {
+                    **self.admin_site.each_context(request),
+                    "units": queryset,
+                    "users": User.objects.order_by("username"),
+                    "action": "assign_to_user",
+                    "selected_action": queryset.values_list("pk", flat=True),
+                    "title": _("Assign selected units to user"),
+                },
+            )
+
+        user = User.objects.get(pk=request.POST["user"])
+        existing_unit_ids = set(
+            ReviewAssignment.objects.filter(
+                reviewer=user, unit__in=queryset
+            ).values_list("unit_id", flat=True)
+        )
+        to_create = [
+            ReviewAssignment(unit=unit, reviewer=user, assigned_by=request.user)
+            for unit in queryset
+            if unit.pk not in existing_unit_ids
+        ]
+        ReviewAssignment.objects.bulk_create(to_create, ignore_conflicts=True)
+        self.message_user(
+            request,
+            _("Assigned %(new)d unit(s) to %(user)s (%(skipped)d already assigned).")
+            % {
+                "new": len(to_create),
+                "skipped": len(existing_unit_ids),
+                "user": user,
+            },
+        )
+        return None
 
     def related_jobs(self, obj):
         """

--- a/lunes_cms/cmsv2/admins/user_admin.py
+++ b/lunes_cms/cmsv2/admins/user_admin.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+from django.utils.translation import gettext_lazy as _
+
+from lunes_cms.cmsv2.models.review import ReviewAssignment
+
+
+class UserReviewAssignmentInline(admin.TabularInline):
+    """
+    Inline admin for ReviewAssignment on the User change page.
+    """
+
+    model = ReviewAssignment
+    fk_name = "reviewer"
+    extra = 0
+    fields = ["unit", "assigned_by", "assigned_at"]
+    readonly_fields = ["assigned_by", "assigned_at"]
+    autocomplete_fields = ["unit"]
+    verbose_name = _("assigned unit")
+    verbose_name_plural = _("assigned units")
+
+    def has_add_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+
+class LunesUserAdmin(DjangoUserAdmin):
+    """
+    User admin extended with a ReviewAssignment inline so admins can grant
+    per-unit access to individual users.
+    """
+
+    inlines = [*DjangoUserAdmin.inlines, UserReviewAssignmentInline]
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is ReviewAssignment:
+            instances = formset.save(commit=False)
+            for obj in formset.deleted_objects:
+                obj.delete()
+            for instance in instances:
+                if instance.assigned_by_id is None:
+                    instance.assigned_by = request.user
+                instance.save()
+            formset.save_m2m()
+        else:
+            super().save_formset(request, form, formset, change)

--- a/lunes_cms/cmsv2/templates/admin/cmsv2/assign_units_to_user.html
+++ b/lunes_cms/cmsv2/templates/admin/cmsv2/assign_units_to_user.html
@@ -1,0 +1,79 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block title %}{% trans "Assign selected units to user" %}{% endblock %}
+
+{% block breadcrumbs %}
+<ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'admin:cmsv2_unit_changelist' %}">{% trans 'Units' %}</a></li>
+    <li class="breadcrumb-item active">{% trans "Assign to user" %}</li>
+</ol>
+{% endblock %}
+
+{% block content_title %}{% trans "Assign selected units to user" %}{% endblock %}
+
+{% block content %}
+<div id="content-main" class="col-12">
+    <form method="post" action="">
+        {% csrf_token %}
+        {% for pk in selected_action %}
+            <input type="hidden" name="_selected_action" value="{{ pk }}">
+        {% endfor %}
+        <input type="hidden" name="action" value="{{ action }}">
+        <input type="hidden" name="apply" value="1">
+
+        <div class="row">
+            <div class="col-12 col-lg-9">
+                <div class="card">
+                    <div class="card-body">
+                        <p>
+                                {% blocktrans trimmed count counter=units.count %}
+                            You are about to assign {{ counter }} unit to a single user.
+                            {% plural %}
+                            You are about to assign {{ counter }} units to a single user.
+                            {% endblocktrans %}
+                        </p>
+
+                        <div class="form-group">
+                            <label for="id_user">{% trans "User" %}</label>
+                            <select name="user" id="id_user" class="form-control" required>
+                                <option value="">--------</option>
+                                {% for user in users %}
+                                    <option value="{{ user.pk }}">{{ user.username }}{% if user.get_full_name %} ({{ user.get_full_name }}){% endif %}</option>
+                                {% endfor %}
+                            </select>
+                            <small class="form-text text-muted">
+                                {% trans "Units already assigned to this user will be skipped." %}
+                            </small>
+                        </div>
+
+                        <details>
+                            <summary>{% trans "Selected units" %}</summary>
+                            <ul>
+                                {% for unit in units %}
+                                    <li>{{ unit }}</li>
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-3">
+                <div class="{{ jazzmin_ui.actions_classes }}">
+                    <div class="form-group">
+                        <button type="submit" class="btn {{ jazzmin_ui.button_classes.success }} form-control">
+                            {% trans "Assign" %}
+                        </button>
+                    </div>
+                    <div class="form-group">
+                        <a href="{% url 'admin:cmsv2_unit_changelist' %}" class="btn {{ jazzmin_ui.button_classes.danger }} form-control">
+                            {% trans "Cancel" %}
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 16:18+0000\n"
+"POT-Creation-Date: 2026-04-26 11:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -109,7 +109,7 @@ msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
 #: cms/admins/discipline_admin.py:387 cms/admins/document_admin.py:179
-#: cms/admins/training_set_admin.py:378 cmsv2/admins/unit_admin.py:151
+#: cms/admins/training_set_admin.py:378 cmsv2/admins/unit_admin.py:240
 #: cmsv2/admins/word_admin.py:434
 msgid "creator group"
 msgstr "Besitzergruppe"
@@ -563,6 +563,7 @@ msgstr ""
 
 #: cms/templates/admin/delete_confirmation.html:16
 #: cms/templates/admin/delete_selected_confirmation.html:15
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:8
 #: cmsv2/templates/admin/csv_form.html:8
 #: cmsv2/templates/admin/generate_audio_base.html:9
 #: cmsv2/templates/admin/generate_image_base.html:9
@@ -664,17 +665,17 @@ msgstr "Datei zu groß! Max. 5 MB"
 msgid "Only use one file extension!"
 msgstr "Nur maximal ein Dateityp erlaubt!"
 
-#: cmsv2/admins/job_admin.py:38 cmsv2/admins/unit_admin.py:42
+#: cmsv2/admins/job_admin.py:38 cmsv2/admins/unit_admin.py:70
 #: cmsv2/admins/word_admin.py:115
 msgid "migration status"
 msgstr "Ablaufdatum"
 
-#: cmsv2/admins/job_admin.py:49 cmsv2/admins/unit_admin.py:53
+#: cmsv2/admins/job_admin.py:49 cmsv2/admins/unit_admin.py:81
 #: cmsv2/admins/word_admin.py:126
 msgid "Migrated from old data model"
 msgstr "Migriert aus altem Datenmodell"
 
-#: cmsv2/admins/job_admin.py:50 cmsv2/admins/unit_admin.py:54
+#: cmsv2/admins/job_admin.py:50 cmsv2/admins/unit_admin.py:82
 #: cmsv2/admins/word_admin.py:127
 msgid "Not migrated from old data model"
 msgstr "Nicht migriert aus altem Datenmodell"
@@ -683,12 +684,12 @@ msgstr "Nicht migriert aus altem Datenmodell"
 msgid "units"
 msgstr "Einheiten"
 
-#: cmsv2/admins/job_admin.py:144 cmsv2/admins/unit_admin.py:165
+#: cmsv2/admins/job_admin.py:144 cmsv2/admins/unit_admin.py:254
 #: cmsv2/models/job.py:34 cmsv2/models/review.py:102 cmsv2/models/unit.py:327
 msgid "created at"
 msgstr "Erstellt"
 
-#: cmsv2/admins/job_admin.py:166 cmsv2/admins/unit_admin.py:187
+#: cmsv2/admins/job_admin.py:166 cmsv2/admins/unit_admin.py:276
 #: cmsv2/admins/word_admin.py:711
 msgid "migrated"
 msgstr "Migriert"
@@ -701,9 +702,38 @@ msgstr "Alle Vokabeln dieser Berufe als CSV exportieren"
 msgid "Import"
 msgstr "Import"
 
-#: cmsv2/admins/unit_admin.py:132
+#: cmsv2/admins/unit_admin.py:50
+msgid "assigned user"
+msgstr "Zugewiesene Person"
+
+#: cmsv2/admins/unit_admin.py:51
+msgid "assigned users"
+msgstr "Zugewiesene Personen"
+
+#: cmsv2/admins/unit_admin.py:162 cmsv2/admins/unit_admin.py:182
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:4
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:14
+msgid "Assign selected units to user"
+msgstr "Ausgewählte Einheiten zuweisen"
+
+#: cmsv2/admins/unit_admin.py:200
+#, python-format
+msgid "Assigned %(new)d unit(s) to %(user)s (%(skipped)d already assigned)."
+msgstr ""
+"%(new)d Einheit(en) an %(user)s zugewiesen (%(skipped)d waren bereits "
+"zugewiesen)."
+
+#: cmsv2/admins/unit_admin.py:221
 msgid "jobs"
 msgstr "Berufe"
+
+#: cmsv2/admins/user_admin.py:21
+msgid "assigned unit"
+msgstr "Zugewiesene Einheit"
+
+#: cmsv2/admins/user_admin.py:22
+msgid "assigned units"
+msgstr "Zugewiesene Einheiten"
 
 #: cmsv2/admins/word_admin.py:20
 msgid "Has Image"
@@ -752,6 +782,7 @@ msgid "image check status"
 msgstr "Bild Prüfstatus"
 
 #: cmsv2/admins/word_export_resource.py:80 cmsv2/models/unit.py:405
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:9
 msgid "Units"
 msgstr "Einheit"
 
@@ -942,6 +973,40 @@ msgstr "Audio Checked Identifier"
 msgid "Words"
 msgstr "Vokabel"
 
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:10
+msgid "Assign to user"
+msgstr "An nutzende Person zuweisen"
+
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:31
+#, python-format
+msgid "You are about to assign %(counter)s unit to a single user."
+msgid_plural "You are about to assign %(counter)s units to a single user."
+msgstr[0] "Du bist dabei, %(counter)s Einheit einer Person zuzuweisen."
+msgstr[1] "Du bist dabei, %(counter)s Einheiten einer Person zuzuweisen."
+
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:39
+msgid "User"
+msgstr "Nutzende Person"
+
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:47
+msgid "Units already assigned to this user will be skipped."
+msgstr ""
+"Einheiten, die dieser Person bereits zugewiesen sind, werden übersprungen."
+
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:52
+msgid "Selected units"
+msgstr "Ausgewählte Einheiten"
+
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:66
+msgid "Assign"
+msgstr "Zuweisen"
+
+#: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:71
+#: cmsv2/templates/admin/csv_form.html:55
+#: cmsv2/templates/admin/csv_form.html:59
+msgid "Cancel"
+msgstr "Abbrechen"
+
 #: cmsv2/templates/admin/cmsv2/import_csv_button.html:7
 #: cmsv2/templates/admin/csv_form.html:4 cmsv2/templates/admin/csv_form.html:13
 #: cmsv2/templates/admin/csv_form.html:17
@@ -955,11 +1020,6 @@ msgstr "Sichern und Wörter importieren"
 #: cmsv2/templates/admin/csv_form.html:49
 msgid "Start import"
 msgstr "Import starten"
-
-#: cmsv2/templates/admin/csv_form.html:55
-#: cmsv2/templates/admin/csv_form.html:59
-msgid "Cancel"
-msgstr "Abbrechen"
 
 #: cmsv2/templates/admin/generate_audio_base.html:16
 #: cmsv2/templates/admin/word_generate_audio.html:9


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Adds actions for assigning units to users.
The workflow for adding all units of a job to a user is: 
- click the select all units checkbox
- (optionally) click the select all <n> units button
- complete the assign selected units bulk action

### Proposed changes
<!-- Describe this PR in more detail. -->

- In the user view, add a new section listing all assigned units
- In the unit view, add a new section listing all assigned users
- In the unit admin, add a new bulk action for assigning all selected units to a user

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #643 
