### PR TITLE
824: Add the job to the image prompt during CSV import

### DIFF
--- a/lunes_cms/cmsv2/services/image_generation.py
+++ b/lunes_cms/cmsv2/services/image_generation.py
@@ -34,6 +34,7 @@ def build_image_prompt(
     word_text: str,
     unit_title: str | None = None,
     additional_info: str | None = None,
+    job_title: str | None = None,
 ) -> str:
     """
     Build the German image-generation prompt shared by the on-demand admin
@@ -42,6 +43,8 @@ def build_image_prompt(
     prompt = (
         f"Ein realistisches, professionelles Foto, das eindeutig zeigt: {word_text}."
     )
+    if job_title:
+        prompt += f" Beruflicher Kontext: {job_title}."
     if unit_title:
         prompt += f" Thematischer Kontext: {unit_title}."
     prompt += (
@@ -57,14 +60,14 @@ def build_image_prompt(
     return prompt
 
 
-def openai_word_image_bytes(word: Word) -> bytes:
+def openai_word_image_bytes(word: Word, job_title: str | None = None) -> bytes:
     """
     Generate PNG bytes for a single word via the OpenAI image API.
     """
     client = get_openai_client()
     response = client.images.generate(
         model=settings.OPENAI_IMAGE_MODEL,
-        prompt=build_image_prompt(word.word),
+        prompt=build_image_prompt(word.word, job_title=job_title),
         size="1024x1024",
         quality=settings.OPENAI_IMAGE_QUALITY,
         n=1,
@@ -72,7 +75,7 @@ def openai_word_image_bytes(word: Word) -> bytes:
     return base64.b64decode(response.data[0].b64_json)
 
 
-def _generate_for_word_image(word: Word) -> None:
+def _generate_for_word_image(word: Word, job_title: str | None = None) -> None:
     """
     Generate a missing image for a single Word and save it to the ImageField.
 
@@ -81,7 +84,7 @@ def _generate_for_word_image(word: Word) -> None:
     field's ``upload_to`` assigns — same as every other image in the system.
     """
     if not word.image:
-        data = openai_word_image_bytes(word)
+        data = openai_word_image_bytes(word, job_title=job_title)
         word.image.save("image.png", ContentFile(data))
         logger.info("Generated image for word_id=%s (%s)", word.pk, word.word)
 
@@ -94,13 +97,19 @@ def _pending_filter(word_ids: list[int] | None = None) -> Q:
 
 
 def drain_pending_images(
-    word_ids: list[int] | None = None, throttle_seconds: float = 1.0
+    word_ids: list[int] | None = None,
+    throttle_seconds: float = 1.0,
+    job_title: str | None = None,
 ) -> None:
     """
     Process Words that need an image, one at a time, until none remain.
 
     ``word_ids`` restricts the drain to those Word rows (the ones a CSV
     import just created). Without it the whole table is scanned.
+
+    ``job_title`` adds the importing job to every prompt in the batch. A CSV
+    import always targets a single job, unlike already saved words which can
+    belong to several jobs.
 
     Single-flight within the process: if another thread already holds the
     drain lock this call returns immediately.
@@ -129,7 +138,7 @@ def drain_pending_images(
             if word is None:
                 return
             try:
-                _generate_for_word_image(word)
+                _generate_for_word_image(word, job_title=job_title)
             except OpenAIConfigurationError:
                 logger.warning("OpenAI not configured — image worker exiting")
                 return

--- a/lunes_cms/cmsv2/templates/admin/unitword_generate_image.html
+++ b/lunes_cms/cmsv2/templates/admin/unitword_generate_image.html
@@ -31,5 +31,6 @@
 function(formData) {
     formData.append("word_text", "{{ unitword_instance.word.word }}")
     formData.append("unit_title", "{{ unitword_instance.unit.title }}")
+    {% if job_title %}formData.append("job_title", "{{ job_title }}"){% endif %}
 }
 {% endblock %}

--- a/lunes_cms/cmsv2/views/generate_image.py
+++ b/lunes_cms/cmsv2/views/generate_image.py
@@ -26,8 +26,11 @@ def generate_image_via_openai(request):
         return JsonResponse({"error": "No word_text provided."}, status=400)
     additional_info = request.POST.get("additional_info")
     unit_title = request.POST.get("unit_title")
+    job_title = request.POST.get("job_title")
 
-    prompt = build_image_prompt(word_text, unit_title, additional_info)
+    prompt = build_image_prompt(
+        word_text, unit_title, additional_info, job_title=job_title
+    )
 
     try:
         client = get_openai_client()

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -115,6 +115,7 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
             threading.Thread(
                 target=drain_pending_images,
                 args=(imported_word_ids,),
+                kwargs={"job_title": selected_job.name},
                 daemon=True,
             ).start()
         return redirect(reverse("admin:cmsv2_job_change", args=[selected_job.pk]))

--- a/lunes_cms/cmsv2/views/unitword_generate_image.py
+++ b/lunes_cms/cmsv2/views/unitword_generate_image.py
@@ -18,7 +18,9 @@ def unitword_generate_image(request, unitword_id):
     """
 
     unitword_instance = get_object_or_404(UnitWordRelation, pk=unitword_id)
-    jobs = list(unitword_instance.unit.jobs.all())
+    # We only want the job name as a hint to the AI when the unit is in exactly one job.
+    # Fetching 2 (LIMIT 2) is enough to tell "exactly one" from "more than one".
+    jobs = list(unitword_instance.unit.jobs.all()[:2])
 
     context = admin.site.each_context(request)
     context.update(

--- a/lunes_cms/cmsv2/views/unitword_generate_image.py
+++ b/lunes_cms/cmsv2/views/unitword_generate_image.py
@@ -18,11 +18,13 @@ def unitword_generate_image(request, unitword_id):
     """
 
     unitword_instance = get_object_or_404(UnitWordRelation, pk=unitword_id)
+    jobs = list(unitword_instance.unit.jobs.all())
 
     context = admin.site.each_context(request)
     context.update(
         {
             "unitword_instance": unitword_instance,
+            "job_title": jobs[0].name if len(jobs) == 1 else None,
             "temp_image_url": None,
         }
     )

--- a/tests/cmsv2/services/test_image_generation.py
+++ b/tests/cmsv2/services/test_image_generation.py
@@ -121,7 +121,7 @@ def test_drain_isolates_failures_per_row(fast_worker):
     failing = _make_word(word="Schraubenzieher")
     succeeding = _make_word(word="Säge")
 
-    def maybe_fail(word: Word) -> bytes:
+    def maybe_fail(word: Word, job_title: str | None = None) -> bytes:
         if word.word == "Schraubenzieher":
             raise ValueError("simulated openai 5xx")
         return b"ok-png"
@@ -218,7 +218,33 @@ def test_build_image_prompt_includes_word_and_optional_hints():
     assert "Lernmodul" not in bare
 
     enriched = image_generation.build_image_prompt(
-        "Hammer", unit_title="Werkzeuge", additional_info="Profilansicht"
+        "Hammer",
+        unit_title="Werkzeuge",
+        additional_info="Profilansicht",
+        job_title="Tischler/in",
     )
     assert "Werkzeuge" in enriched
     assert "Profilansicht" in enriched
+    assert "Tischler/in" in enriched
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_passes_job_title_to_image_generation(fast_worker):
+    imported = _make_word(word="Hammer")
+
+    with mock.patch.object(
+        image_generation, "openai_word_image_bytes", return_value=b"png"
+    ) as image_call:
+        thread = threading.Thread(
+            target=image_generation.drain_pending_images,
+            kwargs={
+                "word_ids": [imported.pk],
+                "throttle_seconds": 0,
+                "job_title": "Tischler/in",
+            },
+        )
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    image_call.assert_called_once_with(mock.ANY, job_title="Tischler/in")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I promise, I'll stop touching the prompt for a bit now 😅 

Nina pointed out correctly that the job title would be very useful in the prompt, so I added it whenever there is only one job.

### Proposed changes
<!-- Describe this PR in more detail. -->

- When importing a CSV file, there is only one job, whose title I passed in to the prompt
- When manually generating an image, there might be more than one job that the word is associated with, so I only passed in the job title when there's only one


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #824 
