### PR TITLE
703: Fix audio upload

### DIFF
--- a/lunes_cms/cmsv2/models/word.py
+++ b/lunes_cms/cmsv2/models/word.py
@@ -199,7 +199,6 @@ class Word(models.Model):
             self.example_sentence_check_status = "NOT_CHECKED"
 
         if audio_updated:
-            self.convert_audio()
             self.audio_check_status = "NOT_CHECKED"
             self.audio_checked_identifier = self.assemble_audio_checked_identifier()
 
@@ -223,6 +222,9 @@ class Word(models.Model):
             self.example_sentence_check_status = None
 
         super().save(*args, **kwargs)
+        if audio_updated:
+            self.convert_audio()
+            super().save(update_fields=["audio"])
         if image_updated and convert_image_to_webp(self.image):
             super().save(update_fields=["image"])
 

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-11 13:28+0000\n"
+"POT-Creation-Date: 2026-05-11 14:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -136,7 +136,7 @@ msgid "singular article"
 msgstr "Singular-Artikel"
 
 #: cms/admins/document_resource.py:24 cmsv2/admins/word_export_resource.py:24
-#: cmsv2/models/word.py:305
+#: cmsv2/models/word.py:307
 msgid "Word"
 msgstr "Vokabel"
 
@@ -975,7 +975,7 @@ msgstr "Einheit"
 msgid "audio checked identifier"
 msgstr "Audio Checked Identifier"
 
-#: cmsv2/models/word.py:306 cmsv2/templates/admin/word_generate_audio.html:7
+#: cmsv2/models/word.py:308 cmsv2/templates/admin/word_generate_audio.html:7
 #: cmsv2/templates/admin/word_generate_example_sentence_audio.html:9
 #: cmsv2/templates/admin/word_generate_image.html:7
 msgid "Words"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently we first convert audio file before actually uploading it via post request, so if we try to save a vocabulary that has a manually uploaded audio file it will result in a not found error, because the file is not there.

### Proposed changes
<!-- Describe this PR in more detail. -->

- convert audio after saving file


### How to test
<!-- Please describe how to test this PR -->

- Go to http://localhost:8080/en/admin/cmsv2/word/
- Add a new word. Provide word information and select an audio file
- Save the word
- Audio file should be successfully converted


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #703
