### PR TITLE
fix(settings): list German before English in LANGUAGES

### DIFF
--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -235,8 +235,8 @@ LANGUAGE_CODE = "en"
 
 #: A list of all available languages (see :setting:`django:LANGUAGES` and :doc:`django:topics/i18n/index`)
 LANGUAGES = [
-    ("en", _("English")),
     ("de", _("German")),
+    ("en", _("English")),
 ]
 
 #: A string representing the time zone for this installation


### PR DESCRIPTION
## Summary

Reorder the `LANGUAGES` setting so German is listed before English in `lunes_cms/core/settings.py`. Closes #771.

## Why this matters

Lunes is a German vocabulary trainer (per the README); the issue notes that during e2e test review it became clear "the system is used mainly in German." The list order in `LANGUAGES` drives the order users see in Django's language picker and any UI that iterates the setting directly. Surfacing German first matches what the actual primary use is.

`LANGUAGE_CODE = "en"` (line 234) is intentionally left alone. The issue scoped the change to list order, not the installation's fallback language; flipping the default would change behavior for unrelated infrastructure pathways (initial-load redirects, untranslated string fallback) that nobody asked about.

### Short description

Swap the two entries in `LANGUAGES` so `("de", _("German"))` comes before `("en", _("English"))`.

### Proposed changes

- Swap the two entries in `LANGUAGES` in `lunes_cms/core/settings.py:237-240`: `("de", _("German"))` first, `("en", _("English"))` second.
- Leave `LANGUAGE_CODE = "en"` (line 234) unchanged — the issue specifically called out list order, not the installation default language.

### How to test

- `grep LANGUAGES -A 5 lunes_cms/core/settings.py` shows German first, English second.
- In a running CMS, Django language pickers, settings panels, and any UI that iterates `LANGUAGES` directly now renders the German entry first.

### Resolved issues

Fixes: #771

AI-assisted.
