### PR TITLE
Chore: Change test data

### DIFF
--- a/lunes_cms/cmsv2/fixtures/test_data.json
+++ b/lunes_cms/cmsv2/fixtures/test_data.json
@@ -47995,13 +47995,13 @@
       "last_login": "2026-06-28T23:17:49.927Z",
       "is_superuser": false,
       "username": "rebecca.redakteurin",
-      "first_name": "Rebecca",
-      "last_name": "Redakteurin",
-      "email": "rebecca.redakteurin@lunes.app",
+      "first_name": "Vanessa",
+      "last_name": "Vokabelverwalterin",
+      "email": "vanessa.vokabelverwalterin@lunes.app",
       "is_staff": true,
       "is_active": true,
       "date_joined": "2026-06-28T23:02:40Z",
-      "groups": [["Vokabelverwalter:innen"]],
+      "groups": [["Vokabelverwaltung"]],
       "user_permissions": []
     }
   },
@@ -48021,11 +48021,27 @@
       "groups": [["Expert:innen"]],
       "user_permissions": []
     }
+  }, {
+    "model": "auth.user",
+    "fields": {
+      "password": "pbkdf2_sha256$260000$tX360jOwBEnw2Ia8XAn0au$aLj/XCWIIqNKbv1UayRjYQA/CUo0AsFto5HuGUZBHPs=",
+      "last_login": "2026-06-28T23:17:49.927Z",
+      "is_superuser": false,
+      "username": "patrizia.partnermanagerin",
+      "first_name": "Patrizia",
+      "last_name": "Partnermanagerin",
+      "email": "patrizia.partnermanagerin@lunes.app",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2026-06-28T23:02:40Z",
+      "groups": [["Partnermanagement"]],
+      "user_permissions": []
+    }
   }, 
   {
     "model": "auth.group",
     "fields": {
-      "name": "Vokabelverwalter:innen",
+      "name": "Vokabelverwaltung",
       "icon": "",
       "permissions": [
         ["add_job", "cmsv2", "job"],
@@ -48065,6 +48081,34 @@
         ["change_imagereview", "cmsv2", "imagereview"],
         ["delete_imagereview", "cmsv2", "imagereview"],
         ["view_imagereview", "cmsv2", "imagereview"]
+      ]
+    }
+  }, {
+    "model": "auth.group",
+    "fields": {
+      "name": "Partnermanagement",
+      "icon": "",
+      "permissions": [
+        ["add_job", "cmsv2", "job"],
+        ["change_job", "cmsv2", "job"],
+        ["delete_job", "cmsv2", "job"],
+        ["view_job", "cmsv2", "job"],
+        ["add_word", "cmsv2", "word"],
+        ["change_word", "cmsv2", "word"],
+        ["delete_word", "cmsv2", "word"],
+        ["view_word", "cmsv2", "word"],
+        ["add_unit", "cmsv2", "unit"],
+        ["change_unit", "cmsv2", "unit"],
+        ["delete_unit", "cmsv2", "unit"],
+        ["view_unit", "cmsv2", "unit"],
+        ["add_feedback", "cmsv2", "feedback"],
+        ["change_feedback", "cmsv2", "feedback"],
+        ["delete_feedback", "cmsv2", "feedback"],
+        ["view_feedback", "cmsv2", "feedback"],
+        ["add_unitwordrelation", "cmsv2", "unitwordrelation"],
+        ["change_unitwordrelation", "cmsv2", "unitwordrelation"],
+        ["delete_unitwordrelation", "cmsv2", "unitwordrelation"],
+        ["view_unitwordrelation", "cmsv2", "unitwordrelation"]
       ]
     }
   }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds changes test data to be closer to the actual data (Vokabelverwalter:innen -> Vokabelverwaltung), and adds both the group "Partnermanagement" and a user "Patrizia" for this group.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add new group "Partnermanagement"
- Add new user "Patrizia"


### How to test
<!-- Please describe how to test this PR -->

- Login as Patrizia, and see that you can login with the standard lunes pw (see Readme). Please keep in mind that it hasn't been fully decided yet what makes the role of Partnermanagement, so the permissions aren't final yet :)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
