### PR TITLE
798: Add release bulk action for units

### DIFF
--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -3,13 +3,15 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
+from django.db.models import QuerySet
+from django.http import HttpRequest
 from django.template.response import TemplateResponse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from lunes_cms.cmsv2.admins.base import BaseAdmin
 from lunes_cms.cmsv2.models.review import ReviewAssignment
-from lunes_cms.cmsv2.models.unit import UnitWordRelation
+from lunes_cms.cmsv2.models.unit import Unit, UnitWordRelation
 
 
 class WordInline(admin.TabularInline):
@@ -133,7 +135,7 @@ class UnitAdmin(BaseAdmin):
     list_display_links = ["title"]
     list_filter = ["released", MigratedFilter, "jobs"]
     list_per_page = 25
-    actions = ["assign_to_user"]
+    actions = ["bulk_release", "assign_to_user"]
 
     class Media:
         """
@@ -161,6 +163,28 @@ class UnitAdmin(BaseAdmin):
             formset.save_m2m()
         else:
             super().save_formset(request, form, formset, change)
+
+    @admin.action(description=_("Release all selected units"))
+    def bulk_release(self, request: HttpRequest, queryset: QuerySet[Unit]) -> None:
+        """
+        Bulk action to release selected units in one go
+        """
+        if not request.user.has_perm("change_unit"):
+            raise PermissionDenied
+
+        units_skipped = queryset.filter(released=True).count()
+        released_unit_count = queryset.filter(released=False).update(released=True)
+
+        self.message_user(
+            request,
+            _(
+                "Released %(unit_count)d unit(s). %(units_skipped)d unit(s) were skipped, because they were already released"
+            )
+            % {
+                "unit_count": released_unit_count,
+                "units_skipped": units_skipped,
+            },
+        )
 
     @admin.action(description=_("Assign selected units to user"))
     def assign_to_user(self, request, queryset):

--- a/lunes_cms/cmsv2/fixtures/test_data.json
+++ b/lunes_cms/cmsv2/fixtures/test_data.json
@@ -47994,14 +47994,14 @@
       "password": "pbkdf2_sha256$260000$tX360jOwBEnw2Ia8XAn0au$aLj/XCWIIqNKbv1UayRjYQA/CUo0AsFto5HuGUZBHPs=",
       "last_login": "2026-06-28T23:17:49.927Z",
       "is_superuser": false,
-      "username": "rebecca.redakteurin",
+      "username": "vanessa.vokabelverwalterin",
       "first_name": "Vanessa",
       "last_name": "Vokabelverwalterin",
       "email": "vanessa.vokabelverwalterin@lunes.app",
       "is_staff": true,
       "is_active": true,
       "date_joined": "2026-06-28T23:02:40Z",
-      "groups": [["Vokabelverwaltung"]],
+      "groups": [["Lunes Vokabelverwaltung (v2)"]],
       "user_permissions": []
     }
   },
@@ -48034,14 +48034,14 @@
       "is_staff": true,
       "is_active": true,
       "date_joined": "2026-06-28T23:02:40Z",
-      "groups": [["Partnermanagement"]],
+      "groups": [["Lunes Partnermanagement (v2)"]],
       "user_permissions": []
     }
   }, 
   {
     "model": "auth.group",
     "fields": {
-      "name": "Vokabelverwaltung",
+      "name": "Lunes Vokabelverwaltung (v2)",
       "icon": "",
       "permissions": [
         ["add_job", "cmsv2", "job"],
@@ -48086,7 +48086,7 @@
   }, {
     "model": "auth.group",
     "fields": {
-      "name": "Partnermanagement",
+      "name": "Lunes Partnermanagement (v2)",
       "icon": "",
       "permissions": [
         ["add_job", "cmsv2", "job"],

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-11 10:41+0000\n"
+"POT-Creation-Date: 2026-06-12 10:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -109,7 +109,7 @@ msgid "published words in released modules"
 msgstr "veröffentlichte Vokabeln in veröffentlichten Modulen"
 
 #: cms/admins/discipline_admin.py:387 cms/admins/document_admin.py:179
-#: cms/admins/training_set_admin.py:378 cmsv2/admins/unit_admin.py:243
+#: cms/admins/training_set_admin.py:378 cmsv2/admins/unit_admin.py:267
 #: cmsv2/admins/word_admin.py:435
 msgid "creator group"
 msgstr "Besitzergruppe"
@@ -665,17 +665,17 @@ msgstr "Datei zu groß! Max. 5 MB"
 msgid "Only use one file extension!"
 msgstr "Nur maximal ein Dateityp erlaubt!"
 
-#: cmsv2/admins/job_admin.py:38 cmsv2/admins/unit_admin.py:70
+#: cmsv2/admins/job_admin.py:38 cmsv2/admins/unit_admin.py:72
 #: cmsv2/admins/word_admin.py:115
 msgid "migration status"
 msgstr "Ablaufdatum"
 
-#: cmsv2/admins/job_admin.py:49 cmsv2/admins/unit_admin.py:81
+#: cmsv2/admins/job_admin.py:49 cmsv2/admins/unit_admin.py:83
 #: cmsv2/admins/word_admin.py:126
 msgid "Migrated from old data model"
 msgstr "Migriert aus altem Datenmodell"
 
-#: cmsv2/admins/job_admin.py:50 cmsv2/admins/unit_admin.py:82
+#: cmsv2/admins/job_admin.py:50 cmsv2/admins/unit_admin.py:84
 #: cmsv2/admins/word_admin.py:127
 msgid "Not migrated from old data model"
 msgstr "Nicht migriert aus altem Datenmodell"
@@ -684,12 +684,12 @@ msgstr "Nicht migriert aus altem Datenmodell"
 msgid "units"
 msgstr "Einheiten"
 
-#: cmsv2/admins/job_admin.py:144 cmsv2/admins/unit_admin.py:257
+#: cmsv2/admins/job_admin.py:144 cmsv2/admins/unit_admin.py:281
 #: cmsv2/models/job.py:34 cmsv2/models/review.py:102 cmsv2/models/unit.py:329
 msgid "created at"
 msgstr "Erstellt"
 
-#: cmsv2/admins/job_admin.py:166 cmsv2/admins/unit_admin.py:279
+#: cmsv2/admins/job_admin.py:166 cmsv2/admins/unit_admin.py:303
 #: cmsv2/admins/word_admin.py:712
 msgid "migrated"
 msgstr "Migriert"
@@ -714,28 +714,41 @@ msgstr "Die ausgewählten Berufe wurden erfolgreich dupliziert."
 msgid "Import"
 msgstr "Import"
 
-#: cmsv2/admins/unit_admin.py:50
+#: cmsv2/admins/unit_admin.py:52
 msgid "assigned user"
 msgstr "Zugewiesene Person"
 
-#: cmsv2/admins/unit_admin.py:51
+#: cmsv2/admins/unit_admin.py:53
 msgid "assigned users"
 msgstr "Zugewiesene Personen"
 
-#: cmsv2/admins/unit_admin.py:165 cmsv2/admins/unit_admin.py:185
+#: cmsv2/admins/unit_admin.py:167
+msgid "Release all selected units"
+msgstr "Alle ausgewählte Einheiten veröffentlichen"
+
+#: cmsv2/admins/unit_admin.py:181
+#, python-format
+msgid ""
+"Released %(unit_count)d unit(s). %(units_skipped)d unit(s) were skipped, "
+"because they were already released"
+msgstr ""
+"%(unit_count)d Einheit(en) wurden veröffentlicht. %(units_skipped)d "
+"Einheiten wurden übersprungen, da sie bereits veröffentlicht waren"
+
+#: cmsv2/admins/unit_admin.py:189 cmsv2/admins/unit_admin.py:209
 #: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:4
 #: cmsv2/templates/admin/cmsv2/assign_units_to_user.html:14
 msgid "Assign selected units to user"
 msgstr "Ausgewählte Einheiten zuweisen"
 
-#: cmsv2/admins/unit_admin.py:203
+#: cmsv2/admins/unit_admin.py:227
 #, python-format
 msgid "Assigned %(new)d unit(s) to %(user)s (%(skipped)d already assigned)."
 msgstr ""
 "%(new)d Einheit(en) an %(user)s zugewiesen (%(skipped)d waren bereits "
 "zugewiesen)."
 
-#: cmsv2/admins/unit_admin.py:224
+#: cmsv2/admins/unit_admin.py:248
 msgid "jobs"
 msgstr "Berufe"
 
@@ -1113,6 +1126,9 @@ msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 #: help/apps.py:13
 msgid "help"
 msgstr "Hilfe"
+
+#~ msgid "Admins"
+#~ msgstr "Administrator:innen"
 
 #, python-format
 #~ msgid "Unexpected error - %(e)s"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds a bulk action to release multiple units at once. At the moments it's really tedious to publish professions because at the moment we need to go through every single unit and publish it first. Because there are a couple of professions waiting to get released soon, this PR is quite important at the moment. I won't be able to commit a lot of time to it, so feel free to improve this PR by adding commits to it :)

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add option to release multiple units at once
- Add constants for user roles


### How to test
<!-- Please describe how to test this PR -->

- Check in units if units can be bulk released
- Check the roles by logging in with the test data :)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #798 
