### PR TITLE
739: Add option to duplicate jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 UNRELEASED
 ----------
 
-* [ [375](https://github.com/digitalfabrik/lunes-cms/issues/375) ] 375: Add created by filter to CMS
+* [ [#375](https://github.com/digitalfabrik/lunes-cms/issues/375) ] 375: Add created by filter to CMS
+* [ [#739](https://github.com/digitalfabrik/lunes-cms/issues/739) ] 739: Add option to duplicate jobs
 
 2026.4.7
 --------

--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import io
 from zipfile import ZipFile
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -98,7 +98,7 @@ class JobAdmin(BaseAdmin):
     ]
     list_display_links = ["name"]
     list_filter = ["released", MigratedFilter]
-    actions = ["export_to_csv"]
+    actions = ["export_to_csv", "duplicate_jobs"]
     list_per_page = 25
     ordering = ["name"]
     change_list_template = "admin/cmsv2/import_csv_button.html"
@@ -198,6 +198,20 @@ class JobAdmin(BaseAdmin):
         response = HttpResponse(zip_buffer.getvalue(), content_type="application/zip")
         response["Content-Disposition"] = 'attachment; filename="Lunes_vocabulary.zip"'
         return response
+
+    @admin.action(description=_("Duplicate selected jobs"))
+    def duplicate_jobs(self, request, queryset):
+        """Duplicate the selected jobs, including their related units."""
+        for job in queryset:
+            units = list(job.units.all())
+            job.pk = None
+            job.v1_id = None
+            job.released = False
+            job.name = f"{job.name} ({_('New')})"
+            job.created_by = request.user.groups.first()
+            job.save()
+            job.units.set(units)
+        messages.success(request, _("Selected jobs have been duplicated successfully."))
 
     def response_add(self, request, obj, post_url_continue=None):
         if "_save_and_import" in request.POST:

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-11 11:55+0000\n"
+"POT-Creation-Date: 2026-05-11 13:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -698,7 +698,15 @@ msgstr "Migriert"
 msgid "Export all vocabulary for these jobs to CSV"
 msgstr "Alle Vokabeln dieser Berufe als CSV exportieren"
 
-#: cmsv2/admins/job_admin.py:221
+#: cmsv2/admins/job_admin.py:202
+msgid "Duplicate selected jobs"
+msgstr "Ausgewählte Berufe duplizieren"
+
+#: cmsv2/admins/job_admin.py:214
+msgid "Selected jobs have been duplicated successfully."
+msgstr "Die ausgewählten Berufe wurden erfolgreich dupliziert."
+
+#: cmsv2/admins/job_admin.py:235
 msgid "Import"
 msgstr "Import"
 
@@ -1086,6 +1094,10 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
+
+#, python-format
+#~ msgid "%(name)s (New)"
+#~ msgstr "%(name)s (Neu)"
 
 #, python-format
 #~ msgid "Unexpected error - %(e)s"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds the option to duplicate existing jobs

### Proposed changes
<!-- Describe this PR in more detail. -->

- Duplicate existing jobs, including their units and add the suffix "New"


### Steps to test

- Please check that all vocabularies and units are copied, but are uncoupled from the previous job
- Please check that the publication status, the migrated state and creator are correct
- Please check that the suffix "New" is correctly translated for German speaking users


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #739 
