### PR TITLE
790: Fix sorting in csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ UNRELEASED
 * [ [#798](https://github.com/digitalfabrik/lunes-cms/issues/798) ] 798: Add bulk action to release units
 * [ [#667](https://github.com/digitalfabrik/lunes-cms/issues/667) ] 667: Show total session duration
 * [ [#625](https://github.com/digitalfabrik/lunes-cms/issues/625) ] 625: Generate example sentences via OpenAI
+* [ [#790](https://github.com/digitalfabrik/lunes-cms/issues/790) ] 790: Fix order of csv import
 
 2026.4.7
 --------

--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -180,7 +180,11 @@ class JobAdmin(BaseAdmin):
         for profession in queryset:
             resource = WordExportResource()
             units = Unit.objects.filter(jobs=profession)
-            words = Word.objects.filter(units__in=units).distinct()
+            words = (
+                Word.objects.filter(units__in=units)
+                .order_by("units__title", "word")
+                .distinct()
+            )
 
             dataset = Dataset(
                 *(resource.export_resource(word) for word in words),

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -1122,6 +1122,9 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 msgid "help"
 msgstr "Hilfe"
 
+#~ msgid "%(name)s %(label)"
+#~ msgstr "%(name)s (Neu)"
+
 #~ msgid "Day"
 #~ msgstr "Tag"
 
@@ -1181,9 +1184,6 @@ msgstr "Hilfe"
 
 #~ msgid "Can view analytics"
 #~ msgstr "Kann Analytik einsehen"
-
-#~ msgid "%(name)s %(label)"
-#~ msgstr "%(name)s (Neu)"
 
 #~ msgid "Admins"
 #~ msgstr "Administrator:innen"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the sorting in the csv export, ordering by units

### Proposed changes
<!-- Describe this PR in more detail. -->

- Order vocabulary by unit, then alphabetically


### How to test
<!-- Please describe how to test this PR -->

- Export a profession and see sorted list


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #790 
