### PR TITLE
625: Generate example sentences via OpenAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ UNRELEASED
 * [ [#804](https://github.com/digitalfabrik/lunes-cms/issues/804) ] 804: Ensure German pronunciation
 * [ [#798](https://github.com/digitalfabrik/lunes-cms/issues/798) ] 798: Add bulk action to release units
 * [ [#667](https://github.com/digitalfabrik/lunes-cms/issues/667) ] 667: Show total session duration
+* [ [#625](https://github.com/digitalfabrik/lunes-cms/issues/625) ] 625: Generate example sentences via OpenAI
 
 2026.4.7
 --------

--- a/docs/src/example-sentence-generation.rst
+++ b/docs/src/example-sentence-generation.rst
@@ -1,0 +1,53 @@
+****************************
+Example Sentence Generation
+****************************
+
+Lunes can generate example sentences for vocabulary via the OpenAI chat API.
+The vocabulary admin can trigger it per word and per unit<>word relation; the
+generated sentence is pasted into the example sentence textbox so it can be
+reviewed, adjusted and saved by the editor.
+
+This requires an API key; without it the feature is simply disabled (a warning
+is logged on startup) and everything else keeps working.
+
+How it works
+============
+
+A *Generate example sentence* button is shown below the example sentence
+textbox in two places:
+
+* On the word edit page. The professional context for the prompt is derived
+  from the jobs of all units the word is assigned to. If the word is not
+  assigned to any unit with a job, an error is shown instead.
+* On unit<>word relation rows (inlines on the word and unit edit pages). Here
+  the prompt additionally includes the title of the unit, so the sentence fits
+  the learning unit. The relation has to be saved once before the button
+  appears.
+
+Clicking the button calls OpenAI in the background and shows a loading
+animation; on success the sentence is filled into the textbox above, on error
+the reason is displayed next to the button. Nothing is stored automatically —
+the editor always saves the (possibly adjusted) sentence manually.
+
+The prompt asks for a short German sentence (5-10 words) from the everyday
+working life of the given job, mainly at language level B1 (occasionally B2),
+with varying sentence types and term positions.
+
+Configuration
+=============
+
+Configure via environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Variable
+     - Default
+     - Description
+   * - ``LUNES_CMS_OPENAI_API_KEY``
+     - –
+     - OpenAI API key (required to enable example sentence generation)
+   * - ``LUNES_CMS_OPENAI_TEXT_MODEL``
+     - ``gpt-4.1``
+     - Model used for text generation

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -37,12 +37,14 @@ Basic Concepts
     continous-integration
     audio-generation
     image-generation
+    example-sentence-generation
 
 * :doc:`internationalization`: Internationalization (i18n)
 * :doc:`documentation`: Documentation (Sphinx)
 * :doc:`continous-integration`: Continous Integration (Circle CI)
 * :doc:`audio-generation`: OpenAI audio generation for vocabulary
 * :doc:`image-generation`: OpenAI image generation for vocabulary
+* :doc:`example-sentence-generation`: OpenAI example sentence generation for vocabulary
 
 Deployment
 ==========

--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -28,10 +28,15 @@ class WordInline(admin.TabularInline):
         "word",
         "image_with_controls",
         "example_sentence",
+        "example_sentence_generate",
         "example_sentence_check_status",
         "example_sentence_audio_player",
     ]
-    readonly_fields = ["image_with_controls", "example_sentence_audio_player"]
+    readonly_fields = [
+        "image_with_controls",
+        "example_sentence_generate",
+        "example_sentence_audio_player",
+    ]
 
     def get_formset(self, request, obj=None, **kwargs):
         formset = super().get_formset(request, obj, **kwargs)
@@ -145,7 +150,11 @@ class UnitAdmin(BaseAdmin):
         particularly for asset management functionality.
         """
 
-        js = ["js/unit_icon_asset_config.js", "js/asset_manager.js"]
+        js = [
+            "js/unit_icon_asset_config.js",
+            "js/asset_manager.js",
+            "js/generate_example_sentence.js",
+        ]
         css = {"all": ["css/asset_manager.css"]}
 
     def get_queryset(self, request):

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -159,10 +159,15 @@ class UnitInline(admin.TabularInline):
         "unit",
         "image_with_controls",
         "example_sentence",
+        "example_sentence_generate",
         "example_sentence_check_status",
         "example_sentence_audio_player",
     ]
-    readonly_fields = ["image_with_controls", "example_sentence_audio_player"]
+    readonly_fields = [
+        "image_with_controls",
+        "example_sentence_generate",
+        "example_sentence_audio_player",
+    ]
 
     def get_formset(self, request, obj=None, **kwargs):
         formset = super().get_formset(request, obj, **kwargs)
@@ -220,6 +225,7 @@ class WordAdmin(BaseAdmin):
             {
                 "fields": (
                     "example_sentence",
+                    "example_sentence_generate",
                     "example_sentence_check_status",
                     "example_sentence_audio",
                     "example_sentence_audio_player",
@@ -243,6 +249,7 @@ class WordAdmin(BaseAdmin):
         "audio_player",
         "example_sentence_audio_generate",
         "example_sentence_audio_player",
+        "example_sentence_generate",
         "created_by",
         "image_generate",
         "image_tag",
@@ -290,6 +297,7 @@ class WordAdmin(BaseAdmin):
             "js/audio_player.js",
             "js/audio_check_status_update.js",
             "js/image_check_status_update.js",
+            "js/generate_example_sentence.js",
         ]
         css = {"all": ["css/asset_manager.css", "css/audio_player.css"]}
 
@@ -330,6 +338,33 @@ class WordAdmin(BaseAdmin):
         return "No audio file uploaded."
 
     audio_player.short_description = "Audio Preview"  # type: ignore[attr-defined]
+
+    def example_sentence_generate(self, obj):
+        """
+        Generate HTML for the example sentence generation button.
+
+        Args:
+            obj: The word object
+
+        Returns:
+            str: HTML markup for the example sentence generation button
+        """
+        if obj.pk:
+            url = reverse(
+                "cmsv2:word_generate_example_sentence_via_openai", args=[obj.pk]
+            )
+            return format_html(
+                '<button type="button" class="btn btn-primary btn-sm generate-example-sentence-btn" '
+                'data-url="{}" data-target="id_example_sentence">{}</button>'
+                '<span class="generate-example-sentence-spinner spinner-border spinner-border-sm" '
+                'style="display: none; margin-left: 8px;"></span>'
+                '<span class="generate-example-sentence-message" style="margin-left: 8px;"></span>',
+                url,
+                _("Generate example sentence"),
+            )
+        return _("Save to enable example sentence generation.")
+
+    example_sentence_generate.short_description = _("Example Sentence Generation")  # type: ignore[attr-defined]
 
     def example_sentence_audio_generate(self, obj):
         """

--- a/lunes_cms/cmsv2/models/unit.py
+++ b/lunes_cms/cmsv2/models/unit.py
@@ -193,6 +193,23 @@ class UnitWordRelation(models.Model):
 
     generate_example_sentence_audio_link.short_description = _("Generate Example Sentence Audio")  # type: ignore[attr-defined]
 
+    def example_sentence_generate(self):
+        """Display a button to generate an example sentence via OpenAI."""
+        if self.pk:
+            url = reverse(
+                "cmsv2:unitword_generate_example_sentence_via_openai", args=[self.pk]
+            )
+            return mark_safe(
+                f'<button type="button" class="button generate-example-sentence-btn" data-url="{url}">'
+                f"{_('Generate example sentence')}</button>"
+                '<span class="generate-example-sentence-spinner spinner-border spinner-border-sm" '
+                'style="display: none; margin-left: 8px;"></span>'
+                '<div class="generate-example-sentence-message" style="margin-top: 4px;"></div>'
+            )
+        return _("Save to enable example sentence generation.")
+
+    example_sentence_generate.short_description = _("Generate Example Sentence")  # type: ignore[attr-defined]
+
     def example_sentence_audio_with_player(self):
         """Display audio player and generate button in a single column."""
         audio_html = ""

--- a/lunes_cms/cmsv2/services/sentence_generation.py
+++ b/lunes_cms/cmsv2/services/sentence_generation.py
@@ -1,0 +1,70 @@
+"""
+Example sentence generation for Word objects via OpenAI.
+"""
+
+from django.conf import settings
+
+from ..utils import get_openai_client
+
+
+def build_example_sentence_prompt(word: str, job: str, unit: str | None = None) -> str:
+    """
+    Build the German prompt for generating an example sentence.
+
+    Args:
+        word: The vocabulary term the sentence is about
+        job: The job (or comma-separated jobs) providing the professional context
+        unit: Optional title of the learning unit for unit<>word relations
+
+    Returns:
+        str: The prompt to send to OpenAI
+    """
+    context = f"im Rahmen des Berufs {job}"
+    if unit:
+        context += f" und der Lerneinheit {unit}"
+    return (
+        "Für eine interaktive Übung in einer Vokabel-Lern-App benötige ich "
+        f"einen Beispielsatz für den Fachbegriff {word} {context}. "
+        "Es können Aussagesätze, Fragesätze oder Aufforderungssätze sein. "
+        "Der Fachbegriff soll nicht immer am Satzanfang stehen. "
+        "Der Beispielsatz sollte aus dem Arbeitsalltag des vorher genannten "
+        "Berufes stammen. Das Sprachniveau der Sätze soll hauptsächlich für "
+        "Lernende mit Deutsch als Zweitsprache (B1) passen, aber es dürfen "
+        "auch ein paar B2 Niveau Sätze sein. Sätze eher kürzer halten "
+        "(5-10 Wörter). "
+        "Antworte ausschließlich mit dem Beispielsatz, ohne Anführungszeichen "
+        "und ohne zusätzliche Erklärungen."
+    )
+
+
+def openai_example_sentence(word: str, job: str, unit: str | None = None) -> str:
+    """
+    Generate a single example sentence for a vocabulary term via OpenAI.
+
+    Args:
+        word: The vocabulary term the sentence is about
+        job: The job (or comma-separated jobs) providing the professional context
+        unit: Optional title of the learning unit for unit<>word relations
+
+    Returns:
+        str: The generated example sentence
+
+    Raises:
+        ValueError: If OpenAI returns an empty response
+    """
+    client = get_openai_client()
+    response = client.chat.completions.create(
+        model=settings.OPENAI_TEXT_MODEL,
+        messages=[
+            {
+                "role": "user",
+                "content": build_example_sentence_prompt(word, job, unit),
+            }
+        ],
+    )
+    sentence = (response.choices[0].message.content or "").strip()
+    # The prompt asks for the bare sentence, but strip stray quotes anyway.
+    sentence = sentence.strip("\"'„“‚‘»«").strip()
+    if not sentence:
+        raise ValueError("OpenAI returned an empty example sentence.")
+    return sentence

--- a/lunes_cms/cmsv2/urls.py
+++ b/lunes_cms/cmsv2/urls.py
@@ -55,6 +55,11 @@ urlpatterns = [
         name="word_store_generated_example_sentence_audio_permanently",
     ),
     path(
+        "words/<int:word_id>/generate-example-sentence-via-openai",
+        views.word_generate_example_sentence_via_openai,
+        name="word_generate_example_sentence_via_openai",
+    ),
+    path(
         "words/<int:word_id>/store-generated-image-permanently",
         views.word_store_generated_image_permanently,
         name="word_store_generated_image_permanently",
@@ -113,6 +118,11 @@ urlpatterns = [
         "unitwordrelations/generate-example-sentence-audio-via-openai",
         views.unitword_generate_example_sentence_audio_via_openai,
         name="unitword_generate_example_sentence_audio_via_openai",
+    ),
+    path(
+        "unitwordrelations/<int:unitword_id>/generate-example-sentence-via-openai",
+        views.unitword_generate_example_sentence_via_openai,
+        name="unitword_generate_example_sentence_via_openai",
     ),
     path(
         "unitwordrelations/<int:unitword_id>/store-generated-example-sentence-audio-permanently",

--- a/lunes_cms/cmsv2/views/__init__.py
+++ b/lunes_cms/cmsv2/views/__init__.py
@@ -1,3 +1,7 @@
+from .generate_example_sentence import (
+    unitword_generate_example_sentence_via_openai,
+    word_generate_example_sentence_via_openai,
+)
 from .generate_image import generate_image_via_openai
 from .import_csv_view import import_from_csv
 from .unitword_generate_example_sentence_audio import (
@@ -39,6 +43,7 @@ __all__ = [
     "unitword_store_generated_image_permanently",
     "unitword_generate_example_sentence_audio",
     "unitword_generate_example_sentence_audio_via_openai",
+    "unitword_generate_example_sentence_via_openai",
     "unitword_store_generated_example_sentence_audio_permanently",
     "update_job_icon",
     "update_unit_icon",
@@ -52,6 +57,7 @@ __all__ = [
     "word_generate_audio_via_openai",
     "word_generate_example_sentence_audio",
     "word_generate_example_sentence_audio_via_openai",
+    "word_generate_example_sentence_via_openai",
     "word_generate_image",
     "word_store_generated_audio_permanently",
     "word_store_generated_example_sentence_audio_permanently",

--- a/lunes_cms/cmsv2/views/generate_example_sentence.py
+++ b/lunes_cms/cmsv2/views/generate_example_sentence.py
@@ -1,0 +1,76 @@
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from openai import OpenAIError
+
+from lunes_cms.cmsv2.models import Job, Word
+from lunes_cms.cmsv2.models.unit import UnitWordRelation
+from lunes_cms.cmsv2.services.sentence_generation import openai_example_sentence
+from lunes_cms.cmsv2.utils import OpenAIConfigurationError
+
+
+def _generate_sentence_response(word, job_names, unit_title=None):
+    """
+    Run the OpenAI generation and wrap the result/errors in a JsonResponse.
+    """
+    if not job_names:
+        return JsonResponse(
+            {
+                "error": "No job found. Assign the word to a unit that belongs to a job first."
+            },
+            status=400,
+        )
+
+    try:
+        sentence = openai_example_sentence(word, ", ".join(job_names), unit_title)
+    except OpenAIConfigurationError as e:
+        return JsonResponse({"error": str(e)}, status=503)
+    except (OpenAIError, ValueError, ConnectionError, TimeoutError) as e:
+        return JsonResponse({"error": str(e)}, status=500)
+
+    return JsonResponse(
+        {
+            "message": "Example sentence generated!",
+            "example_sentence": sentence,
+        }
+    )
+
+
+@staff_member_required
+@csrf_exempt
+@require_POST
+def word_generate_example_sentence_via_openai(_request, word_id):
+    """
+    AJAX endpoint to generate an example sentence for a Word via OpenAI.
+
+    The professional context is derived from the jobs of all units the word
+    is assigned to.
+    """
+    word_instance = get_object_or_404(Word, pk=word_id)
+    # A word can belong to several jobs (via the units it is assigned to);
+    # all of them are joined into the prompt so the generated sentence covers
+    # every relevant professional context.
+    job_names = list(
+        Job.objects.filter(units__words=word_instance)
+        .distinct()
+        .order_by("name")
+        .values_list("name", flat=True)
+    )
+    return _generate_sentence_response(word_instance.word, job_names)
+
+
+@staff_member_required
+@csrf_exempt
+@require_POST
+def unitword_generate_example_sentence_via_openai(_request, unitword_id):
+    """
+    AJAX endpoint to generate an example sentence for a UnitWordRelation via
+    OpenAI, scoped to the relation's unit and its jobs.
+    """
+    relation = get_object_or_404(UnitWordRelation, pk=unitword_id)
+    job_names = list(relation.unit.jobs.order_by("name").values_list("name", flat=True))
+    return _generate_sentence_response(
+        relation.word.word, job_names, relation.unit.title
+    )

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -49,6 +49,9 @@ OPENAI_IMAGE_MODEL = os.environ.get("LUNES_CMS_OPENAI_IMAGE_MODEL", "gpt-image-2
 #: OpenAI image quality tier (low/medium/high)
 OPENAI_IMAGE_QUALITY = os.environ.get("LUNES_CMS_OPENAI_IMAGE_QUALITY", "low")
 
+#: OpenAI model used for text generation (e.g. example sentences)
+OPENAI_TEXT_MODEL = os.environ.get("LUNES_CMS_OPENAI_TEXT_MODEL", "gpt-4.1")
+
 ###################
 # MATOMO TRACKING #
 ###################

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -861,6 +861,18 @@ msgid "Miscellaneous"
 msgstr "Verschiedene"
 
 #: cmsv2/admins/word_admin.py
+msgid "Generate example sentence"
+msgstr "Beispielsatz generieren"
+
+#: cmsv2/admins/word_admin.py cmsv2/models/unit.py
+msgid "Save to enable example sentence generation."
+msgstr "Speichern, um die Beispielsatz-Generierung zu aktivieren."
+
+#: cmsv2/admins/word_admin.py
+msgid "Example Sentence Generation"
+msgstr "Beispielsatz-Generierung"
+
+#: cmsv2/admins/word_admin.py
 msgid "Image Preview"
 msgstr "Bild Vorschau"
 
@@ -1042,6 +1054,10 @@ msgstr "Bild generieren"
 #: cmsv2/templates/admin/word_generate_example_sentence_audio.html
 msgid "Generate Example Sentence Audio"
 msgstr "Generiere Beispielsatz Audio"
+
+#: cmsv2/models/unit.py
+msgid "Generate Example Sentence"
+msgstr "Beispielsatz generieren"
 
 #: cmsv2/models/unit.py
 msgid "Unit-Word Relation"

--- a/lunes_cms/locale/de/LC_MESSAGES/djangojs.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/djangojs.po
@@ -29,3 +29,19 @@ msgstr "Kein Bild verfügbar"
 #: lunes_cms/static/js/manytomany_overlay.js:75
 msgid "No audio available"
 msgstr "Kein Audio verfügbar"
+
+#: lunes_cms/static/js/generate_example_sentence.js
+msgid "Could not find the example sentence field."
+msgstr "Das Beispielsatz-Feld konnte nicht gefunden werden."
+
+#: lunes_cms/static/js/generate_example_sentence.js
+msgid "Generating example sentence..."
+msgstr "Beispielsatz wird generiert …"
+
+#: lunes_cms/static/js/generate_example_sentence.js
+msgid "Example sentence generated!"
+msgstr "Beispielsatz generiert!"
+
+#: lunes_cms/static/js/generate_example_sentence.js
+msgid "Error"
+msgstr "Fehler"

--- a/lunes_cms/src/generate_example_sentence.ts
+++ b/lunes_cms/src/generate_example_sentence.ts
@@ -1,0 +1,98 @@
+"use strict"
+
+function _getSentenceCookie(name: string): string | null {
+    let cookieValue = null
+    if (document.cookie && document.cookie !== "") {
+        const cookies = document.cookie.split(";")
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim()
+            if (cookie.substring(0, name.length + 1) === name + "=") {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1))
+                break
+            }
+        }
+    }
+    return cookieValue
+}
+
+function _findSentenceTextarea(button: HTMLButtonElement): HTMLTextAreaElement | null {
+    if (button.dataset.target) {
+        return document.getElementById(button.dataset.target) as HTMLTextAreaElement | null
+    }
+    // Inline rows: the textarea lives in a sibling cell of the same row.
+    const row = button.closest("tr")
+    return row?.querySelector<HTMLTextAreaElement>('textarea[name$="-example_sentence"]') ?? null
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.addEventListener("click", (event) => {
+        const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+            ".generate-example-sentence-btn",
+        )
+        if (!button || !button.dataset.url) {
+            return
+        }
+        event.preventDefault()
+
+        const container = button.parentElement
+        const spinner = container?.querySelector<HTMLElement>(".generate-example-sentence-spinner")
+        const messageArea = container?.querySelector<HTMLElement>(
+            ".generate-example-sentence-message",
+        )
+        const textarea = _findSentenceTextarea(button)
+
+        const showMessage = (text: string, color: string) => {
+            if (messageArea) {
+                messageArea.textContent = text
+                messageArea.style.color = color
+            }
+        }
+
+        if (!textarea) {
+            showMessage(gettext("Could not find the example sentence field."), "red")
+            return
+        }
+
+        button.disabled = true
+        if (spinner) {
+            spinner.style.display = "inline-block"
+        }
+        showMessage(gettext("Generating example sentence..."), "inherit")
+
+        fetch(button.dataset.url, {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": _getSentenceCookie("csrftoken") ?? "",
+            },
+        })
+            .then(async (response) => {
+                const data = (await response.json()) as {
+                    message?: string
+                    example_sentence?: string
+                    error?: string
+                }
+                if (!response.ok || data.error || !data.example_sentence) {
+                    throw new Error(data.error ?? `HTTP error! status: ${response.status}`)
+                }
+                return data
+            })
+            .then((data) => {
+                textarea.value = data.example_sentence ?? ""
+                textarea.dispatchEvent(new Event("change", { bubbles: true }))
+                showMessage(data.message ?? gettext("Example sentence generated!"), "green")
+            })
+            .catch((error) => {
+                console.error("Example sentence generation error:", error)
+                showMessage(
+                    `${gettext("Error")}: ${error instanceof Error ? error.message : String(error)}`,
+                    "red",
+                )
+            })
+            .finally(() => {
+                button.disabled = false
+                if (spinner) {
+                    spinner.style.display = "none"
+                }
+            })
+    })
+})

--- a/tests/cmsv2/services/test_sentence_generation.py
+++ b/tests/cmsv2/services/test_sentence_generation.py
@@ -1,0 +1,83 @@
+"""
+Tests for example sentence generation via OpenAI.
+"""
+
+from unittest import mock
+
+import pytest
+from django.conf import settings
+
+from lunes_cms.cmsv2.services import sentence_generation
+
+
+def _fake_openai_client(content="Der Hammer liegt auf der Werkbank."):
+    fake_message = mock.Mock()
+    fake_message.content = content
+    fake_choice = mock.Mock()
+    fake_choice.message = fake_message
+    fake_response = mock.Mock()
+    fake_response.choices = [fake_choice]
+    fake_client = mock.Mock()
+    fake_client.chat.completions.create.return_value = fake_response
+    return fake_client
+
+
+def test_prompt_contains_word_and_job():
+    prompt = sentence_generation.build_example_sentence_prompt("Hammer", "Tischler")
+    assert "Fachbegriff Hammer" in prompt
+    assert "im Rahmen des Berufs Tischler" in prompt
+    assert "Lerneinheit" not in prompt
+    assert "B1" in prompt
+    assert "5-10 Wörter" in prompt
+
+
+def test_prompt_contains_unit_when_given():
+    prompt = sentence_generation.build_example_sentence_prompt(
+        "Hammer", "Tischler", "Werkzeuge"
+    )
+    assert "im Rahmen des Berufs Tischler und der Lerneinheit Werkzeuge" in prompt
+
+
+def test_generation_uses_text_model_and_returns_sentence():
+    fake_client = _fake_openai_client()
+
+    with mock.patch.object(
+        sentence_generation, "get_openai_client", return_value=fake_client
+    ):
+        sentence = sentence_generation.openai_example_sentence("Hammer", "Tischler")
+
+    assert sentence == "Der Hammer liegt auf der Werkbank."
+    create_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["model"] == settings.OPENAI_TEXT_MODEL
+    assert "Fachbegriff Hammer" in create_kwargs["messages"][0]["content"]
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ('"Der Hammer ist schwer."', "Der Hammer ist schwer."),
+        ("„Der Hammer ist schwer.“", "Der Hammer ist schwer."),
+        ("  Der Hammer ist schwer.  ", "Der Hammer ist schwer."),
+    ],
+)
+def test_generation_strips_quotes_and_whitespace(raw, expected):
+    fake_client = _fake_openai_client(content=raw)
+
+    with mock.patch.object(
+        sentence_generation, "get_openai_client", return_value=fake_client
+    ):
+        assert (
+            sentence_generation.openai_example_sentence("Hammer", "Tischler")
+            == expected
+        )
+
+
+@pytest.mark.parametrize("content", [None, "", '""'])
+def test_generation_raises_on_empty_response(content):
+    fake_client = _fake_openai_client(content=content)
+
+    with mock.patch.object(
+        sentence_generation, "get_openai_client", return_value=fake_client
+    ):
+        with pytest.raises(ValueError):
+            sentence_generation.openai_example_sentence("Hammer", "Tischler")

--- a/tests/cmsv2/views/test_generate_example_sentence.py
+++ b/tests/cmsv2/views/test_generate_example_sentence.py
@@ -1,0 +1,130 @@
+"""
+Tests for the example sentence generation AJAX endpoints.
+"""
+
+from unittest import mock
+
+import pytest
+from django.urls import reverse
+
+from lunes_cms.cmsv2.models import Job, Word
+from lunes_cms.cmsv2.models.unit import Unit, UnitWordRelation
+from lunes_cms.cmsv2.utils import OpenAIConfigurationError
+from lunes_cms.cmsv2.views import generate_example_sentence
+
+
+@pytest.fixture
+def word_with_job(db):
+    word = Word.objects.create(word="Hammer", singular_article=1)
+    job = Job.objects.create(name="Tischler")
+    unit = Unit.objects.create(title="Werkzeuge")
+    unit.jobs.add(job)
+    relation = UnitWordRelation.objects.create(unit=unit, word=word)
+    return word, job, unit, relation
+
+
+def test_word_endpoint_returns_generated_sentence(admin_client, word_with_job):
+    word, _job, _unit, _relation = word_with_job
+    url = reverse("cmsv2:word_generate_example_sentence_via_openai", args=[word.pk])
+
+    with mock.patch.object(
+        generate_example_sentence,
+        "openai_example_sentence",
+        return_value="Der Hammer liegt auf der Werkbank.",
+    ) as generate:
+        response = admin_client.post(url)
+
+    assert response.status_code == 200
+    assert response.json()["example_sentence"] == "Der Hammer liegt auf der Werkbank."
+    generate.assert_called_once_with("Hammer", "Tischler", None)
+
+
+def test_word_endpoint_joins_multiple_jobs(admin_client, word_with_job):
+    word, _job, _unit, _relation = word_with_job
+    other_job = Job.objects.create(name="Maler")
+    other_unit = Unit.objects.create(title="Farben")
+    other_unit.jobs.add(other_job)
+    UnitWordRelation.objects.create(unit=other_unit, word=word)
+    url = reverse("cmsv2:word_generate_example_sentence_via_openai", args=[word.pk])
+
+    with mock.patch.object(
+        generate_example_sentence,
+        "openai_example_sentence",
+        return_value="Satz.",
+    ) as generate:
+        response = admin_client.post(url)
+
+    assert response.status_code == 200
+    generate.assert_called_once_with("Hammer", "Maler, Tischler", None)
+
+
+def test_word_endpoint_requires_job(admin_client, db):
+    word = Word.objects.create(word="Hammer", singular_article=1)
+    url = reverse("cmsv2:word_generate_example_sentence_via_openai", args=[word.pk])
+
+    with mock.patch.object(
+        generate_example_sentence, "openai_example_sentence"
+    ) as generate:
+        response = admin_client.post(url)
+
+    assert response.status_code == 400
+    assert "error" in response.json()
+    generate.assert_not_called()
+
+
+def test_unitword_endpoint_passes_unit_title(admin_client, word_with_job):
+    _word, _job, _unit, relation = word_with_job
+    url = reverse(
+        "cmsv2:unitword_generate_example_sentence_via_openai", args=[relation.pk]
+    )
+
+    with mock.patch.object(
+        generate_example_sentence,
+        "openai_example_sentence",
+        return_value="Der Hammer liegt auf der Werkbank.",
+    ) as generate:
+        response = admin_client.post(url)
+
+    assert response.status_code == 200
+    generate.assert_called_once_with("Hammer", "Tischler", "Werkzeuge")
+
+
+def test_endpoint_reports_missing_openai_configuration(admin_client, word_with_job):
+    word, _job, _unit, _relation = word_with_job
+    url = reverse("cmsv2:word_generate_example_sentence_via_openai", args=[word.pk])
+
+    with mock.patch.object(
+        generate_example_sentence,
+        "openai_example_sentence",
+        side_effect=OpenAIConfigurationError("missing key"),
+    ):
+        response = admin_client.post(url)
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "missing key"
+
+
+def test_endpoint_reports_generation_errors(admin_client, word_with_job):
+    word, _job, _unit, _relation = word_with_job
+    url = reverse("cmsv2:word_generate_example_sentence_via_openai", args=[word.pk])
+
+    with mock.patch.object(
+        generate_example_sentence,
+        "openai_example_sentence",
+        side_effect=ValueError("boom"),
+    ):
+        response = admin_client.post(url)
+
+    assert response.status_code == 500
+    assert response.json()["error"] == "boom"
+
+
+def test_endpoints_require_post(admin_client, word_with_job):
+    word, _job, _unit, relation = word_with_job
+    for url in [
+        reverse("cmsv2:word_generate_example_sentence_via_openai", args=[word.pk]),
+        reverse(
+            "cmsv2:unitword_generate_example_sentence_via_openai", args=[relation.pk]
+        ),
+    ]:
+        assert admin_client.get(url).status_code == 405


### PR DESCRIPTION
Short description

  Adds a Generate example sentence button to the CMS that generates example sentences via the OpenAI API, for both words and
  unit<>word relations.

  Proposed changes

  - Add OPENAI_TEXT_MODEL setting (LUNES_CMS_OPENAI_TEXT_MODEL, default gpt-4.1) and a sentence generation service using the
  prompt from the issue (German, 5-10 words, B1/B2, job context)
  - Add two AJAX endpoints: word-level (job context derived from the jobs of all units the word is assigned to) and unit<>word
  relation level (additionally includes the unit title in the prompt)
  - Add a Generate example sentence button below the example sentence textbox on the word edit page and on unit<>word inline
  rows, with loading spinner, error display and pasting the result into the textbox for manual review and saving
  - Show meaningful errors: missing job assignment (400), missing API key (503), OpenAI errors (500)
  - Add German translation, documentation page and tests for the service and endpoints

  How to test

  - Run the CMS with LUNES_CMS_OPENAI_API_KEY set, log in to the admin
  - Open a word that belongs to a unit with a job → Example Sentence section → click Generate example sentence → spinner
  appears, sentence is filled into the textbox with a success message; adjust and save
  - Open a unit → word inline rows → click Generate example sentence on a saved row → sentence fits unit context
  - Error cases: run without the API key (error message shown), use a word without a job-linked unit (hint to assign a job
  first)

  Resolved issues

  Fixes: #625