### PR TITLE
775: Fix re import

### DIFF
--- a/.idea/runConfigurations/Run_tests.xml
+++ b/.idea/runConfigurations/Run_tests.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run tests" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="pytest e2e-tests/ -n auto --dist=loadgroup -m e2e" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tools/test.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/tools" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#739](https://github.com/digitalfabrik/lunes-cms/issues/739) ] 739: Add option to duplicate jobs
 * [ [#687](https://github.com/digitalfabrik/lunes-cms/issues/687) ] 687: Add automatical audio generation after CSV import
 * [ [#775](https://github.com/digitalfabrik/lunes-cms/issues/775) ] 775: Fix job csv re-import
+* [ [#777](https://github.com/digitalfabrik/lunes-cms/issues/777) ] 777: Add plural and plural article to CSV import
 
 2026.4.7
 --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#375](https://github.com/digitalfabrik/lunes-cms/issues/375) ] 375: Add created by filter to CMS
 * [ [#739](https://github.com/digitalfabrik/lunes-cms/issues/739) ] 739: Add option to duplicate jobs
 * [ [#687](https://github.com/digitalfabrik/lunes-cms/issues/687) ] 687: Add automatical audio generation after CSV import
+* [ [#775](https://github.com/digitalfabrik/lunes-cms/issues/775) ] 775: Fix job csv re-import
 
 2026.4.7
 --------

--- a/lunes_cms/cmsv2/admins/word_export_resource.py
+++ b/lunes_cms/cmsv2/admins/word_export_resource.py
@@ -39,6 +39,8 @@ class WordExportResource(resources.ModelResource):
                 return article_choice[1]
         return "-"
 
+    plural = fields.Field(column_name=_("Plural"), attribute="plural")
+
     plural_article = fields.Field(
         column_name=_("Plural Article"),
         attribute="plural_article_choices",
@@ -50,7 +52,7 @@ class WordExportResource(resources.ModelResource):
         """
         for article_choice in Static.plural_article_choices:
             if article_choice[0] == word.plural_article:
-                return article_choice[1]
+                return article_choice[1].replace(" (Plural)", "")
         return "-"
 
     has_audio = fields.Field(column_name=_("Has audio?"), attribute="word")
@@ -100,6 +102,7 @@ class WordExportResource(resources.ModelResource):
             "word",
             "word_type",
             "singular_article",
+            "plural",
             "plural_article",
             "has_audio",
             "example_sentence",

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -26,10 +26,10 @@ def _build_column_mapping() -> dict[str, str]:
         "Vokabel": "word",
         # singular article
         "Singular Article": "article",
-        "Singular Artikel": "article",
+        "Singularartikel": "article",
         # plural article
         "Plural Article": "plural_article",
-        "Plural Artikel": "plural_article",
+        "Pluralartikel": "plural_article",
         # example sentence
         "Example sentence": "example",
         "Beispielsatz": "example",

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -51,6 +51,7 @@ class ParsedRow:
     unit: str
     word: str
     article: str
+    plural_article: str = ""
     example: str = ""
 
 
@@ -84,6 +85,18 @@ def map_article_to_int(article: str) -> int:
     return ARTICLE_MAP.get(article, 0)
 
 
+def map_plural_article_to_int(plural_article: str) -> int | None:
+    """
+    Converts plural article string to its int in DB. Returns None for empty or
+    unknown values (the field is nullable).
+    """
+    ARTICLE_MAP: dict[str, int] = {
+        label.lower(): value for value, label in Static.plural_article_choices
+    }
+    normalized = plural_article.lower().strip()
+    return ARTICLE_MAP.get(normalized)
+
+
 def create_unit(unit_title: str, job: Job) -> Unit:
     """
     Create a new unit - even if one already exists with the same title.
@@ -94,12 +107,16 @@ def create_unit(unit_title: str, job: Job) -> Unit:
 
 
 def create_word(
-    word_text: str, singular_article: int
+    word_text: str, singular_article: int, plural_article: int | None
 ) -> Word:
     """
     Creates a new word object.
     """
-    return Word.objects.create(word=word_text, singular_article=singular_article)
+    return Word.objects.create(
+        word=word_text,
+        singular_article=singular_article,
+        plural_article=plural_article,
+    )
 
 
 def update_or_add_example_sentence(word_obj: Word, word_defaults: dict) -> None:
@@ -156,12 +173,14 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
             )
 
         article = mapped.get("article", "").lower()
+        plural_article = mapped.get("plural_article", "")
         example = mapped.get("example", "")
 
         return ParsedRow(
             unit=unit,
             word=word,
             article=article,
+            plural_article=plural_article,
             example=example,
         )
 
@@ -208,7 +227,8 @@ def process_row(
             unit.jobs.add(job)
 
     article_int = map_article_to_int(parsed.article)
-    word = create_word(parsed.word, article_int)
+    plural_article_int = map_plural_article_to_int(parsed.plural_article)
+    word = create_word(parsed.word, article_int, plural_article_int)
     created += 1
 
     update_or_add_example_sentence(word, {"example_sentence": parsed.example})

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -27,6 +27,8 @@ def _build_column_mapping() -> dict[str, str]:
         # singular article
         "Singular Article": "article",
         "Singularartikel": "article",
+        # plural word
+        "Plural": "plural",
         # plural article
         "Plural Article": "plural_article",
         "Pluralartikel": "plural_article",
@@ -51,6 +53,7 @@ class ParsedRow:
     unit: str
     word: str
     article: str
+    plural: str = ""
     plural_article: str = ""
     example: str = ""
 
@@ -92,6 +95,9 @@ def map_plural_article_to_int(plural_article: str) -> int | None:
     """
     ARTICLE_MAP: dict[str, int] = {
         label.lower(): value for value, label in Static.plural_article_choices
+    } | {
+        label.lower().replace(" (plural)", ""): value
+        for value, label in Static.plural_article_choices
     }
     normalized = plural_article.lower().strip()
     return ARTICLE_MAP.get(normalized)
@@ -107,7 +113,7 @@ def create_unit(unit_title: str, job: Job) -> Unit:
 
 
 def create_word(
-    word_text: str, singular_article: int, plural_article: int | None
+    word_text: str, singular_article: int, plural_article: int | None, plural: str = ""
 ) -> Word:
     """
     Creates a new word object.
@@ -116,6 +122,7 @@ def create_word(
         word=word_text,
         singular_article=singular_article,
         plural_article=plural_article,
+        plural=plural,
     )
 
 
@@ -173,6 +180,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
             )
 
         article = mapped.get("article", "").lower()
+        plural = mapped.get("plural", "")
         plural_article = mapped.get("plural_article", "")
         example = mapped.get("example", "")
 
@@ -180,6 +188,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
             unit=unit,
             word=word,
             article=article,
+            plural=plural,
             plural_article=plural_article,
             example=example,
         )
@@ -228,7 +237,7 @@ def process_row(
 
     article_int = map_article_to_int(parsed.article)
     plural_article_int = map_plural_article_to_int(parsed.plural_article)
-    word = create_word(parsed.word, article_int, plural_article_int)
+    word = create_word(parsed.word, article_int, plural_article_int, parsed.plural)
     created += 1
 
     update_or_add_example_sentence(word, {"example_sentence": parsed.example})

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -10,19 +10,36 @@ from ..models import Job, Static, Unit, Word
 logger = logging.getLogger(__name__)
 
 
-COLUMN_MAPPING: dict[str, str] = {
-    key.lower(): value
-    for key, value in {
+def _build_column_mapping() -> dict[str, str]:
+    """
+    Maps CSV column headers (from the exporter or legacy templates) to internal
+    field names. Both German and English export headers are listed explicitly
+    since the exported CSV uses the language of the admin interface at export
+    time.
+    """
+    return {
+        # unit
+        "Units": "unit",
         "Einheit": "unit",
-        "Sinneinheit": "unit",
-        "Sinneseinheit": "unit",
+        # word
+        "Word": "word",
+        "Vokabel": "word",
+        # singular article
+        "Singular Article": "article",
+        "Singular Artikel": "article",
+        # plural article
+        "Plural Article": "plural_article",
+        "Plural Artikel": "plural_article",
+        # example sentence
+        "Example sentence": "example",
+        "Beispielsatz": "example",
+        # For legacy imports
+        "Artikel": "article",
         "Fachbegriff": "word",
         "Begriff": "word",
-        "Vokabel": "word",
-        "Artikel": "article",
-        "Beispielsatz": "example",
-    }.items()
-}
+        "Sinneinheit": "unit",
+        "Sinneseinheit": "unit",
+    }
 
 
 @dataclass(frozen=True)
@@ -76,7 +93,9 @@ def create_unit(unit_title: str, job: Job) -> Unit:
     return unit
 
 
-def create_word(word_text: str, singular_article: int) -> Word:
+def create_word(
+    word_text: str, singular_article: int
+) -> Word:
     """
     Creates a new word object.
     """
@@ -97,12 +116,13 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
     Parses a single row and returns either a ParsedRow or a RowResult (error).
     """
     try:
+        column_mapping = _build_column_mapping()
         mapped = {
-            COLUMN_MAPPING[key.strip().lower()]: (
+            column_mapping[key.strip().lower()]: (
                 value.strip() if isinstance(value, str) else value
             )
             for key, value in raw_row.items()
-            if key and COLUMN_MAPPING.get(key.strip().lower())
+            if key and column_mapping.get(key.strip().lower())
         }
 
         if not mapped:
@@ -112,7 +132,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
             )
 
         unknown_keys = {
-            k.strip() for k in raw_row.keys() if k and not COLUMN_MAPPING.get(k.strip())
+            k.strip() for k in raw_row.keys() if k and not column_mapping.get(k.strip())
         }
         if unknown_keys:
             logger.info(
@@ -138,7 +158,12 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
         article = mapped.get("article", "").lower()
         example = mapped.get("example", "")
 
-        return ParsedRow(unit=unit, word=word, article=article, example=example)
+        return ParsedRow(
+            unit=unit,
+            word=word,
+            article=article,
+            example=example,
+        )
 
     except (AttributeError, TypeError) as exc:
         logger.warning("Row %s – malformed column data: %s", row_number, exc)

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -140,7 +140,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
     Parses a single row and returns either a ParsedRow or a RowResult (error).
     """
     try:
-        column_mapping = _build_column_mapping()
+        column_mapping = {k.lower(): v for k, v in _build_column_mapping().items()}
         mapped = {
             column_mapping[key.strip().lower()]: (
                 value.strip() if isinstance(value, str) else value

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 18:21+0000\n"
+"POT-Creation-Date: 2026-06-09 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,29 +148,29 @@ msgstr "Wortart"
 msgid "Singular Article"
 msgstr "Singular Artikel"
 
-#: cms/admins/document_resource.py:43 cmsv2/admins/word_export_resource.py:43
+#: cms/admins/document_resource.py:43 cmsv2/admins/word_export_resource.py:45
 msgid "Plural Article"
 msgstr "Plural Artikel"
 
-#: cms/admins/document_resource.py:56 cmsv2/admins/word_export_resource.py:56
+#: cms/admins/document_resource.py:56 cmsv2/admins/word_export_resource.py:58
 msgid "Has audio?"
 msgstr "Audio"
 
 #: cms/admins/document_resource.py:63 cmsv2/admins/word_admin.py:25
-#: cmsv2/admins/word_admin.py:75 cmsv2/admins/word_export_resource.py:63
+#: cmsv2/admins/word_admin.py:75 cmsv2/admins/word_export_resource.py:65
 msgid "Yes"
 msgstr "Ja"
 
 #: cms/admins/document_resource.py:64 cmsv2/admins/word_admin.py:26
-#: cmsv2/admins/word_admin.py:76 cmsv2/admins/word_export_resource.py:64
+#: cmsv2/admins/word_admin.py:76 cmsv2/admins/word_export_resource.py:66
 msgid "No"
 msgstr "Nein"
 
-#: cms/admins/document_resource.py:67 cmsv2/admins/word_export_resource.py:67
+#: cms/admins/document_resource.py:67 cmsv2/admins/word_export_resource.py:69
 msgid "Example sentence"
 msgstr "Beispielsatz"
 
-#: cms/admins/document_resource.py:71 cmsv2/admins/word_export_resource.py:71
+#: cms/admins/document_resource.py:71 cmsv2/admins/word_export_resource.py:73
 msgid "Creation date"
 msgstr "Erstellt am"
 
@@ -793,37 +793,43 @@ msgstr "Audio Prüfstatus"
 msgid "image check status"
 msgstr "Bild Prüfstatus"
 
-#: cmsv2/admins/word_export_resource.py:80 cmsv2/models/unit.py:407
+#: cmsv2/admins/word_export_resource.py:42
+#, fuzzy
+#| msgid "plural"
+msgid "Plural"
+msgstr "Plural"
+
+#: cmsv2/admins/word_export_resource.py:82 cmsv2/models/unit.py:407
 #: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:9
 msgid "Units"
 msgstr "Einheit"
 
-#: cmsv2/admins/word_import_resource.py:110
+#: cmsv2/admins/word_import_resource.py:154
 #, python-format
 msgid "Row %(n)s: No recognised columns – row will be skipped."
 msgstr "Zeile %(n)s: Die Spalte Einheit ist leer, wird übersprungen."
 
-#: cmsv2/admins/word_import_resource.py:127
+#: cmsv2/admins/word_import_resource.py:171
 #, python-format
 msgid "Row %(n)s: Unit column is empty, row will be skipped."
 msgstr "Zeile %(n)s: Die Spalte Einheit ist leer, wird übersprungen."
 
-#: cmsv2/admins/word_import_resource.py:134
+#: cmsv2/admins/word_import_resource.py:178
 #, python-format
 msgid "Row %(n)s: Vocabulary column is empty, row will be skipped."
 msgstr "Zeile %(n)s: Die Spalte Vokabel ist leer, wird übersprungen."
 
-#: cmsv2/admins/word_import_resource.py:146
+#: cmsv2/admins/word_import_resource.py:199
 #, python-format
 msgid "Row %(n)s: Malformed column data – %(e)s"
 msgstr "Zeile %(n)s: Fehlerhafte Spaltendaten – %(e)s"
 
-#: cmsv2/admins/word_import_resource.py:155
+#: cmsv2/admins/word_import_resource.py:208
 #, python-format
 msgid "Row %(n)s: Unexpected parsing error – %(e)s"
 msgstr "Zeile %(n)s: Unerwarteter Fehler - %(e)s"
 
-#: cmsv2/admins/word_import_resource.py:229
+#: cmsv2/admins/word_import_resource.py:283
 #, python-format
 msgid "Row %(n)s: %(msg)s"
 msgstr "Zeile %(n)s: %(msg)s"

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -794,8 +794,6 @@ msgid "image check status"
 msgstr "Bild Prüfstatus"
 
 #: cmsv2/admins/word_export_resource.py:42
-#, fuzzy
-#| msgid "plural"
 msgid "Plural"
 msgstr "Plural"
 

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -1,0 +1,244 @@
+"""
+Tests for the CSV word import resource (column mapping, row parsing, full import).
+Covers the re-import workflow described in issue #775.
+"""
+
+import pytest
+from tablib import Dataset
+
+from lunes_cms.cmsv2.admins.word_import_resource import (
+    ParsedRow,
+    RowResult,
+    _build_column_mapping,
+    import_words_from_csv,
+    map_plural_article_to_int,
+    parse_row,
+)
+from lunes_cms.cmsv2.models import Word
+from lunes_cms.cmsv2.models.job import Job
+
+# ---------------------------------------------------------------------------
+# Column mapping
+# ---------------------------------------------------------------------------
+
+
+def test_german_export_columns_are_mapped():
+    """German column names produced by the exporter are recognised."""
+    mapping = _build_column_mapping()
+    assert mapping["Einheit"] == "unit"
+    assert mapping["Vokabel"] == "word"
+    assert mapping["Singular Artikel"] == "article"
+    assert mapping["Plural Artikel"] == "plural_article"
+    assert mapping["Beispielsatz"] == "example"
+
+
+def test_english_export_columns_are_mapped():
+    """English column names produced by the exporter are recognised."""
+    mapping = _build_column_mapping()
+    assert mapping["Units"] == "unit"
+    assert mapping["Word"] == "word"
+    assert mapping["Singular Article"] == "article"
+    assert mapping["Plural Article"] == "plural_article"
+    assert mapping["Example sentence"] == "example"
+
+
+def test_legacy_column_names_are_mapped():
+    """Legacy column names from older import templates are still recognised."""
+    mapping = _build_column_mapping()
+    assert mapping["Sinneinheit"] == "unit"
+    assert mapping["Sinneseinheit"] == "unit"
+    assert mapping["Fachbegriff"] == "word"
+    assert mapping["Begriff"] == "word"
+    assert mapping["Artikel"] == "article"
+
+
+# ---------------------------------------------------------------------------
+# map_plural_article_to_int
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("die (Plural)", 1),
+        ("DIE (PLURAL)", 1),
+        ("keiner", 0),
+        ("", None),
+        ("-", None),
+        ("unknown", None),
+    ],
+)
+def test_map_plural_article_to_int(value, expected):
+    assert map_plural_article_to_int(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# parse_row
+# ---------------------------------------------------------------------------
+
+
+def _make_row(**overrides) -> dict:
+    row = {"Einheit": "Werkzeug", "Vokabel": "Hammer", "Artikel": "der"}
+    row.update(overrides)
+    return row
+
+
+def test_parse_row_returns_parsed_row():
+    result = parse_row(_make_row(), 1)
+    assert isinstance(result, ParsedRow)
+    assert result.unit == "Werkzeug"
+    assert result.word == "Hammer"
+    assert result.article == "der"
+
+
+def test_parse_row_parses_plural_article():
+    result = parse_row(_make_row(**{"Plural Artikel": "die (Plural)"}), 1)
+    assert isinstance(result, ParsedRow)
+    assert result.plural_article == "die (Plural)"
+
+
+def test_parse_row_parses_example_sentence():
+    result = parse_row(_make_row(Beispielsatz="Der Hammer ist schwer."), 1)
+    assert isinstance(result, ParsedRow)
+    assert result.example == "Der Hammer ist schwer."
+
+
+def test_parse_row_english_column_names():
+    row = {
+        "Units": "Werkzeug",
+        "Word": "Hammer",
+        "Singular Article": "der",
+        "Plural Article": "die (Plural)",
+        "Example sentence": "Der Hammer ist schwer.",
+    }
+    result = parse_row(row, 1)
+    assert isinstance(result, ParsedRow)
+    assert result.unit == "Werkzeug"
+    assert result.word == "Hammer"
+    assert result.article == "der"
+    assert result.plural_article == "die (Plural)"
+    assert result.example == "Der Hammer ist schwer."
+
+
+def test_parse_row_missing_unit_returns_error():
+    result = parse_row(_make_row(Einheit=""), 1)
+    assert isinstance(result, RowResult)
+    assert result.error is not None
+
+
+def test_parse_row_missing_word_returns_error():
+    result = parse_row(_make_row(Vokabel=""), 1)
+    assert isinstance(result, RowResult)
+    assert result.error is not None
+
+
+def test_parse_row_no_recognised_columns_returns_error():
+    result = parse_row({"Unknown": "value"}, 1)
+    assert isinstance(result, RowResult)
+    assert result.error is not None
+
+
+def test_parse_row_strips_whitespace_from_column_names():
+    row = {" Einheit ": "Werkzeug", " Vokabel ": "Hammer", " Artikel ": "der"}
+    result = parse_row(row, 1)
+    assert isinstance(result, ParsedRow)
+
+
+# ---------------------------------------------------------------------------
+# import_words_from_csv — integration
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset(headers: list[str], rows: list[list]) -> Dataset:
+    ds = Dataset(headers=headers)
+    for row in rows:
+        ds.append(row)
+    return ds
+
+
+@pytest.fixture
+def job(db) -> Job:
+    return Job.objects.create(name="Test Job")
+
+
+def _job_words(job: Job):
+    """Return queryset of words imported into the given job."""
+    return Word.objects.filter(units__jobs=job)
+
+
+@pytest.mark.django_db
+def test_import_with_german_headers(job):
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["Werkzeug", "Hammer", "der"], ["Werkzeug", "Säge", "die"]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job)
+    assert errors == []
+    assert _job_words(job).count() == 2
+
+
+@pytest.mark.django_db
+def test_reimport_with_english_headers(job):
+    """Re-import of a CSV exported with English admin locale works (issue #775)."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Plural Article", "Example sentence"],
+        [["Werkzeug", "Hammer", "der", "die (Plural)", "Der Hammer ist schwer."]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job)
+    assert errors == []
+    word = _job_words(job).get(word="Hammer")
+    assert word.plural_article == 1
+    assert word.example_sentence == "Der Hammer ist schwer."
+
+
+@pytest.mark.django_db
+def test_reimport_with_german_headers(job):
+    """Re-import of a CSV exported with German admin locale works (issue #775)."""
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Singular Artikel", "Plural Artikel", "Beispielsatz"],
+        [["Werkzeug", "Hammer", "der", "die (Plural)", "Der Hammer ist schwer."]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job)
+    assert errors == []
+    assert _job_words(job).get(word="Hammer").plural_article == 1
+
+
+@pytest.mark.django_db
+def test_plural_article_dash_stored_as_none(job):
+    """'-' in the plural article column (exporter default) is stored as None."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Plural Article"],
+        [["Werkzeug", "Hammer", "der", "-"]],
+    )
+    import_words_from_csv(ds, job)
+    assert _job_words(job).get(word="Hammer").plural_article is None
+
+
+@pytest.mark.django_db
+def test_extra_export_columns_are_ignored(job):
+    """Extra columns from the export (Word type, Has audio?, Creation date) don't cause errors."""
+    ds = _make_dataset(
+        [
+            "Units",
+            "Word",
+            "Singular Article",
+            "Word type",
+            "Has audio?",
+            "Creation date",
+        ],
+        [["Werkzeug", "Hammer", "der", "noun", "No", "01.01.2026 10:00"]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job)
+    assert errors == []
+    assert _job_words(job).count() == 1
+
+
+@pytest.mark.django_db
+def test_empty_rows_produce_errors(job):
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["", "Hammer", "der"], ["Werkzeug", "", "der"]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job)
+    assert len(errors) == 2
+    assert _job_words(job).count() == 0

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -27,8 +27,9 @@ def test_german_export_columns_are_mapped():
     mapping = _build_column_mapping()
     assert mapping["Einheit"] == "unit"
     assert mapping["Vokabel"] == "word"
-    assert mapping["Singular Artikel"] == "article"
-    assert mapping["Plural Artikel"] == "plural_article"
+    assert mapping["Singularartikel"] == "article"
+    assert mapping["Plural"] == "plural"
+    assert mapping["Pluralartikel"] == "plural_article"
     assert mapping["Beispielsatz"] == "example"
 
 
@@ -38,6 +39,7 @@ def test_english_export_columns_are_mapped():
     assert mapping["Units"] == "unit"
     assert mapping["Word"] == "word"
     assert mapping["Singular Article"] == "article"
+    assert mapping["Plural"] == "plural"
     assert mapping["Plural Article"] == "plural_article"
     assert mapping["Example sentence"] == "example"
 
@@ -62,6 +64,8 @@ def test_legacy_column_names_are_mapped():
     [
         ("die (Plural)", 1),
         ("DIE (PLURAL)", 1),
+        ("die", 1),
+        ("DIE", 1),
         ("keiner", 0),
         ("", None),
         ("-", None),
@@ -92,7 +96,7 @@ def test_parse_row_returns_parsed_row():
 
 
 def test_parse_row_parses_plural_article():
-    result = parse_row(_make_row(**{"Plural Artikel": "die (Plural)"}), 1)
+    result = parse_row(_make_row(**{"Pluralartikel": "die (Plural)"}), 1)
     assert isinstance(result, ParsedRow)
     assert result.plural_article == "die (Plural)"
 
@@ -195,11 +199,36 @@ def test_reimport_with_english_headers(job):
 def test_reimport_with_german_headers(job):
     """Re-import of a CSV exported with German admin locale works (issue #775)."""
     ds = _make_dataset(
-        ["Einheit", "Vokabel", "Singular Artikel", "Plural Artikel", "Beispielsatz"],
+        ["Einheit", "Vokabel", "Singularartikel", "Pluralartikel", "Beispielsatz"],
         [["Werkzeug", "Hammer", "der", "die (Plural)", "Der Hammer ist schwer."]],
     )
     _, _, errors, _ = import_words_from_csv(ds, job)
     assert errors == []
+    assert _job_words(job).get(word="Hammer").plural_article == 1
+
+
+@pytest.mark.django_db
+def test_import_plural_word(job):
+    """The Plural column is imported and stored on the word."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Plural", "Plural Article"],
+        [["Werkzeug", "Hammer", "der", "Hämmer", "die"]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job)
+    assert errors == []
+    word = _job_words(job).get(word="Hammer")
+    assert word.plural == "Hämmer"
+    assert word.plural_article == 1
+
+
+@pytest.mark.django_db
+def test_plural_article_short_form_stored(job):
+    """'die' (short form exported by the exporter) is stored as plural article 1."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Plural Article"],
+        [["Werkzeug", "Hammer", "der", "die"]],
+    )
+    import_words_from_csv(ds, job)
     assert _job_words(job).get(word="Hammer").plural_article == 1
 
 


### PR DESCRIPTION
### Short description
I addressed the column mismatched between article and singular article and also improved the language issue.

### Proposed changes
<!-- Describe this PR in more detail. -->

- distinguish between singular and plural article
- plural article will also be exported (and imported)
- fix language mismatch, f.e. english exports couldn't be imported because the import expects german header column names
- add plural word to csv (import & export)
- add tests 
- add intelliJ runConfig for tests


### How to test
<!-- Please describe how to test this PR -->

- export german job to csv
- import german job csv 
- switch to english and do the same
- Also add a plural article in some words and export the csv and check that the article will be exported 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #775
Fixes: #777
