### PR TITLE
782: Support Python3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: pip-{{ checksum "setup.cfg" }}-v6
+          key: pip-{{ checksum "pyproject.toml" }}-v7
       - run:
           name: Creating virtual environment
           command: |
@@ -29,10 +29,10 @@ jobs:
             else
               python3 -m venv .venv
               source .venv/bin/activate
-              pip install -e .[dev,doc,test]
+              pip install -e .[dev,pinned,dev-pinned]
             fi
       - save_cache:
-          key: pip-{{ checksum "setup.cfg" }}-v6
+          key: pip-{{ checksum "pyproject.toml" }}-v7
           paths:
             - .venv
             - lunes_cms.egg-info
@@ -135,6 +135,37 @@ jobs:
           at: .
       - qlty/coverage_publish:
           files: coverage.xml
+  test-python313:
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          LUNES_CMS_SECRET_KEY: circleci-dummy-key
+          LUNES_CMS_DB_BACKEND: sqlite
+    steps:
+      - checkout
+      - restore_cache:
+          key: pip-3.13-{{ checksum "pyproject.toml" }}-v1
+      - run:
+          name: Create virtual environment
+          command: |
+            if [[ -d ".venv" ]]; then
+              echo "Virtual environment restored from cache, skipping pip install"
+            else
+              python3 -m venv .venv
+              source .venv/bin/activate
+              pip install -e .[dev,pinned,dev-pinned]
+            fi
+      - save_cache:
+          key: pip-3.13-{{ checksum "pyproject.toml" }}-v1
+          paths:
+            - .venv
+            - lunes_cms.egg-info
+            - /home/circleci/.cache/pip
+      - run:
+          name: Run tests
+          command: |
+            source .venv/bin/activate
+            pytest --disable-warnings --ds=lunes_cms.core.settings -q
   black:
     docker:
       - image: cimg/python:3.11
@@ -562,6 +593,10 @@ workflows:
       - test:
           requires:
             - compile-translations
+      - test-python313:
+          filters:
+            branches:
+              ignore: main
       - upload-test-coverage:
           context: codeclimate-lunes-cms
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
           name: Run tests
           command: |
             source .venv/bin/activate
-            pytest --disable-warnings --ds=lunes_cms.core.settings -q
+            ./tools/test.sh --ci
   black:
     docker:
       - image: cimg/python:3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 5.1",
     "Operating System :: POSIX :: Linux",
@@ -159,7 +160,7 @@ exclude_also = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.13"
 exclude = [
     '^lunes_cms/cms/',
     '^tests/api/',
@@ -171,7 +172,7 @@ check_untyped_defs = false
 disallow_untyped_defs = false
 
 [tool.black]
-target-version = ["py311"]
+target-version = ["py311", "py312", "py313"]
 
 [tool.isort]
 profile = "black"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -17,8 +17,15 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         # Verbosity for pytest
         -v|-vv|-vvv|-vvvv) VERBOSITY="$1";shift;;
+        # CI mode: skip database setup (pytest-django manages its own test DB)
+        --ci) CI_MODE=1;shift;;
     esac
 done
+
+# Require that the database exists and is in the correct state (skipped in CI mode)
+if [[ -z "${CI_MODE}" ]]; then
+    require_database
+fi
 
 # The default pytests args we use
 PYTEST_ARGS=("--disable-warnings" "--color=yes" "--cov=lunes_cms" "--cov-report=html" "--ds=lunes_cms.core.settings")
@@ -32,5 +39,7 @@ fi
 pytest "${PYTEST_ARGS[@]}"
 echo "✔ Tests successfully completed " | print_success
 
-echo -e "Open the following file in your browser to view the test coverage:\n" | print_info
-echo -e "\tfile://${BASE_DIR}/htmlcov/index.html\n" | print_bold
+if [[ -z "${CI_MODE}" ]]; then
+    echo -e "Open the following file in your browser to view the test coverage:\n" | print_info
+    echo -e "\tfile://${BASE_DIR}/htmlcov/index.html\n" | print_bold
+fi


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds support for Python3.13. The testing in the venv was successful. This PR changes the support of Python versions to include Python3.13, adds the Python version check to our CI and changes Python version Mypy checks against to 3.13.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add Python3.13
- Add Python to Circle CI
- Change Python default for Mypy to 3.13


### How to test
<!-- Please describe how to test this PR -->

- Please double check the CI config, I'm still struggling with that, and unsure if it makes sense
- Check the core functionality of the CMS 
- Node20 is already supported, so this closes 782

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #782 
