### PR TITLE
Fix test python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,16 @@ jobs:
             - lunes_cms.egg-info
             - /home/circleci/.cache/pip
       - run:
+          name: Migrate database
+          command: |
+            source .venv/bin/activate
+            lunes-cms-cli migrate
+      - run:
+          name: Load basic test data
+          command: |
+            source .venv/bin/activate
+            lunes-cms-cli loaddata lunes_cms/cms/fixtures/test_data.json
+      - run:
           name: Run tests
           command: |
             source .venv/bin/activate


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently the test python job imports all assets from git even they are not needed here.
As a result the job takes around 15m every time

### Proposed changes
<!-- Describe this PR in more detail. -->

- add db migration step and test data, to avoid loading all test data in bash script

### How to test
<!-- Please describe how to test this PR -->
Pipeline now runs in 2m35s

- https://app.circleci.com/pipelines/gh/digitalfabrik/lunes-cms/1896/workflows/6de87863-0a61-473b-8c25-e92a6866a5d8?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
