### PR TITLE
Fix pytests ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ push = false
 
 # Exclude e2e tests temporarily in pytest, will be removed in #747
 [tool.pytest.ini_options]
-norecursedirs = ["e2e-tests"]
+addopts = "--ignore=e2e-tests"
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The norecursedirs option has some defaults: https://docs.pytest.org/en/7.1.x/reference/reference.html#confval-norecursedirs

By setting `norecursedirs` to a value, these values got overwritten. This broke tests for me locally, because it not longer ignored some directories for testing


### Proposed changes
<!-- Describe this PR in more detail. -->

- Use a command line option instead, so that the default ignores still apply


### How to test
<!-- Please describe how to test this PR -->

- I guess my (nix-based) setup is not the most common setup, so I don't know if this broke tests for anyone else locally


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /
