### PR TITLE
Docs/python virtual environment intellij

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ cd lunes-cms
 ./tools/install.sh
 ```
 
+### IntelliJ with Python virtual environment
+
+Some IntelliJ versions do not activate Python virtual environment automatically.
+In this case can use IntelliJ together with the [direnv plugin](https://plugins.jetbrains.com/plugin/15285-direnv-integration) and the provided `.envrc`.
+It automatically activates the Python virtual environment (`.venv`) when opening the project.
+* Note: The direnv binary has to be installed on your system.
+
 ### Run development server
 
 ```


### PR DESCRIPTION
### Short description
On macos with intelliJ Ultimate i was not really able to activate the python virtual environment automatically.
Therefore i added the direnv binary and plugin.

I read that it would work better with pyCharm or other IDEs.

I tried several things in the standard intelliJ config that didn't work (no automatically activation)
If you know a proper way, let me know and i will close that pr.


### Proposed changes
<!-- Describe this PR in more detail. -->

- add `.envrc` file
- update documentation

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
