### PR TITLE
805: Fix caching of audio files

### DIFF
--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -10,7 +10,7 @@ from lunes_cms.cmsv2.admins.base import BaseAdmin
 from lunes_cms.cmsv2.models import Job
 from lunes_cms.cmsv2.models.static import Static
 from lunes_cms.cmsv2.models.unit import Unit, UnitWordRelation
-from lunes_cms.cmsv2.utils import get_image_tag, is_not_blank
+from lunes_cms.cmsv2.utils import cache_busted_url, get_image_tag, is_not_blank
 from lunes_cms.core import settings
 
 
@@ -325,7 +325,7 @@ class WordAdmin(BaseAdmin):
         if obj.audio:
             return format_html(
                 "<audio controls id='audio_preview_player' src='{}'></audio>",
-                obj.audio.url,
+                cache_busted_url(obj.audio),
             )
         return "No audio file uploaded."
 
@@ -363,7 +363,7 @@ class WordAdmin(BaseAdmin):
         if obj.example_sentence_audio:
             return format_html(
                 "<audio controls id='example_sentence_audio_preview_player' src='{}'></audio>",
-                obj.example_sentence_audio.url,
+                cache_busted_url(obj.example_sentence_audio),
             )
         return "No audio file uploaded."
 
@@ -451,7 +451,7 @@ class WordAdmin(BaseAdmin):
         if obj.audio:
             audio_html = f"""
             <div class="audio-player-container">
-                <audio class="minimal-audio-player"><source src="{obj.audio.url}" type="audio/mpeg"></audio>
+                <audio class="minimal-audio-player"><source src="{cache_busted_url(obj.audio)}" type="audio/mpeg"></audio>
                 <div class="play-btn">
                     <div>
                         <i class="fas fa-play"></i>

--- a/lunes_cms/cmsv2/utils.py
+++ b/lunes_cms/cmsv2/utils.py
@@ -77,6 +77,29 @@ def word_to_string(word):
     )
 
 
+def cache_busted_url(file):
+    """
+    Return a media file's URL with a ?v= query that changes when the file does.
+
+    Regenerated audio is always re-saved under the same deterministic filename
+    (e.g. <word>.mp3), so its URL never changes when the content does — and
+    browsers keep playing the cached copy. Appending the file's modification
+    time makes the URL change on each regeneration, forcing a refetch. Falls
+    back to the plain URL if the storage can't report a modification time.
+
+    Args:
+        file: A Django FieldFile (e.g. word.audio).
+
+    Returns:
+        str: The file URL, cache-busted when possible.
+    """
+    try:
+        version = int(file.storage.get_modified_time(file.name).timestamp())
+    except (NotImplementedError, OSError, ValueError):
+        return file.url
+    return f"{file.url}?v={version}"
+
+
 def get_image_tag(image, width=330):
     """
     Generate an HTML image tag for the given image.

--- a/lunes_cms/cmsv2/views/update_word_audio.py
+++ b/lunes_cms/cmsv2/views/update_word_audio.py
@@ -4,6 +4,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from ..models import Word
+from ..utils import cache_busted_url
 
 
 @staff_member_required
@@ -42,7 +43,7 @@ def update_word_audio(request, word_id):
             {
                 "status": "success",
                 "message": "Audio added successfully",
-                "audio_url": word.audio.url if word.audio else None,
+                "audio_url": cache_busted_url(word.audio) if word.audio else None,
             }
         )
 

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-09 14:08+0000\n"
+"POT-Creation-Date: 2026-06-10 16:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -649,7 +649,7 @@ msgstr "Zusammenfassung"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: cms/utils.py:164 cmsv2/utils.py:117
+#: cms/utils.py:164 cmsv2/utils.py:140
 msgid "and"
 msgstr "und"
 

--- a/tests/cmsv2/test_utils.py
+++ b/tests/cmsv2/test_utils.py
@@ -1,0 +1,46 @@
+"""
+Tests for cmsv2 utility helpers.
+"""
+
+import datetime
+from unittest import mock
+
+from lunes_cms.cmsv2.utils import cache_busted_url
+
+
+def _fake_file(url, name="audio/Apfel.mp3"):
+    file = mock.Mock()
+    file.url = url
+    file.name = name
+    return file
+
+
+def test_cache_busted_url_appends_modified_time():
+    """The URL gets a ?v= query derived from the file's last-modified time."""
+    file = _fake_file("/media/audio/Apfel.mp3")
+    file.storage.get_modified_time.return_value = datetime.datetime(2026, 6, 10, 12, 0)
+
+    busted = cache_busted_url(file)
+
+    expected = int(datetime.datetime(2026, 6, 10, 12, 0).timestamp())
+    assert busted == f"/media/audio/Apfel.mp3?v={expected}"
+
+
+def test_cache_busted_url_changes_when_file_is_modified():
+    """A regenerated file (new mtime, same URL) yields a different busted URL."""
+    file = _fake_file("/media/audio/Apfel.mp3")
+
+    file.storage.get_modified_time.return_value = datetime.datetime(2026, 6, 10, 12, 0)
+    before = cache_busted_url(file)
+    file.storage.get_modified_time.return_value = datetime.datetime(2026, 6, 10, 12, 5)
+    after = cache_busted_url(file)
+
+    assert before != after
+
+
+def test_cache_busted_url_falls_back_when_mtime_unavailable():
+    """Storages that can't report a modification time get the plain URL."""
+    file = _fake_file("/media/audio/Apfel.mp3")
+    file.storage.get_modified_time.side_effect = NotImplementedError
+
+    assert cache_busted_url(file) == "/media/audio/Apfel.mp3"

--- a/tests/cmsv2/test_utils.py
+++ b/tests/cmsv2/test_utils.py
@@ -27,7 +27,7 @@ def test_cache_busted_url_appends_modified_time():
 
 
 def test_cache_busted_url_changes_when_file_is_modified():
-    """A regenerated file (new mtime, same URL) yields a different busted URL."""
+    """A regenerated file (new modification time, same URL) yields a different busted URL."""
     file = _fake_file("/media/audio/Apfel.mp3")
 
     file.storage.get_modified_time.return_value = datetime.datetime(2026, 6, 10, 12, 0)
@@ -38,7 +38,7 @@ def test_cache_busted_url_changes_when_file_is_modified():
     assert before != after
 
 
-def test_cache_busted_url_falls_back_when_mtime_unavailable():
+def test_cache_busted_url_falls_back_when_modification_time_unavailable():
     """Storages that can't report a modification time get the plain URL."""
     file = _fake_file("/media/audio/Apfel.mp3")
     file.storage.get_modified_time.side_effect = NotImplementedError


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds breaks the caching on test audios by adding a random query parameter to each

Note: we'd discussed breaking caching for all audio files, but that would have to happen on the server, and it would also break caching for app users, which we distinctly don't want.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Make a new function that breaks caching
- Use that function for links to audio files

### How to test
<!-- Please describe how to test this PR -->

- Re-generate the vocabulary on an existing word, see that it changed. But only if you manage to reproduce the original issue, which I did not.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #805 
