### PR TITLE
666: Data aggregation job

### DIFF
--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -32,6 +32,8 @@ from lunes_cms.analytics.models import (
 
 logger = logging.getLogger(__name__)
 
+RETENTION_DAYS = 90
+
 
 class EventAggregator(ABC):
     """
@@ -385,6 +387,41 @@ class Command(BaseCommand):
         dry_run: bool = options["dry_run"]
         for aggregator_class in EVENT_AGGREGATORS:
             self._aggregate_event_type(aggregator_class, dry_run)
+        self._delete_old_unprocessed_events(dry_run)
+
+    @transaction.atomic
+    def _delete_old_unprocessed_events(self, dry_run: bool) -> None:
+        """
+        Delete events not covered by any batch aggregator that are older than RETENTION_DAYS.
+
+        This includes exercise_repetition events (aggregated inline on receipt)
+        and any unknown event types.
+
+        We exclude batch aggregator event types from this deletion for security reasons to avoid data loss.
+        For example someone removes atomic transaction annotation and aggregation fails.
+        """
+        batch_aggregated_types = [
+            event_type
+            for aggregator in EVENT_AGGREGATORS
+            for event_type in aggregator.event_types
+        ]
+        cutoff = datetime.datetime.now(tz=UTC) - datetime.timedelta(days=RETENTION_DAYS)
+        old_events = AnalyticsEvent.objects.filter(timestamp__lt=cutoff).exclude(
+            event_type__in=batch_aggregated_types
+        )
+        count, _ = old_events.delete()
+
+        if dry_run:
+            transaction.set_rollback(True)
+            self.stdout.write(
+                f"[DRY RUN] Would delete {count} unprocessed events older than {RETENTION_DAYS} days."
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Deleted {count} unprocessed events older than {RETENTION_DAYS} days."
+                )
+            )
 
     @transaction.atomic
     def _aggregate_event_type(

--- a/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
+++ b/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -759,3 +759,54 @@ class DropoutAggregateTests(TestCase):
         self.assertIsNone(
             DropoutAggregate.objects.get(exercise_type="word_choice").vocabulary_item_id
         )
+
+
+class UnprocessedEventCleanupTests(TestCase):
+    """
+    Tests for deletion of events not covered by batch aggregators (task 3 of #666).
+    exercise_repetition events are aggregated inline on receipt and must be cleaned
+    up by the management command after RETENTION_DAYS days.
+    """
+
+    OLD_TIMESTAMP = datetime.now(tz=timezone.utc) - timedelta(days=91)
+    RECENT_TIMESTAMP = datetime.now(tz=timezone.utc) - timedelta(days=1)
+
+    def _create_event(self, event_type: str, timestamp: datetime) -> AnalyticsEvent:
+        return AnalyticsEvent.objects.create(
+            installation_id="test-install",
+            event_type=event_type,
+            timestamp=timestamp,
+            payload={},
+        )
+
+    def test_deletes_old_exercise_repetition_events(self) -> None:
+        """exercise_repetition events older than 90 days are deleted"""
+        self._create_event("exercise_repetition", self.OLD_TIMESTAMP)
+
+        call_command("aggregate_analytics")
+
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
+
+    def test_keeps_recent_exercise_repetition_events(self) -> None:
+        """exercise_repetition events within 90 days are kept"""
+        self._create_event("exercise_repetition", self.RECENT_TIMESTAMP)
+
+        call_command("aggregate_analytics")
+
+        self.assertEqual(AnalyticsEvent.objects.count(), 1)
+
+    def test_deletes_old_unknown_event_types(self) -> None:
+        """Events of unknown type older than 90 days are deleted"""
+        self._create_event("unknown_future_type", self.OLD_TIMESTAMP)
+
+        call_command("aggregate_analytics")
+
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
+
+    def test_keeps_recent_unknown_event_types(self) -> None:
+        """Events of unknown type within 90 days are kept"""
+        self._create_event("unknown_future_type", self.RECENT_TIMESTAMP)
+
+        call_command("aggregate_analytics")
+
+        self.assertEqual(AnalyticsEvent.objects.count(), 1)

--- a/sample-data/analytics_test_events.json
+++ b/sample-data/analytics_test_events.json
@@ -1,0 +1,130 @@
+[
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99001,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "job_selected",
+      "timestamp": "2026-06-09T08:00:00Z",
+      "payload": {"job_id": 1, "action": "add"},
+      "created_at": "2026-06-09T08:00:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99002,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "job_selected",
+      "timestamp": "2026-06-09T09:00:00Z",
+      "payload": {"job_id": 1, "action": "add"},
+      "created_at": "2026-06-09T09:00:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99003,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "job_selected",
+      "timestamp": "2026-06-09T10:00:00Z",
+      "payload": {"job_id": 1, "action": "remove"},
+      "created_at": "2026-06-09T10:00:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99004,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "session_start",
+      "timestamp": "2026-06-09T08:00:00Z",
+      "payload": {"session_id": "aabbccddeeff00112233445566778899"},
+      "created_at": "2026-06-09T08:00:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99005,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "session_end",
+      "timestamp": "2026-06-09T08:07:42Z",
+      "payload": {"session_id": "aabbccddeeff00112233445566778899"},
+      "created_at": "2026-06-09T08:07:42Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99006,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "module_duration",
+      "timestamp": "2026-06-09T08:05:00Z",
+      "payload": {
+        "exercise_key": {"type": "exercise", "exercise_type": "word_choice", "unit_id": 1},
+        "duration_seconds": 462
+      },
+      "created_at": "2026-06-09T08:05:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99007,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "module_duration",
+      "timestamp": "2026-06-09T08:06:00Z",
+      "payload": {
+        "exercise_key": {"type": "training", "exercise_type": "image", "job_id": 1},
+        "duration_seconds": 180
+      },
+      "created_at": "2026-06-09T08:06:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99008,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "exercise_dropout",
+      "timestamp": "2026-06-09T08:04:00Z",
+      "payload": {
+        "exercise_key": {"type": "exercise", "exercise_type": "word_choice", "unit_id": 1},
+        "position": 3,
+        "total": 10
+      },
+      "created_at": "2026-06-09T08:04:00Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99009,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "exercise_dropout",
+      "timestamp": "2026-06-09T08:04:30Z",
+      "payload": {
+        "exercise_key": {"type": "training", "exercise_type": "image", "job_id": 1},
+        "position": 2,
+        "total": 8,
+        "vocabulary_item_id": 42
+      },
+      "created_at": "2026-06-09T08:04:30Z"
+    }
+  },
+  {
+    "model": "analytics.analyticsevent",
+    "pk": 99010,
+    "fields": {
+      "installation_id": "test-aggregate-delete-me",
+      "event_type": "exercise_repetition",
+      "timestamp": "2026-01-01T00:00:00Z",
+      "payload": {
+        "exercise_key": {"type": "exercise", "exercise_type": "word_choice", "unit_id": 1},
+        "session_id": "aabbccddeeff00112233445566778899"
+      },
+      "created_at": "2026-01-01T00:00:00Z"
+    }
+  }
+]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Actually most of the work was already done in #690 just the cleanup was missing

### Proposed changes
<!-- Describe this PR in more detail. -->

- delete unprocessed events that are older than 90 days
- add some sample data
- adjust tests
- cron tab example was already added here: https://github.com/digitalfabrik/lunes-cms/pull/758


### How to test
<!-- Please describe how to test this PR -->

-  run to import analytics test data
```
! LUNES_CMS_DEBUG=True LUNES_CMS_DB_BACKEND=sqlite lunes-cms-cli loaddata sample-data/analytics_test_events.json
```
- check the db table for the raw events `analytics_analyticsevent`
- run aggregate command
(Dry run)
```
! LUNES_CMS_DEBUG=True LUNES_CMS_DB_BACKEND=sqlite .venv/bin/python -m django aggregate_analytics --dry-run --settings=lunes_cms.core.settings
```
(not dry run)
```
! LUNES_CMS_DEBUG=True LUNES_CMS_DB_BACKEND=sqlite .venv/bin/python -m django aggregate_analytics --settings=lunes_cms.core.settings
```


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #666
