### PR TITLE
Work around different gettext versions

### DIFF
--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -207,7 +207,8 @@ class JobAdmin(BaseAdmin):
             job.pk = None
             job.v1_id = None
             job.released = False
-            job.name = _("%(name)s (New)") % {"name": job.name}
+            new_label = ("New")
+            job.name = _("%(name)s %(label)") % {"name": job.name, "label": new_label}
             job.created_by = request.user.groups.first()
             job.save()
             job.units.set(units)

--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -207,7 +207,7 @@ class JobAdmin(BaseAdmin):
             job.pk = None
             job.v1_id = None
             job.released = False
-            job.name = f"{job.name} ({_('New')})"
+            job.name = _("%(name)s (New)") % {"name": job.name}
             job.created_by = request.user.groups.first()
             job.save()
             job.units.set(units)

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-18 09:18+0000\n"
+"POT-Creation-Date: 2026-05-20 11:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -702,6 +702,11 @@ msgstr "Alle Vokabeln dieser Berufe als CSV exportieren"
 msgid "Duplicate selected jobs"
 msgstr "Ausgewählte Berufe duplizieren"
 
+#: cmsv2/admins/job_admin.py:210
+#, python-format
+msgid "%(name)s (New)"
+msgstr "%(name)s (Neu)"
+
 #: cmsv2/admins/job_admin.py:214
 msgid "Selected jobs have been duplicated successfully."
 msgstr "Die ausgewählten Berufe wurden erfolgreich dupliziert."
@@ -1096,10 +1101,6 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
-
-#, python-format
-#~ msgid "%(name)s (New)"
-#~ msgstr "%(name)s (Neu)"
 
 #, python-format
 #~ msgid "Unexpected error - %(e)s"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

I keep getting a different translation file because I have a newer version of gettext in my IDE which seems to be very hard to downgrade. With a slightly different formatting on this string, it seems to work again.