### PR TITLE
687: Generate word images on CSV import

### DIFF
--- a/docs/src/image-generation.rst
+++ b/docs/src/image-generation.rst
@@ -1,0 +1,50 @@
+**********************
+Image Generation
+**********************
+
+Lunes can generate vocabulary images via the OpenAI image API. The vocabulary
+admin can trigger it per word, and images are generated automatically in the
+background for words created through the CSV import.
+
+This requires an API key; without it the feature is simply disabled (a warning
+is logged on startup) and everything else keeps working.
+
+The on-demand admin view and the background worker share the same prompt, model
+and quality settings, so a manually generated image and an import-generated one
+are produced the same way.
+
+Background worker
+=================
+
+The database itself is the queue: a ``Word`` with an empty ``image`` field is
+considered "pending". After a successful CSV import, a background worker thread
+picks up the rows that import just created, calls the OpenAI image API and saves
+the files.
+
+The drain is scoped to the word IDs of that import, so an import only generates
+images for its own rows. The work is idempotent (already-populated rows are
+skipped) and isolates failures per row, so a single failing word does not block
+the rest. Generated files are stored under a UUID name by the field's
+``upload_to`` — the same convention as every other image in the system.
+
+Configuration
+=============
+
+Configure via environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Variable
+     - Default
+     - Description
+   * - ``LUNES_CMS_OPENAI_API_KEY``
+     - –
+     - OpenAI API key (required to enable image generation)
+   * - ``LUNES_CMS_OPENAI_IMAGE_MODEL``
+     - ``gpt-image-2``
+     - Model used for word image generation
+   * - ``LUNES_CMS_OPENAI_IMAGE_QUALITY``
+     - ``low``
+     - Image quality tier (``low`` / ``medium`` / ``high``)

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -36,11 +36,13 @@ Basic Concepts
     documentation
     continous-integration
     audio-generation
+    image-generation
 
 * :doc:`internationalization`: Internationalization (i18n)
 * :doc:`documentation`: Documentation (Sphinx)
 * :doc:`continous-integration`: Continous Integration (Circle CI)
 * :doc:`audio-generation`: OpenAI audio generation for vocabulary
+* :doc:`image-generation`: OpenAI image generation for vocabulary
 
 Deployment
 ==========

--- a/lunes_cms/cmsv2/services/image_generation.py
+++ b/lunes_cms/cmsv2/services/image_generation.py
@@ -1,0 +1,155 @@
+"""
+Background image generation for Word objects.
+
+Mirrors ``audio_generation``: the DB is the queue, a Word with an empty
+``image`` is "pending". A worker thread picks pending rows, calls the OpenAI
+image API, saves the file. Idempotent — already-populated rows are filtered
+out, so re-runs are free.
+
+The OpenAI call is made *outside* any DB transaction. An in-process lock makes
+the drain single-flight; it is separate from the audio drain's lock so image
+and audio generation can run concurrently.
+"""
+
+import base64
+import logging
+import threading
+import time
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.db import connection
+from django.db.models import Q
+from openai import RateLimitError
+
+from ..models import Word
+from ..utils import get_openai_client, OpenAIConfigurationError
+
+logger = logging.getLogger(__name__)
+
+_drain_lock = threading.Lock()
+
+
+def build_image_prompt(
+    word_text: str,
+    unit_title: str | None = None,
+    additional_info: str | None = None,
+) -> str:
+    """
+    Build the German image-generation prompt shared by the on-demand admin
+    view and the background import drain.
+    """
+    prompt = """Du bist Content-Manager für eine Vokabel-Lern-App namens "Lunes". Die App richtet sich an Zugewanderte, die in Deutschland eine Ausbildung machen oder bereits beruflich tätig sind. Sie lernen Deutsch als Fremdsprache und benötigen spezifischen Fachwortschatz, der in regulären Sprachkursen nicht vermittelt wird.
+
+        Die App zeigt Fachbegriffe aus dem Berufsfeld in Form von Bildern. Alle Vokabeln werden einsprachig (nur auf Deutsch) vermittelt – durch realistische Fotos, die das Wort eindeutig visuell darstellen.
+
+        Für die Bildsprache gelten folgende Vorgaben:
+        - Es sollen realistische Fotos sein (keine Illustrationen, keine Renderings).
+        - Das Bildmotiv muss eindeutig dem jeweiligen Fachbegriff zuzuordnen sein.
+        - Es soll nur der relevante Gegenstand oder die relevante Handlung zu sehen sein.
+        - Keine zusätzlichen Objekte, kein Text, neutraler Hintergrund (z.B. weiß oder freigestellt).
+    """
+    if unit_title:
+        prompt += f"Der Begriff gehört zum Lernmodul: {unit_title}.\n"
+    prompt += f'Erstelle ein passendes realistisches Foto zur Vokabel: "{word_text}".\n'
+    if additional_info:
+        prompt += f"Zusätzliche Hinweise zur Bildgestaltung: {additional_info}\n"
+    prompt += "Ziel ist es, dass die Vokabel durch das Bild eindeutig verstanden werden kann – auch ohne Text oder Erklärung."
+    return prompt
+
+
+def openai_word_image_bytes(word: Word) -> bytes:
+    """
+    Generate PNG bytes for a single word via the OpenAI image API.
+    """
+    client = get_openai_client()
+    response = client.images.generate(
+        model=settings.OPENAI_IMAGE_MODEL,
+        prompt=build_image_prompt(word.word),
+        size="1024x1024",
+        quality=settings.OPENAI_IMAGE_QUALITY,
+        n=1,
+    )
+    return base64.b64decode(response.data[0].b64_json)
+
+
+def _generate_for_word_image(word: Word) -> None:
+    """
+    Generate a missing image for a single Word and save it to the ImageField.
+
+    ``Word.save()`` converts the uploaded image to WebP and the field defaults
+    ``image_check_status`` to ``NOT_CHECKED``. The file name is the UUID the
+    field's ``upload_to`` assigns — same as every other image in the system.
+    """
+    if not word.image:
+        data = openai_word_image_bytes(word)
+        word.image.save("image.png", ContentFile(data))
+        logger.info("Generated image for word_id=%s (%s)", word.pk, word.word)
+
+
+def _pending_filter(word_ids: list[int] | None = None) -> Q:
+    pending = (Q(image="") | Q(image__isnull=True)) & ~Q(word="")
+    if word_ids is not None:
+        pending &= Q(pk__in=word_ids)
+    return pending
+
+
+def drain_pending_images(
+    word_ids: list[int] | None = None, throttle_seconds: float = 1.0
+) -> None:
+    """
+    Process Words that need an image, one at a time, until none remain.
+
+    ``word_ids`` restricts the drain to those Word rows (the ones a CSV
+    import just created). Without it the whole table is scanned.
+
+    Single-flight within the process: if another thread already holds the
+    drain lock this call returns immediately.
+
+    Failures on a single row are logged and the loop continues — the row's
+    image field stays empty so it'll be picked up on the next pass.
+    """
+    # Non-blocking single-flight guard; released in the finally below.
+    if not _drain_lock.acquire(blocking=False):  # pylint: disable=consider-using-with
+        return
+    failed_pks: set[int] = set()
+    try:
+        pending = Word.objects.filter(_pending_filter(word_ids)).count()
+        logger.info(
+            "Image drain starting: %s word(s) pending — "
+            "up to %s OpenAI image request(s)",
+            pending,
+            pending,
+        )
+        while True:
+            word = (
+                Word.objects.filter(_pending_filter(word_ids))
+                .exclude(pk__in=failed_pks)
+                .first()
+            )
+            if word is None:
+                return
+            try:
+                _generate_for_word_image(word)
+            except OpenAIConfigurationError:
+                logger.warning("OpenAI not configured — image worker exiting")
+                return
+            except RateLimitError:
+                # Org RPM limit hit. Back off and retry the same row — the
+                # SDK already did its own short retries before raising.
+                logger.warning("OpenAI rate limit — backing off 30s")
+                time.sleep(30)
+                continue
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception(
+                    "Image generation failed for word_id=%s — leaving for retry",
+                    word.pk,
+                )
+                # Don't re-pick this row in this pass; it'll be retried on the
+                # next drain (import / app restart).
+                failed_pks.add(word.pk)
+                continue
+            time.sleep(throttle_seconds)
+    finally:
+        _drain_lock.release()
+        connection.close()

--- a/lunes_cms/cmsv2/templates/admin/generate_image_base.html
+++ b/lunes_cms/cmsv2/templates/admin/generate_image_base.html
@@ -26,15 +26,6 @@
             </label>
             <input id="prompt-additional-info" type="text" style="width: 100%"/>
         </div>
-        <div style="margin-top: 16px; margin-bottom: 16px;">
-            <label for="model">
-                <strong>Model:</strong>
-            </label>
-            <select id="model" style="width: 100%; padding: 8px;">
-                <option value="gpt-image-1">gpt-image-1 (&asymp; 0.18$ per generation)</option>
-                <option value="dall-e-3">dall-e-3 (&asymp; 0.04$ per generation)</option>
-            </select>
-        </div>
 
         <div class="form-row">
             <button type="button" class="btn btn-primary" id="generate_button">Generate Image</button>

--- a/lunes_cms/cmsv2/views/generate_image.py
+++ b/lunes_cms/cmsv2/views/generate_image.py
@@ -7,6 +7,7 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
+from lunes_cms.cmsv2.services.image_generation import build_image_prompt
 from lunes_cms.cmsv2.utils import get_openai_client, OpenAIConfigurationError
 from lunes_cms.core import settings
 
@@ -25,42 +26,19 @@ def generate_image_via_openai(request):
         return JsonResponse({"error": "No word_text provided."}, status=400)
     additional_info = request.POST.get("additional_info")
     unit_title = request.POST.get("unit_title")
-    model = request.POST.get("model")
-    if not model:
-        return JsonResponse({"error": "No model provided."}, status=400)
 
-    prompt = """Du bist Content-Manager für eine Vokabel-Lern-App namens "Lunes". Die App richtet sich an Zugewanderte, die in Deutschland eine Ausbildung machen oder bereits beruflich tätig sind. Sie lernen Deutsch als Fremdsprache und benötigen spezifischen Fachwortschatz, der in regulären Sprachkursen nicht vermittelt wird.
-
-        Die App zeigt Fachbegriffe aus dem Berufsfeld in Form von Bildern. Alle Vokabeln werden einsprachig (nur auf Deutsch) vermittelt – durch realistische Fotos, die das Wort eindeutig visuell darstellen.
-        
-        Für die Bildsprache gelten folgende Vorgaben:
-        - Es sollen realistische Fotos sein (keine Illustrationen, keine Renderings).
-        - Das Bildmotiv muss eindeutig dem jeweiligen Fachbegriff zuzuordnen sein.
-        - Es soll nur der relevante Gegenstand oder die relevante Handlung zu sehen sein.
-        - Keine zusätzlichen Objekte, kein Text, neutraler Hintergrund (z.B. weiß oder freigestellt).
-    """
-    if unit_title:
-        prompt += f"Der Begriff gehört zum Lernmodul: {unit_title}"
-    prompt += f'Erstelle ein passendes realistisches Foto zur Vokabel: "{word_text}"'
-    if additional_info:
-        prompt += f"Zusätzliche Hinweise zur Bildgestaltung: {additional_info}"
-    prompt += "Ziel ist es, dass die Vokabel durch das Bild eindeutig verstanden werden kann – auch ohne Text oder Erklärung."
+    prompt = build_image_prompt(word_text, unit_title, additional_info)
 
     try:
         client = get_openai_client()
 
-        if model == "gpt-image-1":
-            response = client.images.generate(
-                model=model, prompt=prompt, size="1024x1024", n=1
-            )
-        else:
-            response = client.images.generate(
-                model=model,
-                prompt=prompt,
-                response_format="b64_json",
-                size="1024x1024",
-                n=1,
-            )
+        response = client.images.generate(
+            model=settings.OPENAI_IMAGE_MODEL,
+            prompt=prompt,
+            size="1024x1024",
+            quality=settings.OPENAI_IMAGE_QUALITY,
+            n=1,
+        )
 
         b64_image = response.data[0].b64_json
         image_data = base64.b64decode(b64_image)

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -13,6 +13,7 @@ from tablib.exceptions import InvalidDimensions
 from ..admins.word_import_resource import import_words_from_csv
 from ..models import Job
 from ..services.audio_generation import drain_pending_audio
+from ..services.image_generation import drain_pending_images
 
 
 class ImportCSVForm(forms.Form):
@@ -99,7 +100,8 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
                 request,
                 _(
                     "Import successful! %(created)s new entries, %(updated)s updated. "
-                    "Audio is being generated in the background."
+                    "Audio and images are being generated in the background. This may "
+                    "take a few minutes..."
                 )
                 % {"created": created_count, "updated": updated_count},
             )
@@ -107,6 +109,11 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
         if imported_word_ids:
             threading.Thread(
                 target=drain_pending_audio,
+                args=(imported_word_ids,),
+                daemon=True,
+            ).start()
+            threading.Thread(
+                target=drain_pending_images,
                 args=(imported_word_ids,),
                 daemon=True,
             ).start()

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -43,6 +43,11 @@ OPENAI_TTS_VOICE = os.environ.get("LUNES_CMS_OPENAI_TTS_VOICE", "nova")
 OPENAI_TTS_LOUDNESS_LUFS = float(
     os.environ.get("LUNES_CMS_OPENAI_TTS_LOUDNESS_LUFS", "-16.0")
 )
+#: OpenAI model used for word image generation
+OPENAI_IMAGE_MODEL = os.environ.get("LUNES_CMS_OPENAI_IMAGE_MODEL", "gpt-image-2")
+
+#: OpenAI image quality tier (low/medium/high)
+OPENAI_IMAGE_QUALITY = os.environ.get("LUNES_CMS_OPENAI_IMAGE_QUALITY", "low")
 
 ###################
 # MATOMO TRACKING #

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-10 16:25+0000\n"
+"POT-Creation-Date: 2026-06-11 10:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -849,7 +849,7 @@ msgstr "zuletzt geändert"
 msgid "Icon"
 msgstr "Icon"
 
-#: cmsv2/models/job.py:92 cmsv2/views/import_csv_view.py:25
+#: cmsv2/models/job.py:92 cmsv2/views/import_csv_view.py:26
 msgid "Job"
 msgstr "Beruf"
 
@@ -1042,11 +1042,11 @@ msgstr "Import starten"
 msgid "Generate Audio"
 msgstr "Audio generieren"
 
-#: cmsv2/views/import_csv_view.py:29
+#: cmsv2/views/import_csv_view.py:30
 msgid "Select CSV file"
 msgstr "CSV Datei auswählen"
 
-#: cmsv2/views/import_csv_view.py:31
+#: cmsv2/views/import_csv_view.py:32
 msgid ""
 "The file should contain the columns \"Einheit\", \"Artikel\", \"Vokabel\" "
 "and \"Beispielsatz\"."
@@ -1054,25 +1054,26 @@ msgstr ""
 "Die Datei sollte die Spalten \"Einheit\", \"Artikel\", \"Vokabel\" und "
 "\"Beispielsatz\" enthalten."
 
-#: cmsv2/views/import_csv_view.py:51
+#: cmsv2/views/import_csv_view.py:52
 msgid "CSV import for vocabulary"
 msgstr "CSV Import für Vokabeln"
 
-#: cmsv2/views/import_csv_view.py:94
+#: cmsv2/views/import_csv_view.py:95
 #, python-format
 msgid "Import completed with warnings: %(summary)s"
 msgstr "Import mit folgenden Warnungen abgeschlossen: %(summary)s"
 
-#: cmsv2/views/import_csv_view.py:101
+#: cmsv2/views/import_csv_view.py:102
 #, python-format
 msgid ""
-"Import successful! %(created)s new entries, %(updated)s updated. Audio is "
-"being generated in the background."
+"Import successful! %(created)s new entries, %(updated)s updated. Audio and "
+"images are being generated in the background. This may take a few minutes..."
 msgstr ""
 "Import erfolgreich! %(created)s neue Einträge, %(updated)s wurden "
-"aktualisiert. Audio wird im Hintergrund generiert."
+"aktualisiert. Audio und Bilder werden im Hintergrund generiert. Dies kann "
+"einige Minuten dauern..."
 
-#: cmsv2/views/import_csv_view.py:119
+#: cmsv2/views/import_csv_view.py:126
 msgid ""
 "Import failed. The size of the column or row doesn't fit the table "
 "dimensions. Please adjust your table and try again."
@@ -1080,7 +1081,7 @@ msgstr ""
 "Der Import ist fehlgeschlagen. Die Anzahl der Spalten oder Zeilen passen "
 "nicht zur Tabelle. Bitte passe die Tabelle an und versuche es erneut."
 
-#: cmsv2/views/import_csv_view.py:128
+#: cmsv2/views/import_csv_view.py:135
 #, python-format
 msgid "Import failed: %(e)s"
 msgstr "Import fehlgeschlagen: %(e)s"
@@ -1093,19 +1094,19 @@ msgstr "Ungültige Audiodatei"
 msgid "Could not measure audio loudness"
 msgstr "Die Lautstärke der Audiodatei konnte nicht gemessen werden."
 
-#: core/settings.py:239
+#: core/settings.py:244
 msgid "German"
 msgstr "Deutsch"
 
-#: core/settings.py:240
+#: core/settings.py:245
 msgid "English"
 msgstr "Englisch"
 
-#: core/settings.py:497 core/settings.py:498 core/settings.py:500
+#: core/settings.py:502 core/settings.py:503 core/settings.py:505
 msgid "Lunes Administration"
 msgstr "Lunes-Verwaltung"
 
-#: core/settings.py:499
+#: core/settings.py:504
 msgid "Welcome to the vocabulary management of Lunes!"
 msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 

--- a/lunes_cms/src/generate_image.ts
+++ b/lunes_cms/src/generate_image.ts
@@ -58,8 +58,6 @@ window.initImageGenerator = function (config: ImageGeneratorConfig): void {
 
         const inputElement = document.getElementById("prompt-additional-info") as HTMLInputElement
         formData.append("additional_info", inputElement.value)
-        const modelSelectElement = document.getElementById("model") as HTMLSelectElement
-        formData.append("model", modelSelectElement.value)
         formData.append("csrfmiddlewaretoken", _getImageCookie("csrftoken") ?? "")
 
         fetch(config.generateUrl, {

--- a/tests/cmsv2/services/test_image_generation.py
+++ b/tests/cmsv2/services/test_image_generation.py
@@ -1,0 +1,222 @@
+"""
+Tests for the background image generation worker.
+"""
+
+import threading
+from unittest import mock
+
+import pytest
+from django.core.files.base import ContentFile
+
+from lunes_cms.cmsv2.models import Word
+from lunes_cms.cmsv2.models import word as word_module
+from lunes_cms.cmsv2.services import image_generation
+from lunes_cms.cmsv2.utils import OpenAIConfigurationError
+
+
+@pytest.fixture(autouse=True)
+def _bypass_webp_conversion():
+    """
+    Word.save() runs ``convert_image_to_webp()`` (Pillow re-encodes the file)
+    when an image is set. We feed dummy bytes through the worker, so skip the
+    conversion step in tests.
+    """
+    with mock.patch.object(
+        word_module, "convert_image_to_webp", lambda image_field: False
+    ):
+        yield
+
+
+@pytest.fixture
+def fast_worker(transactional_db, settings, tmp_path):
+    """
+    Strip the throttle so tests don't sleep, start from an empty Word table,
+    and write media to an isolated temp dir.
+
+    The worker scans the *whole* Word table. The session-scoped ``test_data``
+    fixture plus ``transaction=True`` (no rollback between tests) can leave rows
+    around, so wipe them first to keep these tests isolated. A per-test
+    ``MEDIA_ROOT`` keeps generated files isolated across runs.
+    """
+    settings.MEDIA_ROOT = str(tmp_path)
+    Word.objects.all().delete()
+    with mock.patch.object(image_generation, "time") as mocked_time:
+        mocked_time.sleep = lambda _seconds: None
+        yield
+
+
+def _run_drain(word_ids=None):
+    """
+    Run the worker in a thread, like it runs in production.
+
+    ``drain_pending_images`` calls ``connection.close()`` on exit (it returns
+    the DB connection of its worker thread); calling it inline would close the
+    *test's* connection. All worker tests are ``transaction=True`` so the
+    worker thread sees committed data.
+    """
+    thread = threading.Thread(
+        target=image_generation.drain_pending_images,
+        kwargs={"word_ids": word_ids, "throttle_seconds": 0},
+    )
+    thread.start()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+
+
+def _make_word(**overrides) -> Word:
+    defaults = {
+        "word": "Hammer",
+        "singular_article": 1,
+    }
+    defaults.update(overrides)
+    return Word.objects.create(**defaults)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_generates_image_for_word_missing_image(fast_worker):
+    word = _make_word(word="Hammer")
+
+    with mock.patch.object(
+        image_generation, "openai_word_image_bytes", return_value=b"fake-png"
+    ) as image_call:
+        _run_drain()
+
+    word.refresh_from_db()
+    assert word.image
+    assert word.image.read() == b"fake-png"
+    assert image_call.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_stores_image_under_standard_path(fast_worker):
+    word = _make_word(word="Säge & Co")
+
+    with mock.patch.object(
+        image_generation, "openai_word_image_bytes", return_value=b"fake-png"
+    ):
+        _run_drain()
+
+    word.refresh_from_db()
+    # Naming is delegated to the field's ``upload_to`` (a UUID under images/),
+    # consistent with every other image in the system — never word-derived.
+    assert word.image.name.startswith("images/")
+    assert word.image.name.endswith(".png")
+    assert "Säge" not in word.image.name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_is_idempotent_for_already_generated_words(fast_worker):
+    word = _make_word(word="Hammer")
+    word.image.save("hammer.png", ContentFile(b"existing"))
+    word.refresh_from_db()
+
+    with mock.patch.object(image_generation, "openai_word_image_bytes") as image_call:
+        _run_drain()
+
+    assert image_call.call_count == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_isolates_failures_per_row(fast_worker):
+    failing = _make_word(word="Schraubenzieher")
+    succeeding = _make_word(word="Säge")
+
+    def maybe_fail(word: Word) -> bytes:
+        if word.word == "Schraubenzieher":
+            raise ValueError("simulated openai 5xx")
+        return b"ok-png"
+
+    with mock.patch.object(
+        image_generation, "openai_word_image_bytes", side_effect=maybe_fail
+    ):
+        _run_drain()
+
+    failing.refresh_from_db()
+    succeeding.refresh_from_db()
+    assert not failing.image
+    assert succeeding.image.read() == b"ok-png"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_exits_quietly_when_openai_not_configured(fast_worker):
+    _make_word(word="Hammer")
+
+    with mock.patch.object(
+        image_generation,
+        "openai_word_image_bytes",
+        side_effect=OpenAIConfigurationError("missing key"),
+    ):
+        # Should return without raising.
+        _run_drain()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_skips_words_with_empty_word(fast_worker):
+    Word.objects.create(word="", singular_article=0)
+
+    with mock.patch.object(image_generation, "openai_word_image_bytes") as image_call:
+        _run_drain()
+
+    assert image_call.call_count == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_does_not_repick_a_failed_row(fast_worker):
+    word = _make_word(word="Hammer")
+
+    with mock.patch.object(
+        image_generation,
+        "openai_word_image_bytes",
+        side_effect=ValueError("boom"),
+    ) as image_call:
+        _run_drain()
+
+    word.refresh_from_db()
+    assert not word.image
+    # Tried exactly once this pass, then parked in failed_pks (no money-burning loop).
+    assert image_call.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_only_processes_given_word_ids(fast_worker):
+    imported = _make_word(word="Hammer")
+    other = _make_word(word="Säge")
+
+    with mock.patch.object(
+        image_generation, "openai_word_image_bytes", return_value=b"png"
+    ) as image_call:
+        _run_drain(word_ids=[imported.pk])
+
+    imported.refresh_from_db()
+    other.refresh_from_db()
+    assert imported.image.read() == b"png"
+    assert not other.image
+    assert image_call.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_is_single_flight(fast_worker):
+    _make_word(word="Hammer")
+
+    image_generation._drain_lock.acquire()  # pylint: disable=protected-access
+    try:
+        with mock.patch.object(
+            image_generation, "openai_word_image_bytes"
+        ) as image_call:
+            # Lock already held -> should return immediately, doing nothing.
+            _run_drain()
+        assert image_call.call_count == 0
+    finally:
+        image_generation._drain_lock.release()  # pylint: disable=protected-access
+
+
+def test_build_image_prompt_includes_word_and_optional_hints():
+    bare = image_generation.build_image_prompt("Hammer")
+    assert '"Hammer"' in bare
+    assert "Lernmodul" not in bare
+
+    enriched = image_generation.build_image_prompt(
+        "Hammer", unit_title="Werkzeuge", additional_info="Profilansicht"
+    )
+    assert "Werkzeuge" in enriched
+    assert "Profilansicht" in enriched

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -77,7 +77,7 @@ function print_with_borders {
 # This function applies different sed replacements to make sure the matched lines from grep are aligned and colored
 function format_grep_output {
     while read -r line; do
-        echo "$line" | sed --regexp-extended \
+        echo "$line" | sed -E \
             -e "s/^([0-9])([:-])(.*)/\1\2      \3/"         `# Pad line numbers with 1 digit` \
             -e "s/^([0-9]{2})([:-])(.*)/\1\2     \3/"       `# Pad line numbers with 2 digits` \
             -e "s/^([0-9]{3})([:-])(.*)/\1\2    \3/"        `# Pad line numbers with 3 digits` \


### PR DESCRIPTION
### Short description

  Part two of #687: auto-generate an illustrative image for every word created by a CSV import, mirroring the existing background TTS audio pipeline.

  ### Proposed changes
  
  - New `services/image_generation.py` — DB-as-queue background worker (`drain_pending_images`) that picks Words with an empty `image`, calls the OpenAI image API
  (`gpt-image-2`, quality `low`), and saves the result. Single-flight lock separate from the audio drain so both run concurrently.
  - CSV import (`import_csv_view`) starts a second daemon thread to drain images for the just-imported word IDs; success message updated to "Audio and images are being
  generated in the background."
  - Generated images get a deterministic word-derived filename (`<word>.webp`, pk suffix on collision) instead of the random UUID `upload_to` produces.
  - Shared German image prompt extracted into `build_image_prompt()` — `generate_image` view now reuses it (removes duplication).
  - New settings `OPENAI_IMAGE_MODEL` / `OPENAI_IMAGE_QUALITY` (env-overridable).
  - Tests for the worker (`tests/cmsv2/services/test_image_generation.py`).

  ### How to test

  - Set `LUNES_CMS_OPENAI_API_KEY`, run a CSV import of ~3 words via the admin CSV import page. Watch logs for `Image drain starting: N word(s) pending`; confirm each Word
  gets `image` populated (WebP, `image_check_status=NOT_CHECKED`).
  - Re-run the same import → drain reports 0 pending (idempotent).
  - Manual "Generate Image" button still works (shared prompt helper).
  - Run `pytest tests/cmsv2/services/test_image_generation.py`.

  ### Cost / quality comparison (according to claude)

Chosen default is **gpt-image-2, quality `low`** (~$0.006/image, ~$0.60 per 100-word import).

  `gpt-image-2` (launched 2026-04-21, API open early May) — token pricing $8/M image input, $2/M cached, $30/M image output, $5/M text input.

  | Model | Quality | per 1024×1024 | 100 words |
  |-------|---------|---------------|-----------|
  | gpt-image-1 | low (default) | ~$0.011 | ~$1.10 |
  | gpt-image-1 | medium | ~$0.042 | ~$4.20 |
  | gpt-image-1 | high | ~$0.167 | ~$16.70 |
  | gpt-image-2 | low | ~$0.006 | ~$0.60 |
  | gpt-image-2 | medium | ~$0.053 | ~$5.30 |
  | gpt-image-2 | high | ~$0.211 | ~$21.10 |

  (gpt-image-2 per-image figures are OpenAI calculator estimates, not flat list prices.)

  #### gpt-image-1 samples
  
  <table>
    <tr><th>Word</th><th>low</th><th>medium</th><th>high</th></tr>
    <tr>
      <td>Hammer</td>
      <td><img width="200" src="https://github.com/user-attachments/assets/18b8a263-01b9-4bac-9652-956ec4314730" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/7ff21eef-ae45-499d-8f0e-c0a41deca2aa" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/93d73b9c-cff7-4bd2-9c6a-6ebf22d6f1c8" /></td>
    </tr>
    <tr>
      <td>Säge</td>
      <td><img width="200" src="https://github.com/user-attachments/assets/d0e74e74-c782-4b39-b16b-0ff0dfcf7c83" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/edb3fcd9-923d-40ac-9489-0f259f030eb5" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/05d489f8-09ee-44fd-a999-08d988498c4d" /></td>
    </tr>
    <tr>
      <td>Schraubenzieher</td>
      <td><img width="200" src="https://github.com/user-attachments/assets/4dd8ca47-27ae-4fcc-8386-bea608441ca0" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/0fcfa220-5f37-4311-96da-6f3f3c206a3a" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/f12221fb-3d87-4299-abaa-e4208ce0960a" /></td>
    </tr>
  </table>

  #### gpt-image-2 samples
  
<table>
    <tr><th>Word</th><th>low</th><th>medium</th><th>high</th></tr>
    <tr>
      <td>Hammer</td>
      <td><img width="200" src="https://github.com/user-attachments/assets/f2ba88ec-3997-415a-93c3-fa00aad5b3d6" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/36222294-ccd0-4b9a-a22c-73195e8183f3" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/e2cf0ccf-7e03-4277-9929-470679356407" /></td>
    </tr>
    <tr>
      <td>Säge</td>
      <td><img width="200" src="https://github.com/user-attachments/assets/884d5b08-d752-4ed8-bbba-ec74473f4a18" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/650d6414-086d-4aaa-acb9-90ce71a1be99" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/422ee735-c6d6-452d-9cc1-dcc69c8147b2" /></td>
    </tr>
    <tr>
      <td>Schraubenzieher</td>
      <td><img width="200" src="https://github.com/user-attachments/assets/6585b1b9-7670-4615-b4dc-b5e0d2f15f35" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/8f57c790-9a6f-41ea-9d3d-1b93fbebdde5" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/6c8a2f84-169b-4363-89df-5b207a396255" /></td>
    </tr>
  </table>

  ### Resolved issues
  
  Fixes: #687