### PR TITLE
276: Clean up utils file

### DIFF
--- a/lunes_cms/cmsv2/models/job.py
+++ b/lunes_cms/cmsv2/models/job.py
@@ -4,7 +4,7 @@ from django.db.models.deletion import CASCADE
 from django.utils.html import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from ..utils import get_child_count, get_image_tag
+from ..utils import get_image_tag
 from .static import convert_umlaute_images
 
 
@@ -33,18 +33,6 @@ class Job(models.Model):
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
     created_at = models.DateTimeField(auto_now_add=True, verbose_name=_("created at"))
     modified_at = models.DateTimeField(auto_now=True, verbose_name=_("modified at"))
-
-    def is_valid(self):
-        """
-        Check if the job is valid for display.
-
-        A job is considered valid if it has at least one child with training sets
-        or at least one released unit.
-
-        Returns:
-            bool: True if the job is valid, False otherwise
-        """
-        return get_child_count(self) > 0 or self.units.filter(released=True).count() > 0
 
     def image_tag(self):
         """

--- a/lunes_cms/cmsv2/utils.py
+++ b/lunes_cms/cmsv2/utils.py
@@ -77,39 +77,6 @@ def word_to_string(word):
     )
 
 
-def get_child_count(disc):
-    """
-    Count the number of released children with training sets.
-
-    Args:
-        disc: The parent object whose children will be counted
-
-    Returns:
-        int: The count of released children with at least one training set
-    """
-    children_counter = 0
-    for child in disc.get_children():
-        if child.released and get_training_set_count(child) > 0:
-            children_counter += 1
-    return children_counter
-
-
-def get_training_set_count(disc):
-    """
-    Count the total number of training sets for an object and its descendants.
-
-    Args:
-        disc: The object whose training sets will be counted
-
-    Returns:
-        int: The total count of training sets
-    """
-    training_set_counter = 0
-    for child in disc.get_descendants(include_self=True):
-        training_set_counter += child.training_sets.count()
-    return training_set_counter
-
-
 def get_image_tag(image, width=330):
     """
     Generate an HTML image tag for the given image.

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-07 20:13+0000\n"
+"POT-Creation-Date: 2026-05-11 11:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -649,7 +649,7 @@ msgstr "Zusammenfassung"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: cms/utils.py:164 cmsv2/utils.py:150
+#: cms/utils.py:164 cmsv2/utils.py:117
 msgid "and"
 msgstr "und"
 
@@ -829,15 +829,15 @@ msgstr "Beruf"
 msgid "modified at"
 msgstr "zuletzt geändert"
 
-#: cmsv2/models/job.py:91 cmsv2/models/unit.py:372
+#: cmsv2/models/job.py:79 cmsv2/models/unit.py:372
 msgid "Icon"
 msgstr "Icon"
 
-#: cmsv2/models/job.py:104 cmsv2/views/import_csv_view.py:22
+#: cmsv2/models/job.py:92 cmsv2/views/import_csv_view.py:22
 msgid "Job"
 msgstr "Beruf"
 
-#: cmsv2/models/job.py:105 cmsv2/templates/admin/csv_form.html:9
+#: cmsv2/models/job.py:93 cmsv2/templates/admin/csv_form.html:9
 msgid "Jobs"
 msgstr "Berufe"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR cleans up the utils file for v2. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove `get_child_count` as it's not used in v2 anymore
- Remove `get_training_set_count` as it's not used in v2 anymore
- Remove `is_valid` as it's not used in v2 anymore (and depends on dead code itself)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #276 
