### PR TITLE
604: Add error handling for audio upload and convertion

### DIFF
--- a/lunes_cms/cms/models/document.py
+++ b/lunes_cms/cms/models/document.py
@@ -1,11 +1,12 @@
 import os
-import subprocess
 from pathlib import Path
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.files import File
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+from lunes_cms.core.audio import run_ffmpeg, validate_audio_upload
 
 from ..utils import document_to_string
 from ..validators import (
@@ -98,6 +99,13 @@ class Document(models.Model):
     creator_is_admin = models.BooleanField(default=True, verbose_name=_("admin"))
     feedback = GenericRelation(Feedback)
 
+    def clean(self):
+        """Validate the audio file with ffmpeg before saving to prevent storing invalid audio."""
+        super().clean()
+        if not self.audio:
+            return
+        validate_audio_upload(self.audio.file)
+
     @property
     def converted(self):
         """
@@ -113,11 +121,7 @@ class Document(models.Model):
         super().save()
         file_path = self.audio.path
         new_path = file_path[:-4] + "-conv.mp3"
-        subprocess.run(
-            ["ffmpeg", "-i", file_path, "-b:a", "44.1k", new_path],
-            check=True,
-            capture_output=True,
-        )
+        run_ffmpeg("-i", file_path, "-b:a", "44.1k", new_path)
 
         with open(new_path, "rb") as file:
             converted_audiofile = File(file, name=Path(new_path).name)

--- a/lunes_cms/cmsv2/models/word.py
+++ b/lunes_cms/cmsv2/models/word.py
@@ -1,10 +1,11 @@
 import os
-import subprocess
 
 from django.contrib.auth.models import Group
 from django.core.files import File
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+from lunes_cms.core.audio import run_ffmpeg, validate_audio_upload
 
 from ..utils import get_image_tag, make_safe_filename, word_to_string
 from ..validators import (
@@ -149,6 +150,20 @@ class Word(models.Model):
     )
     v1_id = models.IntegerField(null=True, blank=True, editable=False)
 
+    def clean(self):
+        """Validate changed audio with ffmpeg before saving to prevent storing invalid audio."""
+        super().clean()
+        if not self.audio:
+            return
+        previous = Word.objects.filter(pk=self.pk).first() if self.pk else None
+        audio_will_convert = not previous or (
+            previous.assemble_audio_checked_identifier()
+            != self.assemble_audio_checked_identifier()
+        )
+        if not audio_will_convert:
+            return
+        validate_audio_upload(self.audio.file)
+
     def convert_audio(self):
         """
         Converts the uploaded audio file to MP3 format and sets, but doesn't save, it as a Django File object.
@@ -159,11 +174,7 @@ class Word(models.Model):
         original_name = self.audio.name
         file_path = self.audio.path
         new_path = file_path[:-4] + "-conv.mp3"
-        subprocess.run(
-            ["ffmpeg", "-i", file_path, "-b:a", "44.1k", new_path],
-            check=True,
-            capture_output=True,
-        )
+        run_ffmpeg("-i", file_path, "-b:a", "44.1k", new_path)
 
         # Store the re-encoded file under a deterministic, word-derived name.
         # Drop the just-uploaded source file and any stale file already sitting

--- a/lunes_cms/core/audio.py
+++ b/lunes_cms/core/audio.py
@@ -1,0 +1,28 @@
+import subprocess
+import tempfile
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+def validate_audio_upload(uploaded_file):
+    """Probe an uploaded audio file with ffmpeg before it is saved to storage."""
+    with tempfile.NamedTemporaryFile(suffix=".tmp") as tmp:
+        for chunk in uploaded_file.chunks():
+            tmp.write(chunk)
+        tmp.flush()
+        probe_ffmpeg(tmp.name)
+    uploaded_file.seek(0)
+
+
+def run_ffmpeg(*args):
+    """Run ffmpeg with the given arguments, raising ValidationError on failure."""
+    try:
+        subprocess.run(["ffmpeg", *args], check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        raise ValidationError({"audio": _("Invalid audio file")}) from e
+
+
+def probe_ffmpeg(path):
+    """Probe an audio file path with ffmpeg to check it contains a valid audio stream."""
+    run_ffmpeg("-v", "error", "-i", path, "-map", "0:a:0", "-f", "null", "-")

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-20 09:36+0000\n"
+"POT-Creation-Date: 2026-05-20 11:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -71,8 +71,8 @@ msgstr "Modulgruppen"
 msgid "training sets"
 msgstr "Module"
 
-#: cms/admin.py:38 cms/forms.py:52 cms/forms.py:53 cms/models/document.py:150
-#: cms/models/document.py:151
+#: cms/admin.py:38 cms/forms.py:52 cms/forms.py:53 cms/models/document.py:158
+#: cms/models/document.py:159
 msgid "vocabulary"
 msgstr "Vokabeln"
 
@@ -119,24 +119,24 @@ msgstr "Besitzergruppe"
 msgid "training set"
 msgstr "Modul"
 
-#: cms/admins/document_admin.py:196 cms/models/document.py:66
-#: cmsv2/admins/word_admin.py:502 cmsv2/models/word.py:68
+#: cms/admins/document_admin.py:196 cms/models/document.py:68
+#: cmsv2/admins/word_admin.py:502 cmsv2/models/word.py:70
 msgid "audio"
 msgstr "Audio"
 
 #: cms/admins/document_admin.py:216 cms/models/document_image.py:124
-#: cmsv2/models/unit.py:41 cmsv2/models/word.py:141
+#: cmsv2/models/unit.py:41 cmsv2/models/word.py:143
 msgid "image"
 msgstr "Bild"
 
 #: cms/admins/document_admin.py:231 cms/models/alternative_word.py:24
-#: cms/models/document.py:43 cmsv2/admins/word_admin.py:676
-#: cmsv2/models/word.py:45
+#: cms/models/document.py:45 cmsv2/admins/word_admin.py:676
+#: cmsv2/models/word.py:47
 msgid "singular article"
 msgstr "Singular-Artikel"
 
 #: cms/admins/document_resource.py:24 cmsv2/admins/word_export_resource.py:24
-#: cmsv2/models/word.py:319
+#: cmsv2/models/word.py:334
 msgid "Word"
 msgstr "Vokabel"
 
@@ -331,13 +331,13 @@ msgstr "Alternatives Wort"
 msgid "grammatical gender"
 msgstr "Genus"
 
-#: cms/models/alternative_word.py:28 cms/models/document.py:47
-#: cmsv2/models/word.py:49
+#: cms/models/alternative_word.py:28 cms/models/document.py:49
+#: cmsv2/models/word.py:51
 msgid "plural"
 msgstr "Plural"
 
-#: cms/models/alternative_word.py:34 cms/models/document.py:53
-#: cmsv2/models/word.py:55
+#: cms/models/alternative_word.py:34 cms/models/document.py:55
+#: cmsv2/models/word.py:57
 msgid "plural article"
 msgstr "Plural-Artikel"
 
@@ -366,15 +366,15 @@ msgstr "Beschreibung"
 msgid "icon"
 msgstr "Icon"
 
-#: cms/models/discipline.py:33 cms/models/document.py:94
+#: cms/models/discipline.py:33 cms/models/document.py:96
 #: cms/models/training_set.py:39 cmsv2/models/job.py:30
-#: cmsv2/models/unit.py:326 cmsv2/models/word.py:135
+#: cmsv2/models/unit.py:326 cmsv2/models/word.py:137
 msgid "created by"
 msgstr "Erstellt von"
 
-#: cms/models/discipline.py:36 cms/models/document.py:98
+#: cms/models/discipline.py:36 cms/models/document.py:100
 #: cms/models/training_set.py:41 cmsv2/models/job.py:33
-#: cmsv2/models/unit.py:328 cmsv2/models/word.py:139
+#: cmsv2/models/unit.py:328 cmsv2/models/word.py:141
 msgid "admin"
 msgstr "Admin"
 
@@ -382,38 +382,42 @@ msgstr "Admin"
 msgid "parent"
 msgstr "Übergeordnete Modulgruppe"
 
-#: cms/models/document.py:31 cmsv2/models/word.py:33
+#: cms/models/document.py:33 cmsv2/models/word.py:35
 msgid "word type"
 msgstr "Wortart"
 
-#: cms/models/document.py:33 cmsv2/models/unit.py:323 cmsv2/models/word.py:35
+#: cms/models/document.py:35 cmsv2/models/unit.py:323 cmsv2/models/word.py:37
 msgid "word"
 msgstr "Wort"
 
-#: cms/models/document.py:36 cmsv2/models/word.py:38
+#: cms/models/document.py:38 cmsv2/models/word.py:40
 msgid "Grammatical gender"
 msgstr "Genus"
 
-#: cms/models/document.py:68 cmsv2/models/unit.py:50 cmsv2/models/word.py:83
+#: cms/models/document.py:70 cmsv2/models/unit.py:50 cmsv2/models/word.py:85
 msgid "example sentence"
 msgstr "Beispielsatz"
 
-#: cms/models/document.py:70 cms/models/group_api_key.py:65
-#: cmsv2/admins/word_admin.py:690 cmsv2/models/word.py:110
+#: cms/models/document.py:72 cms/models/group_api_key.py:65
+#: cmsv2/admins/word_admin.py:690 cmsv2/models/word.py:112
 msgid "creation date"
 msgstr "Erstellt am"
 
-#: cms/models/document.py:76 cmsv2/models/word.py:117
+#: cms/models/document.py:78 cmsv2/models/word.py:119
 msgid "definition"
 msgstr "Definition"
 
-#: cms/models/document.py:82 cmsv2/models/word.py:123
+#: cms/models/document.py:84 cmsv2/models/word.py:125
 msgid "additional meaning 1"
 msgstr "Zusätzliche Bedeutung 1"
 
-#: cms/models/document.py:88 cmsv2/models/word.py:129
+#: cms/models/document.py:90 cmsv2/models/word.py:131
 msgid "additional meaning 2"
 msgstr "Zusätzliche Bedeutung 2"
+
+#: cms/models/document.py:111 cmsv2/models/word.py:169 core/audio.py:23
+msgid "Invalid audio file"
+msgstr "Ungültige Audiodatei"
 
 #: cms/models/document_image.py:125
 msgid "images"
@@ -702,6 +706,10 @@ msgstr "Alle Vokabeln dieser Berufe als CSV exportieren"
 msgid "Duplicate selected jobs"
 msgstr "Ausgewählte Berufe duplizieren"
 
+#: cmsv2/admins/job_admin.py:210
+msgid "New"
+msgstr "Neu"
+
 #: cmsv2/admins/job_admin.py:214
 msgid "Selected jobs have been duplicated successfully."
 msgstr "Die ausgewählten Berufe wurden erfolgreich dupliziert."
@@ -780,12 +788,12 @@ msgstr "Verschiedene"
 msgid "Image Preview"
 msgstr "Bild Vorschau"
 
-#: cmsv2/admins/word_admin.py:726 cmsv2/models/word.py:74
+#: cmsv2/admins/word_admin.py:726 cmsv2/models/word.py:76
 msgid "audio check status"
 msgstr "Audio Prüfstatus"
 
 #: cmsv2/admins/word_admin.py:741 cmsv2/models/unit.py:47
-#: cmsv2/models/word.py:147
+#: cmsv2/models/word.py:149
 msgid "image check status"
 msgstr "Bild Prüfstatus"
 
@@ -833,7 +841,7 @@ msgstr "Vokabelverwaltung v2"
 msgid "job"
 msgstr "Beruf"
 
-#: cmsv2/models/job.py:35 cmsv2/models/unit.py:330 cmsv2/models/word.py:112
+#: cmsv2/models/job.py:35 cmsv2/models/unit.py:330 cmsv2/models/word.py:114
 msgid "modified at"
 msgstr "zuletzt geändert"
 
@@ -928,19 +936,19 @@ msgid "Reviewer"
 msgstr "Expert:in"
 
 #: cmsv2/models/unit.py:60 cmsv2/models/unit.py:218 cmsv2/models/unit.py:290
-#: cmsv2/models/word.py:93
+#: cmsv2/models/word.py:95
 msgid "example sentence audio"
 msgstr "Beispielsatz Audio"
 
-#: cmsv2/models/unit.py:66 cmsv2/models/word.py:99
+#: cmsv2/models/unit.py:66 cmsv2/models/word.py:101
 msgid "example sentence check status"
 msgstr "Beispielsatz Check Status"
 
-#: cmsv2/models/unit.py:71 cmsv2/models/word.py:104
+#: cmsv2/models/unit.py:71 cmsv2/models/word.py:106
 msgid "example sentence audio regenerated"
 msgstr "Beispielsatz Audio neu generiert"
 
-#: cmsv2/models/unit.py:73 cmsv2/models/word.py:106
+#: cmsv2/models/unit.py:73 cmsv2/models/word.py:108
 msgid ""
 "Indicates whether the audio has been regenerated with the new TTS model."
 msgstr "Gibt an, ob das Audio mit dem neuen TTS-Modell neu generiert wurde."
@@ -971,11 +979,11 @@ msgstr "Einheit-Wort Beziehungen"
 msgid "Unit"
 msgstr "Einheit"
 
-#: cmsv2/models/word.py:81
+#: cmsv2/models/word.py:83
 msgid "audio checked identifier"
 msgstr "Audio Checked Identifier"
 
-#: cmsv2/models/word.py:320 cmsv2/templates/admin/word_generate_audio.html:7
+#: cmsv2/models/word.py:335 cmsv2/templates/admin/word_generate_audio.html:7
 #: cmsv2/templates/admin/word_generate_example_sentence_audio.html:9
 #: cmsv2/templates/admin/word_generate_image.html:7
 msgid "Words"
@@ -1096,9 +1104,6 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
-
-#~ msgid "New"
-#~ msgstr "Neu"
 
 #, python-format
 #~ msgid "%(name)s (New)"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
With this i add some error handling if the audio file is corrupt. The user will get

### Proposed changes
<!-- Describe this PR in more detail. -->

- add helper functions for audio conversion error handling
- show error message if audio file is corrupt and don't save/edit the word


### How to test
<!-- Please describe how to test this PR -->

- Add/edit a work
- use f.e. a jpg file and rename it to `.mp3` or any other non audio file for audio upload
- Click save


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
