### PR TITLE
820: Move analytics aggregated data to grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 dist
 .vscode
 .idea/dataSources.xml
+.idea/misc.xml
 .coverage
 docs/dist/
 docs/src/ref/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+lunes-cms.ini
 *.pyc
 *.mo
 media

--- a/docs/src/analytics.rst
+++ b/docs/src/analytics.rst
@@ -1,0 +1,46 @@
+******************
+Analytics
+******************
+
+We aggregate our analytics data with
+
+.. code-block:: bash
+
+    lunes-cms-cli aggregate_analytics
+
+This script does the following actions:
+
+* Aggregate data from `analytics_analyticsevent` table
+* Send the data to grafana: https://grafana.tuerantuer.org/
+* Delete aggregated data (currently disabled for testing purposes)
+
+The script runs as a crontab on the server every night at 2am.
+
+Local testing
+=============
+
+* get the ca, client.crt and client.key from the lunes test server
+
+.. code-block:: bash
+
+    ssh username@lunes-test.tuerantuer.org "sudo cat /etc/pki/client.crt" > client.crt
+    ssh username@lunes-test.tuerantuer.org "sudo cat /etc/pki/client.key" > client.key
+    ssh username@lunes-test.tuerantuer.org "cat /usr/local/share/ca-certificates/ca.crt" > ca.crt
+
+* create a local `lunes-cms.ini` in the root folder and override variables
+
+.. code-block:: ini
+
+    [influxdb]
+    INFLUX_URL = https://monitoring.tuerantuer.org/write
+    INFLUX_DB = lunes_test
+    INFLUX_CERT = /path/to/lunes-cms/example-configs/client.crt
+    INFLUX_KEY = /path/to/lunes-cms/example-configs/client.key
+    INFLUX_CA = /path/to/lunes-cms/example-configs/ca.crt
+
+* run:
+
+.. code-block:: bash
+
+    lunes-cms-cli aggregate_analytics --dry-run
+    lunes-cms-cli aggregate_analytics

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -37,6 +37,7 @@ Basic Concepts
     continous-integration
     audio-generation
     image-generation
+    analytics
     example-sentence-generation
 
 * :doc:`internationalization`: Internationalization (i18n)
@@ -44,6 +45,7 @@ Basic Concepts
 * :doc:`continous-integration`: Continous Integration (Circle CI)
 * :doc:`audio-generation`: OpenAI audio generation for vocabulary
 * :doc:`image-generation`: OpenAI image generation for vocabulary
+* :doc:`analytics`: Analytics
 * :doc:`example-sentence-generation`: OpenAI example sentence generation for vocabulary
 
 Deployment

--- a/example-configs/lunes-cms.ini
+++ b/example-configs/lunes-cms.ini
@@ -51,6 +51,18 @@ EMAIL_USE_TLS = True
 # Whether SSL (implicit TLS) is enabled [optional, defaults to False]
 EMAIL_USE_SSL = False
 
+[influxdb]
+# InfluxDB write endpoint [optional, defaults to "https://monitoring.tuerantuer.org/write"]
+INFLUX_URL = https://monitoring.tuerantuer.org/write
+# InfluxDB database name [optional, defaults to "lunes_test" in debug mode, "lunes_production" otherwise]
+INFLUX_DB = lunes_test
+# Path to the client TLS certificate for mTLS auth [optional, defaults to "/etc/pki/client.crt"]
+INFLUX_CERT = /path/to/client.crt
+# Path to the client TLS key for mTLS auth [optional, defaults to "/etc/pki/client.key"]
+INFLUX_KEY = /path/to/client.key
+# Path to the CA certificate for verifying the InfluxDB server [optional, defaults to "/etc/pki/ca.crt"]
+INFLUX_CA = /path/to/ca.crt
+
 [logging]
 # The path to your log file [optional, defaults to "lunes-cms.log" in the application directory]
 LOGFILE = /var/lunes-cms.log

--- a/lunes_cms/analytics/api/views.py
+++ b/lunes_cms/analytics/api/views.py
@@ -4,9 +4,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle, SimpleRateThrottle
 
-from lunes_cms.analytics.influx import _escape_tag, push_lines
-from lunes_cms.cmsv2.models import Job
-
 from ..models import AnalyticsEvent
 from .serializers import AnalyticsEventSerializer
 
@@ -37,33 +34,7 @@ class AnalyticsEventViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     serializer_class = AnalyticsEventSerializer
 
     def perform_create(self, serializer: AnalyticsEventSerializer) -> None:
-        event = serializer.save()
-        if event.event_type == AnalyticsEvent.EventType.EXERCISE_REPETITION:
-            payload = event.payload
-            exercise_key = payload["exercise_key"]
-            exercise_type = exercise_key["exercise_type"]
-            session_id = payload["session_id"]
-            job_id = exercise_key.get("job_id")
-            unit_id = exercise_key.get("unit_id")
-            ts = int(event.timestamp.timestamp() * 1_000_000_000)
-
-            if job_id is not None:
-                job_name = (
-                    Job.objects.filter(id=job_id).values_list("name", flat=True).first()
-                )
-                key_tag = f"job={_escape_tag(job_name or f'unknown_{job_id}')}"
-            else:
-                key_tag = f"unit_id={unit_id}"
-
-            push_lines(
-                [
-                    f"lunes_exercise_repetition"
-                    f",{key_tag}"
-                    f",exercise_type={exercise_type}"
-                    f",session_id={session_id}"
-                    f" repetition_count=1i {ts}"
-                ]
-            )
+        serializer.save()
 
 
 class AnalyticsGDPRViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/lunes_cms/analytics/api/views.py
+++ b/lunes_cms/analytics/api/views.py
@@ -1,10 +1,13 @@
-from django.db.models import F, QuerySet
+from django.db.models import QuerySet
 from rest_framework import mixins, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle, SimpleRateThrottle
 
-from ..models import AnalyticsEvent, ExerciseRepetitionAggregate
+from lunes_cms.analytics.influx import _escape_tag, push_lines
+from lunes_cms.cmsv2.models import Job
+
+from ..models import AnalyticsEvent
 from .serializers import AnalyticsEventSerializer
 
 
@@ -38,13 +41,28 @@ class AnalyticsEventViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
         if event.event_type == AnalyticsEvent.EventType.EXERCISE_REPETITION:
             payload = event.payload
             exercise_key = payload["exercise_key"]
-            ExerciseRepetitionAggregate.objects.update_or_create(
-                unit_id=exercise_key.get("unit_id"),
-                job_id=exercise_key.get("job_id"),
-                exercise_type=exercise_key["exercise_type"],
-                session_id=payload["session_id"],
-                defaults={"repetition_count": F("repetition_count") + 1},
-                create_defaults={"repetition_count": 1},
+            exercise_type = exercise_key["exercise_type"]
+            session_id = payload["session_id"]
+            job_id = exercise_key.get("job_id")
+            unit_id = exercise_key.get("unit_id")
+            ts = int(event.timestamp.timestamp() * 1_000_000_000)
+
+            if job_id is not None:
+                job_name = (
+                    Job.objects.filter(id=job_id).values_list("name", flat=True).first()
+                )
+                key_tag = f"job={_escape_tag(job_name or f'unknown_{job_id}')}"
+            else:
+                key_tag = f"unit_id={unit_id}"
+
+            push_lines(
+                [
+                    f"lunes_exercise_repetition"
+                    f",{key_tag}"
+                    f",exercise_type={exercise_type}"
+                    f",session_id={session_id}"
+                    f" repetition_count=1i {ts}"
+                ]
             )
 
 

--- a/lunes_cms/analytics/influx.py
+++ b/lunes_cms/analytics/influx.py
@@ -52,5 +52,5 @@ def push_lines(lines: list[str]) -> None:
         logger.debug(
             "Pushed %d lines to InfluxDB (db=%s)", len(lines), settings.INFLUX_DB
         )
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.error("InfluxDB push failed (%d lines): %s", len(lines), exc)

--- a/lunes_cms/analytics/influx.py
+++ b/lunes_cms/analytics/influx.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timezone
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _escape_tag(value: str) -> str:
+    """Escape special characters in InfluxDB line protocol tag values."""
+    return value.replace(",", r"\,").replace("=", r"\=").replace(" ", r"\ ")
+
+
+def date_to_ns(d: date) -> int:
+    """Convert a date to a nanosecond Unix timestamp at midnight UTC."""
+    dt = datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def resolve_job(job_id: int | str | None, job_names: dict[int, str]) -> str | None:
+    """Return an escaped job name for use as an InfluxDB tag value.
+
+    Returns None if job_id is None, or a fallback string if the id is not found.
+    """
+    if job_id is None:
+        return None
+    name = job_names.get(int(job_id), f"unknown_{job_id}")
+    return _escape_tag(name)
+
+
+def push_lines(lines: list[str]) -> None:
+    """Push InfluxDB line protocol lines to the configured write endpoint.
+
+    Failures are logged but never raise, so a monitoring outage cannot break
+    the aggregation pipeline.
+    """
+    if not lines:
+        return
+    try:
+        response = requests.post(
+            settings.INFLUX_URL,
+            params={"db": settings.INFLUX_DB},
+            data="\n".join(lines).encode(),
+            cert=(settings.INFLUX_CERT, settings.INFLUX_KEY),
+            verify=settings.INFLUX_CA,
+            timeout=10,
+        )
+        response.raise_for_status()
+        logger.debug(
+            "Pushed %d lines to InfluxDB (db=%s)", len(lines), settings.INFLUX_DB
+        )
+    except Exception as exc:
+        logger.error("InfluxDB push failed (%d lines): %s", len(lines), exc)

--- a/lunes_cms/analytics/influx.py
+++ b/lunes_cms/analytics/influx.py
@@ -31,6 +31,17 @@ def resolve_job(job_id: int | str | None, job_names: dict[int, str]) -> str | No
     return _escape_tag(name)
 
 
+def resolve_unit(unit_id: int | str | None, unit_names: dict[int, str]) -> str | None:
+    """Return an escaped unit title for use as an InfluxDB tag value.
+
+    Returns None if unit_id is None, or a fallback string if the id is not found.
+    """
+    if unit_id is None:
+        return None
+    name = unit_names.get(int(unit_id), f"unknown_{unit_id}")
+    return _escape_tag(name)
+
+
 def push_lines(lines: list[str]) -> None:
     """Push InfluxDB line protocol lines to the configured write endpoint.
 

--- a/lunes_cms/analytics/influx.py
+++ b/lunes_cms/analytics/influx.py
@@ -9,11 +9,6 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
-def _escape_tag(value: str) -> str:
-    """Escape special characters in InfluxDB line protocol tag values."""
-    return value.replace(",", r"\,").replace("=", r"\=").replace(" ", r"\ ")
-
-
 def _escape_field_string(value: str) -> str:
     """Escape special characters in InfluxDB line protocol string field values."""
     return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/lunes_cms/analytics/influx.py
+++ b/lunes_cms/analytics/influx.py
@@ -14,6 +14,11 @@ def _escape_tag(value: str) -> str:
     return value.replace(",", r"\,").replace("=", r"\=").replace(" ", r"\ ")
 
 
+def _escape_field_string(value: str) -> str:
+    """Escape special characters in InfluxDB line protocol string field values."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def date_to_ns(d: date) -> int:
     """Convert a date to a nanosecond Unix timestamp at midnight UTC."""
     dt = datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
@@ -21,25 +26,25 @@ def date_to_ns(d: date) -> int:
 
 
 def resolve_job(job_id: int | str | None, job_names: dict[int, str]) -> str | None:
-    """Return an escaped job name for use as an InfluxDB tag value.
+    """Return an escaped job name for use as an InfluxDB string field value.
 
     Returns None if job_id is None, or a fallback string if the id is not found.
     """
     if job_id is None:
         return None
     name = job_names.get(int(job_id), f"unknown_{job_id}")
-    return _escape_tag(name)
+    return _escape_field_string(name)
 
 
 def resolve_unit(unit_id: int | str | None, unit_names: dict[int, str]) -> str | None:
-    """Return an escaped unit title for use as an InfluxDB tag value.
+    """Return an escaped unit title for use as an InfluxDB string field value.
 
     Returns None if unit_id is None, or a fallback string if the id is not found.
     """
     if unit_id is None:
         return None
     name = unit_names.get(int(unit_id), f"unknown_{unit_id}")
-    return _escape_tag(name)
+    return _escape_field_string(name)
 
 
 def push_lines(lines: list[str]) -> None:

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -418,7 +418,8 @@ class Command(BaseCommand):
         job_names: dict[int, str] = dict(Job.objects.values_list("id", "name"))
         for aggregator_class in EVENT_AGGREGATORS:
             self._aggregate_event_type(aggregator_class, dry_run, job_names)
-        self._delete_old_unprocessed_events(dry_run)
+       # Will be uncommented when we are sure that aggregation works as expected
+       # self._delete_old_unprocessed_events(dry_run)
 
     @transaction.atomic
     def _delete_old_unprocessed_events(self, dry_run: bool) -> None:

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -21,9 +21,9 @@ from django.db.models.fields.json import KT
 from django.db.models.functions import Cast, TruncDate
 from django.utils import timezone
 
-from lunes_cms.analytics.influx import date_to_ns, push_lines, resolve_job
+from lunes_cms.analytics.influx import date_to_ns, push_lines, resolve_job, resolve_unit
 from lunes_cms.analytics.models import AnalyticsEvent
-from lunes_cms.cmsv2.models import Job
+from lunes_cms.cmsv2.models import Job, Unit
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,7 @@ class EventAggregator(ABC):
         events: QuerySet[AnalyticsEvent],
         aggregated_at: datetime,
         job_names: dict[int, str],
+        unit_names: dict[int, str],
     ) -> list[str]:
         """
         Aggregate the given events into InfluxDB line protocol strings and mark
@@ -73,6 +74,7 @@ class JobSelectionAggregator(EventAggregator):
         events: QuerySet[AnalyticsEvent],
         aggregated_at: datetime,
         job_names: dict[int, str],
+        unit_names: dict[int, str],
     ) -> list[str]:
         daily_stats = (
             events.annotate(job_id=KT("payload__job_id"))
@@ -129,6 +131,7 @@ class SessionAggregator(EventAggregator):
         events: QuerySet[AnalyticsEvent],
         aggregated_at: datetime,
         job_names: dict[int, str],
+        unit_names: dict[int, str],
     ) -> list[str]:
         # Accumulate per-date totals in Python before building lines
         daily: dict[Any, tuple[int, int]] = (
@@ -214,6 +217,7 @@ class ModuleDurationAggregator(EventAggregator):
         events: QuerySet[AnalyticsEvent],
         aggregated_at: datetime,
         job_names: dict[int, str],
+        unit_names: dict[int, str],
     ) -> list[str]:
         standard_events = events.filter(
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.STANDARD
@@ -239,14 +243,20 @@ class ModuleDurationAggregator(EventAggregator):
             )
         )
         for event in standard_aggregated:
+            unit = resolve_unit(event["unit_id"], unit_names)
+            if unit is None:
+                logger.warning(
+                    "module_duration standard event has no unit_id, skipping"
+                )
+                continue
             ts = date_to_ns(event["event_date"])
             lines.append(
-                f"lunes_module_duration,unit_id={event['unit_id']},exercise_type={event['exercise_type']}"
+                f"lunes_module_duration,unit={unit},exercise_type={event['exercise_type']}"
                 f" total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
             )
             logger.info(
-                "Queued module_duration (standard) line: unit_id=%s exercise_type=%s date=%s",
-                event["unit_id"],
+                "Queued module_duration (standard) line: unit=%s exercise_type=%s date=%s",
+                unit,
                 event["exercise_type"],
                 event["event_date"],
             )
@@ -299,6 +309,7 @@ class DropoutAggregator(EventAggregator):
         events: QuerySet[AnalyticsEvent],
         aggregated_at: datetime,
         job_names: dict[int, str],
+        unit_names: dict[int, str],
     ) -> list[str]:
         standard_events = events.filter(
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.STANDARD
@@ -320,19 +331,15 @@ class DropoutAggregator(EventAggregator):
                 "unit_id",
                 "payload__position",
                 "payload__total",
-                "payload__vocabulary_item_id",
             )
             .annotate(dropout_count=Count("pk"))
         )
         for event in standard_aggregated:
             ts = date_to_ns(event["event_date"])
-            vocab_id = event["payload__vocabulary_item_id"]
-            vocab_tag = f",vocab_id={vocab_id}" if vocab_id is not None else ""
             lines.append(
                 f"lunes_dropout"
                 f",unit_id={event['unit_id']}"
                 f",exercise_type={event['exercise_type']}"
-                f"{vocab_tag}"
                 f",position={event['payload__position']}"
                 f",total={event['payload__total']}"
                 f" dropout_count={event['dropout_count']}i {ts}"
@@ -355,7 +362,6 @@ class DropoutAggregator(EventAggregator):
                 "job_id",
                 "payload__position",
                 "payload__total",
-                "payload__vocabulary_item_id",
             )
             .annotate(dropout_count=Count("pk"))
         )
@@ -365,13 +371,10 @@ class DropoutAggregator(EventAggregator):
                 logger.warning("dropout training event has no job_id, skipping")
                 continue
             ts = date_to_ns(event["event_date"])
-            vocab_id = event["payload__vocabulary_item_id"]
-            vocab_tag = f",vocab_id={vocab_id}" if vocab_id is not None else ""
             lines.append(
                 f"lunes_dropout"
                 f",job={job}"
                 f",exercise_type={event['exercise_type']}"
-                f"{vocab_tag}"
                 f",position={event['payload__position']}"
                 f",total={event['payload__total']}"
                 f" dropout_count={event['dropout_count']}i {ts}"
@@ -387,11 +390,118 @@ class DropoutAggregator(EventAggregator):
         return lines
 
 
+class ExerciseRepetitionAggregator(EventAggregator):
+    """
+    Aggregates exercise_repetition events into a daily histogram per exercise:
+    for each (day, exercise, repetitions_per_session) bucket, reports how many sessions
+    landed there. This preserves the per-session difficulty signal (one user grinding an
+    exercise 5 times vs. five users doing it once) without storing session_id in InfluxDB.
+    """
+
+    event_types = [AnalyticsEvent.EventType.EXERCISE_REPETITION]
+
+    @staticmethod
+    def aggregate(
+        events: QuerySet[AnalyticsEvent],
+        aggregated_at: datetime,
+        job_names: dict[int, str],
+        unit_names: dict[int, str],
+    ) -> list[str]:
+        standard_events = events.filter(
+            payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.STANDARD
+        )
+        training_events = events.filter(
+            payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.TRAINING
+        )
+        lines = ExerciseRepetitionAggregator._standard_lines(
+            standard_events
+        ) + ExerciseRepetitionAggregator._training_lines(training_events, job_names)
+        events.update(aggregated_at=aggregated_at)
+        return lines
+
+    @staticmethod
+    def _standard_lines(standard_events: QuerySet[AnalyticsEvent]) -> list[str]:
+        per_session = (
+            standard_events.annotate(
+                exercise_type=KT("payload__exercise_key__exercise_type"),
+                unit_id=KT("payload__exercise_key__unit_id"),
+                session_id=KT("payload__session_id"),
+            )
+            .values("event_date", "exercise_type", "unit_id", "session_id")
+            .annotate(reps=Count("pk"))
+        )
+        dist: dict[tuple, int] = {}
+        for row in per_session:
+            key = (row["event_date"], row["exercise_type"], row["unit_id"], row["reps"])
+            dist[key] = dist.get(key, 0) + 1
+        lines = []
+        for (event_date, exercise_type, unit_id, reps), session_count in dist.items():
+            ts = date_to_ns(event_date)
+            lines.append(
+                f"lunes_exercise_repetition"
+                f",unit_id={unit_id}"
+                f",exercise_type={exercise_type}"
+                f",repetitions_per_session={reps}"
+                f" session_count={session_count}i {ts}"
+            )
+            logger.info(
+                "Queued exercise_repetition (standard) line: unit_id=%s exercise_type=%s reps=%d date=%s",
+                unit_id,
+                exercise_type,
+                reps,
+                event_date,
+            )
+        return lines
+
+    @staticmethod
+    def _training_lines(
+        training_events: QuerySet[AnalyticsEvent], job_names: dict[int, str]
+    ) -> list[str]:
+        per_session = (
+            training_events.annotate(
+                exercise_type=KT("payload__exercise_key__exercise_type"),
+                job_id=KT("payload__exercise_key__job_id"),
+                session_id=KT("payload__session_id"),
+            )
+            .values("event_date", "exercise_type", "job_id", "session_id")
+            .annotate(reps=Count("pk"))
+        )
+        dist: dict[tuple, int] = {}
+        for row in per_session:
+            job = resolve_job(row["job_id"], job_names)
+            if job is None:
+                logger.warning(
+                    "exercise_repetition training event has no job_id, skipping"
+                )
+                continue
+            key = (row["event_date"], job, row["exercise_type"], row["reps"])
+            dist[key] = dist.get(key, 0) + 1
+        lines = []
+        for (event_date, job, exercise_type, reps), session_count in dist.items():
+            ts = date_to_ns(event_date)
+            lines.append(
+                f"lunes_exercise_repetition"
+                f",job={job}"
+                f",exercise_type={exercise_type}"
+                f",repetitions_per_session={reps}"
+                f" session_count={session_count}i {ts}"
+            )
+            logger.info(
+                "Queued exercise_repetition (training) line: job=%s exercise_type=%s reps=%d date=%s",
+                job,
+                exercise_type,
+                reps,
+                event_date,
+            )
+        return lines
+
+
 EVENT_AGGREGATORS: list[type[EventAggregator]] = [
     JobSelectionAggregator,
     SessionAggregator,
     ModuleDurationAggregator,
     DropoutAggregator,
+    ExerciseRepetitionAggregator,
 ]
 
 
@@ -415,8 +525,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         dry_run: bool = options["dry_run"]
         job_names: dict[int, str] = dict(Job.objects.values_list("id", "name"))
+        unit_names: dict[int, str] = dict(Unit.objects.values_list("id", "title"))
         for aggregator_class in EVENT_AGGREGATORS:
-            self._aggregate_event_type(aggregator_class, dry_run, job_names)
+            self._aggregate_event_type(aggregator_class, dry_run, job_names, unit_names)
 
     # Will be uncommented with #829
     # self._delete_old_unprocessed_events(dry_run)
@@ -461,6 +572,7 @@ class Command(BaseCommand):
         aggregator_class: type[EventAggregator],
         dry_run: bool,
         job_names: dict[int, str],
+        unit_names: dict[int, str],
     ) -> None:
         event_types = aggregator_class.event_types
 
@@ -481,7 +593,7 @@ class Command(BaseCommand):
         ).annotate(event_date=TruncDate("timestamp", tzinfo=UTC))
 
         aggregated_at = timezone.now()
-        lines = aggregator_class.aggregate(events, aggregated_at, job_names)
+        lines = aggregator_class.aggregate(events, aggregated_at, job_names, unit_names)
 
         marked_count = AnalyticsEvent.objects.filter(
             event_type__in=event_types,

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -10,7 +10,6 @@ from django.core.management.base import BaseCommand
 from django.db import models, transaction
 from django.db.models import (
     Count,
-    F,
     IntegerField,
     OuterRef,
     Q,
@@ -418,8 +417,9 @@ class Command(BaseCommand):
         job_names: dict[int, str] = dict(Job.objects.values_list("id", "name"))
         for aggregator_class in EVENT_AGGREGATORS:
             self._aggregate_event_type(aggregator_class, dry_run, job_names)
-       # Will be uncommented when we are sure that aggregation works as expected
-       # self._delete_old_unprocessed_events(dry_run)
+
+    # Will be uncommented when we are sure that aggregation works as expected
+    # self._delete_old_unprocessed_events(dry_run)
 
     @transaction.atomic
     def _delete_old_unprocessed_events(self, dry_run: bool) -> None:

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -418,7 +418,7 @@ class Command(BaseCommand):
         for aggregator_class in EVENT_AGGREGATORS:
             self._aggregate_event_type(aggregator_class, dry_run, job_names)
 
-    # Will be uncommented when we are sure that aggregation works as expected
+    # Will be uncommented with #829
     # self._delete_old_unprocessed_events(dry_run)
 
     @transaction.atomic
@@ -496,7 +496,8 @@ class Command(BaseCommand):
             )
         else:
             # Push after the transaction commits so we only push data that was successfully marked.
-            transaction.on_commit(lambda: push_lines(lines))
+            if lines:
+                transaction.on_commit(lambda: push_lines(lines))
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Aggregated and marked {marked_count} {event_types} events "

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -443,27 +443,25 @@ class ExerciseRepetitionAggregator(EventAggregator):
             .annotate(reps=Count("pk"))
         )
         dist: dict[tuple, int] = {}
-        unit_name_cache: dict[str, str] = {}
         for row in per_session:
             unit_id = row["unit_id"]
-            unit_name = resolve_unit(unit_id, unit_names)
-            if unit_name is None:
+            if resolve_unit(unit_id, unit_names) is None:
                 logger.warning(
                     "exercise_repetition standard event has no unit_id, skipping"
                 )
                 continue
-            unit_name_cache[unit_id] = unit_name
             key = (row["event_date"], row["exercise_type"], unit_id, row["reps"])
             dist[key] = dist.get(key, 0) + 1
         lines = []
         for (event_date, exercise_type, unit_id, reps), session_count in dist.items():
             ts = date_to_ns(event_date)
+            unit_name = resolve_unit(unit_id, unit_names)
             lines.append(
                 f"lunes_exercise_repetition"
                 f",unit_id={unit_id}"
                 f",exercise_type={exercise_type}"
                 f",repetitions_per_session={reps}"
-                f' unit_name="{unit_name_cache[unit_id]}",session_count={session_count}i {ts}'
+                f' unit_name="{unit_name}",session_count={session_count}i {ts}'
             )
             logger.info(
                 "Queued exercise_repetition (standard) line: unit_id=%s exercise_type=%s reps=%d date=%s",
@@ -488,27 +486,25 @@ class ExerciseRepetitionAggregator(EventAggregator):
             .annotate(reps=Count("pk"))
         )
         dist: dict[tuple, int] = {}
-        job_name_cache: dict[str, str] = {}
         for row in per_session:
             job_id = row["job_id"]
-            job_name = resolve_job(job_id, job_names)
-            if job_name is None:
+            if resolve_job(job_id, job_names) is None:
                 logger.warning(
                     "exercise_repetition training event has no job_id, skipping"
                 )
                 continue
-            job_name_cache[job_id] = job_name
             key = (row["event_date"], job_id, row["exercise_type"], row["reps"])
             dist[key] = dist.get(key, 0) + 1
         lines = []
         for (event_date, job_id, exercise_type, reps), session_count in dist.items():
             ts = date_to_ns(event_date)
+            job_name = resolve_job(job_id, job_names)
             lines.append(
                 f"lunes_exercise_repetition"
                 f",job_id={job_id}"
                 f",exercise_type={exercise_type}"
                 f",repetitions_per_session={reps}"
-                f' job_name="{job_name_cache[job_id]}",session_count={session_count}i {ts}'
+                f' job_name="{job_name}",session_count={session_count}i {ts}'
             )
             logger.info(
                 "Queued exercise_repetition (training) line: job_id=%s exercise_type=%s reps=%d date=%s",

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -22,13 +22,9 @@ from django.db.models.fields.json import KT
 from django.db.models.functions import Cast, TruncDate
 from django.utils import timezone
 
-from lunes_cms.analytics.models import (
-    AnalyticsEvent,
-    DropoutAggregate,
-    JobSelectionAggregate,
-    ModuleDurationAggregate,
-    SessionAggregate,
-)
+from lunes_cms.analytics.influx import date_to_ns, push_lines, resolve_job
+from lunes_cms.analytics.models import AnalyticsEvent
+from lunes_cms.cmsv2.models import Job
 
 logger = logging.getLogger(__name__)
 
@@ -38,36 +34,47 @@ RETENTION_DAYS = 90
 class EventAggregator(ABC):
     """
     Base class for event type aggregators.
-    Subclasses implement aggregate() to transform raw events into aggregate models
-    and to mark the consumed events with ``aggregated_at`` so they are not picked
-    up on subsequent runs.
+    Subclasses implement aggregate() to transform raw events into InfluxDB line
+    protocol strings and to mark the consumed events with ``aggregated_at`` so
+    they are not picked up on subsequent runs.
     """
 
     event_types: list[str]
 
     @staticmethod
     @abstractmethod
-    def aggregate(events: QuerySet[AnalyticsEvent], aggregated_at: datetime) -> None:
+    def aggregate(
+        events: QuerySet[AnalyticsEvent],
+        aggregated_at: datetime,
+        job_names: dict[int, str],
+    ) -> list[str]:
         """
-        Aggregate the given events into the corresponding aggregate model and
-        mark the events that were consumed by setting ``aggregated_at``.
+        Aggregate the given events into InfluxDB line protocol strings and mark
+        the events that were consumed by setting ``aggregated_at``.
 
         The queryset is already filtered to events of this aggregator's types,
         bounded by the snapshot ID, restricted to ``aggregated_at__isnull=True``
         and annotated with ``event_date`` (UTC date of the event).
+
+        Returns a list of InfluxDB line protocol strings to be pushed after the
+        transaction commits.
         """
 
 
 class JobSelectionAggregator(EventAggregator):
     """
-    Aggregates job_selected events into daily JobSelectionAggregate records.
+    Aggregates job_selected events into daily lunes_job_selection measurements.
     selection_count = number of "add" events minus number of "remove" events.
     """
 
     event_types = [AnalyticsEvent.EventType.JOB_SELECTED]
 
     @staticmethod
-    def aggregate(events: QuerySet[AnalyticsEvent], aggregated_at: datetime) -> None:
+    def aggregate(
+        events: QuerySet[AnalyticsEvent],
+        aggregated_at: datetime,
+        job_names: dict[int, str],
+    ) -> list[str]:
         daily_stats = (
             events.annotate(job_id=KT("payload__job_id"))
             .values("job_id", "event_date")
@@ -79,24 +86,31 @@ class JobSelectionAggregator(EventAggregator):
             )
         )
 
+        lines = []
         for stat in daily_stats:
-            aggregate, _created = JobSelectionAggregate.objects.update_or_create(
-                job_id=stat["job_id"],
-                date=stat["event_date"],
-                defaults={
-                    "selection_count": F("selection_count") + stat["selection_count"]
-                },
-                create_defaults={"selection_count": stat["selection_count"]},
+            job = resolve_job(stat["job_id"], job_names)
+            if job is None:
+                logger.warning("job_selected event has no job_id, skipping")
+                continue
+            ts = date_to_ns(stat["event_date"])
+            lines.append(
+                f"lunes_job_selection,job={job} selection_count={stat['selection_count']}i {ts}"
             )
-            logger.info("Created or updated aggregate %r", aggregate)
+            logger.info(
+                "Queued job_selection line: job=%s date=%s count=%d",
+                job,
+                stat["event_date"],
+                stat["selection_count"],
+            )
 
         events.update(aggregated_at=aggregated_at)
+        return lines
 
 
 class SessionAggregator(EventAggregator):
     """
-    Aggregates session_start and session_end events into daily SessionAggregate
-    records. Pairs events by session_id to compute duration.
+    Aggregates session_start and session_end events into daily lunes_sessions
+    measurements. Pairs events by session_id to compute duration.
 
     Sessions whose start and end fall on different UTC days are attributed to
     their start day. Sessions that cannot be paired in this run (for example a
@@ -112,35 +126,39 @@ class SessionAggregator(EventAggregator):
 
     @classmethod
     def aggregate(
-        cls, events: QuerySet[AnalyticsEvent], aggregated_at: datetime
-    ) -> None:
+        cls,
+        events: QuerySet[AnalyticsEvent],
+        aggregated_at: datetime,
+        job_names: dict[int, str],
+    ) -> list[str]:
+        # Accumulate per-date totals in Python before building lines
+        daily: dict[Any, tuple[int, int]] = (
+            {}
+        )  # event_date -> (session_count, total_duration_seconds)
         consumed_session_ids: list[str] = []
+
         for session in cls.sessions(events):
-            date = session["event_date"]
+            d = session["event_date"]
             duration_seconds = int(
                 (session["end_timestamp"] - session["timestamp"]).total_seconds()
             )
-            aggregate, _created = SessionAggregate.objects.update_or_create(
-                date=date,
-                defaults={
-                    "total_sessions": F("total_sessions") + 1,
-                    "total_duration_seconds": F("total_duration_seconds")
-                    + duration_seconds,
-                },
-                create_defaults={
-                    "total_sessions": 1,
-                    "total_duration_seconds": duration_seconds,
-                },
-            )
+            count, total = daily.get(d, (0, 0))
+            daily[d] = (count + 1, total + duration_seconds)
             consumed_session_ids.append(session["payload__session_id"])
-            logger.info(
-                "Created or updated aggregate %r with session %r", aggregate, session
+            logger.info("Queued session for date=%s duration=%ds", d, duration_seconds)
+
+        lines = []
+        for d, (count, total_duration) in daily.items():
+            ts = date_to_ns(d)
+            lines.append(
+                f"lunes_sessions total_sessions={count}i,total_duration_seconds={total_duration}i {ts}"
             )
 
         if consumed_session_ids:
             events.filter(payload__session_id__in=consumed_session_ids).update(
                 aggregated_at=aggregated_at
             )
+        return lines
 
     @staticmethod
     def sessions(
@@ -186,19 +204,26 @@ class SessionAggregator(EventAggregator):
 
 class ModuleDurationAggregator(EventAggregator):
     """
-    Aggregates module duration events for both standard and training exercises.
+    Aggregates module duration events into daily lunes_module_duration measurements
+    for both standard (unit-based) and training (job-based) exercises.
     """
 
     event_types = [AnalyticsEvent.EventType.MODULE_DURATION]
 
     @staticmethod
-    def aggregate(events: QuerySet[AnalyticsEvent], aggregated_at: datetime) -> None:
+    def aggregate(
+        events: QuerySet[AnalyticsEvent],
+        aggregated_at: datetime,
+        job_names: dict[int, str],
+    ) -> list[str]:
         standard_events = events.filter(
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.STANDARD
         )
         training_events = events.filter(
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.TRAINING
         )
+
+        lines = []
 
         standard_aggregated = (
             standard_events.annotate(
@@ -215,22 +240,17 @@ class ModuleDurationAggregator(EventAggregator):
             )
         )
         for event in standard_aggregated:
-            aggregate, _created = ModuleDurationAggregate.objects.update_or_create(
-                date=event["event_date"],
-                exercise_type=event["exercise_type"],
-                unit_id=event["unit_id"],
-                job_id=None,
-                defaults={
-                    "total_duration_seconds": F("total_duration_seconds")
-                    + event["total_duration_seconds"],
-                    "total_sessions": F("total_sessions") + event["total_sessions"],
-                },
-                create_defaults={
-                    "total_duration_seconds": event["total_duration_seconds"],
-                    "total_sessions": event["total_sessions"],
-                },
+            ts = date_to_ns(event["event_date"])
+            lines.append(
+                f"lunes_module_duration,unit_id={event['unit_id']},exercise_type={event['exercise_type']}"
+                f" total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
             )
-            logger.info("Created or updated aggregate %r", aggregate)
+            logger.info(
+                "Queued module_duration (standard) line: unit_id=%s exercise_type=%s date=%s",
+                event["unit_id"],
+                event["exercise_type"],
+                event["event_date"],
+            )
 
         training_aggregated = (
             training_events.annotate(
@@ -247,44 +267,48 @@ class ModuleDurationAggregator(EventAggregator):
             )
         )
         for event in training_aggregated:
-            aggregate, _created = ModuleDurationAggregate.objects.update_or_create(
-                date=event["event_date"],
-                exercise_type=event["exercise_type"],
-                unit_id=None,
-                job_id=event["job_id"],
-                defaults={
-                    "total_duration_seconds": F("total_duration_seconds")
-                    + event["total_duration_seconds"],
-                    "total_sessions": F("total_sessions") + event["total_sessions"],
-                },
-                create_defaults={
-                    "total_duration_seconds": event["total_duration_seconds"],
-                    "total_sessions": event["total_sessions"],
-                },
+            job = resolve_job(event["job_id"], job_names)
+            if job is None:
+                logger.warning("module_duration training event has no job_id, skipping")
+                continue
+            ts = date_to_ns(event["event_date"])
+            lines.append(
+                f"lunes_module_duration,job={job},exercise_type={event['exercise_type']}"
+                f" total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
             )
-            logger.info("Created or updated aggregate %r", aggregate)
+            logger.info(
+                "Queued module_duration (training) line: job=%s exercise_type=%s date=%s",
+                job,
+                event["exercise_type"],
+                event["event_date"],
+            )
 
         events.update(aggregated_at=aggregated_at)
+        return lines
 
 
 class DropoutAggregator(EventAggregator):
     """
-    Aggregates exercise dropout events into daily DropoutAggregate records
+    Aggregates exercise dropout events into daily lunes_dropout measurements
     for both standard and training exercises.
-    Groups standard events by (date, exercise_type, unit_id, dropout_position, total_items).
-    Groups training events by (date, exercise_type, job_id, vocabulary_item_id, dropout_position, total_items).
     """
 
     event_types = [AnalyticsEvent.EventType.EXERCISE_DROPOUT]
 
     @staticmethod
-    def aggregate(events: QuerySet[AnalyticsEvent], aggregated_at: datetime) -> None:
+    def aggregate(
+        events: QuerySet[AnalyticsEvent],
+        aggregated_at: datetime,
+        job_names: dict[int, str],
+    ) -> list[str]:
         standard_events = events.filter(
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.STANDARD
         )
         training_events = events.filter(
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.TRAINING
         )
+
+        lines = []
 
         standard_aggregated = (
             standard_events.annotate(
@@ -302,22 +326,24 @@ class DropoutAggregator(EventAggregator):
             .annotate(dropout_count=Count("pk"))
         )
         for event in standard_aggregated:
-            aggregate, _created = DropoutAggregate.objects.update_or_create(
-                date=event["event_date"],
-                exercise_type=event["exercise_type"],
-                unit_id=event["unit_id"],
-                job_id=None,
-                vocabulary_item_id=event["payload__vocabulary_item_id"],
-                dropout_position=event["payload__position"],
-                total_items=event["payload__total"],
-                defaults={
-                    "dropout_count": F("dropout_count") + event["dropout_count"],
-                },
-                create_defaults={
-                    "dropout_count": event["dropout_count"],
-                },
+            ts = date_to_ns(event["event_date"])
+            vocab_id = event["payload__vocabulary_item_id"]
+            vocab_tag = f",vocab_id={vocab_id}" if vocab_id is not None else ""
+            lines.append(
+                f"lunes_dropout"
+                f",unit_id={event['unit_id']}"
+                f",exercise_type={event['exercise_type']}"
+                f"{vocab_tag}"
+                f",position={event['payload__position']}"
+                f",total={event['payload__total']}"
+                f" dropout_count={event['dropout_count']}i {ts}"
             )
-            logger.info("Created or updated aggregate %r", aggregate)
+            logger.info(
+                "Queued dropout (standard) line: unit_id=%s exercise_type=%s date=%s",
+                event["unit_id"],
+                event["exercise_type"],
+                event["event_date"],
+            )
 
         training_aggregated = (
             training_events.annotate(
@@ -335,24 +361,31 @@ class DropoutAggregator(EventAggregator):
             .annotate(dropout_count=Count("pk"))
         )
         for event in training_aggregated:
-            aggregate, _created = DropoutAggregate.objects.update_or_create(
-                date=event["event_date"],
-                exercise_type=event["exercise_type"],
-                unit_id=None,
-                job_id=event["job_id"],
-                vocabulary_item_id=event["payload__vocabulary_item_id"],
-                dropout_position=event["payload__position"],
-                total_items=event["payload__total"],
-                defaults={
-                    "dropout_count": F("dropout_count") + event["dropout_count"],
-                },
-                create_defaults={
-                    "dropout_count": event["dropout_count"],
-                },
+            job = resolve_job(event["job_id"], job_names)
+            if job is None:
+                logger.warning("dropout training event has no job_id, skipping")
+                continue
+            ts = date_to_ns(event["event_date"])
+            vocab_id = event["payload__vocabulary_item_id"]
+            vocab_tag = f",vocab_id={vocab_id}" if vocab_id is not None else ""
+            lines.append(
+                f"lunes_dropout"
+                f",job={job}"
+                f",exercise_type={event['exercise_type']}"
+                f"{vocab_tag}"
+                f",position={event['payload__position']}"
+                f",total={event['payload__total']}"
+                f" dropout_count={event['dropout_count']}i {ts}"
             )
-            logger.info("Created or updated aggregate %r", aggregate)
+            logger.info(
+                "Queued dropout (training) line: job=%s exercise_type=%s date=%s",
+                job,
+                event["exercise_type"],
+                event["event_date"],
+            )
 
         events.update(aggregated_at=aggregated_at)
+        return lines
 
 
 EVENT_AGGREGATORS: list[type[EventAggregator]] = [
@@ -365,25 +398,26 @@ EVENT_AGGREGATORS: list[type[EventAggregator]] = [
 
 class Command(BaseCommand):
     """
-    Aggregate analytics events into daily summaries.
+    Aggregate analytics events and push daily summaries to InfluxDB.
 
     Raw events are kept after aggregation; each consumed event is stamped with
     ``aggregated_at`` so subsequent runs only process newly arrived events.
     """
 
-    help = "Aggregate analytics events into daily summaries (raw events are retained)."
+    help = "Aggregate analytics events and push daily summaries to InfluxDB (raw events are retained)."
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Run the full aggregation pipeline but roll back all changes.",
+            help="Run the full aggregation pipeline but roll back all DB changes and skip InfluxDB push.",
         )
 
     def handle(self, *args, **options) -> None:
         dry_run: bool = options["dry_run"]
+        job_names: dict[int, str] = dict(Job.objects.values_list("id", "name"))
         for aggregator_class in EVENT_AGGREGATORS:
-            self._aggregate_event_type(aggregator_class, dry_run)
+            self._aggregate_event_type(aggregator_class, dry_run, job_names)
         self._delete_old_unprocessed_events(dry_run)
 
     @transaction.atomic
@@ -425,6 +459,7 @@ class Command(BaseCommand):
         self,
         aggregator_class: type[EventAggregator],
         dry_run: bool,
+        job_names: dict[int, str],
     ) -> None:
         event_types = aggregator_class.event_types
 
@@ -445,7 +480,7 @@ class Command(BaseCommand):
         ).annotate(event_date=TruncDate("timestamp", tzinfo=UTC))
 
         aggregated_at = timezone.now()
-        aggregator_class.aggregate(events, aggregated_at)
+        lines = aggregator_class.aggregate(events, aggregated_at, job_names)
 
         marked_count = AnalyticsEvent.objects.filter(
             event_type__in=event_types,
@@ -455,11 +490,15 @@ class Command(BaseCommand):
         if dry_run:
             transaction.set_rollback(True)
             self.stdout.write(
-                f"[DRY RUN] Would aggregate and mark {marked_count} {event_types} events."
+                f"[DRY RUN] Would aggregate and mark {marked_count} {event_types} events "
+                f"({len(lines)} InfluxDB lines skipped)."
             )
         else:
+            # Push after the transaction commits so we only push data that was successfully marked.
+            transaction.on_commit(lambda: push_lines(lines))
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Aggregated and marked {marked_count} {event_types} events."
+                    f"Aggregated and marked {marked_count} {event_types} events "
+                    f"({len(lines)} InfluxDB lines queued)."
                 )
             )

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -89,17 +89,19 @@ class JobSelectionAggregator(EventAggregator):
 
         lines = []
         for stat in daily_stats:
-            job = resolve_job(stat["job_id"], job_names)
-            if job is None:
+            job_id = stat["job_id"]
+            job_name = resolve_job(job_id, job_names)
+            if job_name is None:
                 logger.warning("job_selected event has no job_id, skipping")
                 continue
             ts = date_to_ns(stat["event_date"])
             lines.append(
-                f"lunes_job_selection,job={job} selection_count={stat['selection_count']}i {ts}"
+                f"lunes_job_selection,job_id={job_id}"
+                f" job_name=\"{job_name}\",selection_count={stat['selection_count']}i {ts}"
             )
             logger.info(
-                "Queued job_selection line: job=%s date=%s count=%d",
-                job,
+                "Queued job_selection line: job_id=%s date=%s count=%d",
+                job_id,
                 stat["event_date"],
                 stat["selection_count"],
             )
@@ -243,20 +245,21 @@ class ModuleDurationAggregator(EventAggregator):
             )
         )
         for event in standard_aggregated:
-            unit = resolve_unit(event["unit_id"], unit_names)
-            if unit is None:
+            unit_id = event["unit_id"]
+            unit_name = resolve_unit(unit_id, unit_names)
+            if unit_name is None:
                 logger.warning(
                     "module_duration standard event has no unit_id, skipping"
                 )
                 continue
             ts = date_to_ns(event["event_date"])
             lines.append(
-                f"lunes_module_duration,unit={unit},exercise_type={event['exercise_type']}"
-                f" total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
+                f"lunes_module_duration,unit_id={unit_id},exercise_type={event['exercise_type']}"
+                f" unit_name=\"{unit_name}\",total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
             )
             logger.info(
-                "Queued module_duration (standard) line: unit=%s exercise_type=%s date=%s",
-                unit,
+                "Queued module_duration (standard) line: unit_id=%s exercise_type=%s date=%s",
+                unit_id,
                 event["exercise_type"],
                 event["event_date"],
             )
@@ -276,18 +279,19 @@ class ModuleDurationAggregator(EventAggregator):
             )
         )
         for event in training_aggregated:
-            job = resolve_job(event["job_id"], job_names)
-            if job is None:
+            job_id = event["job_id"]
+            job_name = resolve_job(job_id, job_names)
+            if job_name is None:
                 logger.warning("module_duration training event has no job_id, skipping")
                 continue
             ts = date_to_ns(event["event_date"])
             lines.append(
-                f"lunes_module_duration,job={job},exercise_type={event['exercise_type']}"
-                f" total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
+                f"lunes_module_duration,job_id={job_id},exercise_type={event['exercise_type']}"
+                f" job_name=\"{job_name}\",total_sessions={event['total_sessions']}i,total_duration_seconds={event['total_duration_seconds']}i {ts}"
             )
             logger.info(
-                "Queued module_duration (training) line: job=%s exercise_type=%s date=%s",
-                job,
+                "Queued module_duration (training) line: job_id=%s exercise_type=%s date=%s",
+                job_id,
                 event["exercise_type"],
                 event["event_date"],
             )
@@ -335,18 +339,23 @@ class DropoutAggregator(EventAggregator):
             .annotate(dropout_count=Count("pk"))
         )
         for event in standard_aggregated:
+            unit_id = event["unit_id"]
+            unit_name = resolve_unit(unit_id, unit_names)
+            if unit_name is None:
+                logger.warning("dropout standard event has no unit_id, skipping")
+                continue
             ts = date_to_ns(event["event_date"])
             lines.append(
                 f"lunes_dropout"
-                f",unit_id={event['unit_id']}"
+                f",unit_id={unit_id}"
                 f",exercise_type={event['exercise_type']}"
                 f",position={event['payload__position']}"
                 f",total={event['payload__total']}"
-                f" dropout_count={event['dropout_count']}i {ts}"
+                f" unit_name=\"{unit_name}\",dropout_count={event['dropout_count']}i {ts}"
             )
             logger.info(
                 "Queued dropout (standard) line: unit_id=%s exercise_type=%s date=%s",
-                event["unit_id"],
+                unit_id,
                 event["exercise_type"],
                 event["event_date"],
             )
@@ -366,22 +375,23 @@ class DropoutAggregator(EventAggregator):
             .annotate(dropout_count=Count("pk"))
         )
         for event in training_aggregated:
-            job = resolve_job(event["job_id"], job_names)
-            if job is None:
+            job_id = event["job_id"]
+            job_name = resolve_job(job_id, job_names)
+            if job_name is None:
                 logger.warning("dropout training event has no job_id, skipping")
                 continue
             ts = date_to_ns(event["event_date"])
             lines.append(
                 f"lunes_dropout"
-                f",job={job}"
+                f",job_id={job_id}"
                 f",exercise_type={event['exercise_type']}"
                 f",position={event['payload__position']}"
                 f",total={event['payload__total']}"
-                f" dropout_count={event['dropout_count']}i {ts}"
+                f" job_name=\"{job_name}\",dropout_count={event['dropout_count']}i {ts}"
             )
             logger.info(
-                "Queued dropout (training) line: job=%s exercise_type=%s date=%s",
-                job,
+                "Queued dropout (training) line: job_id=%s exercise_type=%s date=%s",
+                job_id,
                 event["exercise_type"],
                 event["event_date"],
             )
@@ -414,13 +424,15 @@ class ExerciseRepetitionAggregator(EventAggregator):
             payload__exercise_key__type=AnalyticsEvent.ExerciseKeyType.TRAINING
         )
         lines = ExerciseRepetitionAggregator._standard_lines(
-            standard_events
+            standard_events, unit_names
         ) + ExerciseRepetitionAggregator._training_lines(training_events, job_names)
         events.update(aggregated_at=aggregated_at)
         return lines
 
     @staticmethod
-    def _standard_lines(standard_events: QuerySet[AnalyticsEvent]) -> list[str]:
+    def _standard_lines(
+        standard_events: QuerySet[AnalyticsEvent], unit_names: dict[int, str]
+    ) -> list[str]:
         per_session = (
             standard_events.annotate(
                 exercise_type=KT("payload__exercise_key__exercise_type"),
@@ -431,8 +443,17 @@ class ExerciseRepetitionAggregator(EventAggregator):
             .annotate(reps=Count("pk"))
         )
         dist: dict[tuple, int] = {}
+        unit_name_cache: dict[str, str] = {}
         for row in per_session:
-            key = (row["event_date"], row["exercise_type"], row["unit_id"], row["reps"])
+            unit_id = row["unit_id"]
+            unit_name = resolve_unit(unit_id, unit_names)
+            if unit_name is None:
+                logger.warning(
+                    "exercise_repetition standard event has no unit_id, skipping"
+                )
+                continue
+            unit_name_cache[unit_id] = unit_name
+            key = (row["event_date"], row["exercise_type"], unit_id, row["reps"])
             dist[key] = dist.get(key, 0) + 1
         lines = []
         for (event_date, exercise_type, unit_id, reps), session_count in dist.items():
@@ -442,7 +463,7 @@ class ExerciseRepetitionAggregator(EventAggregator):
                 f",unit_id={unit_id}"
                 f",exercise_type={exercise_type}"
                 f",repetitions_per_session={reps}"
-                f" session_count={session_count}i {ts}"
+                f' unit_name="{unit_name_cache[unit_id]}",session_count={session_count}i {ts}'
             )
             logger.info(
                 "Queued exercise_repetition (standard) line: unit_id=%s exercise_type=%s reps=%d date=%s",
@@ -467,28 +488,31 @@ class ExerciseRepetitionAggregator(EventAggregator):
             .annotate(reps=Count("pk"))
         )
         dist: dict[tuple, int] = {}
+        job_name_cache: dict[str, str] = {}
         for row in per_session:
-            job = resolve_job(row["job_id"], job_names)
-            if job is None:
+            job_id = row["job_id"]
+            job_name = resolve_job(job_id, job_names)
+            if job_name is None:
                 logger.warning(
                     "exercise_repetition training event has no job_id, skipping"
                 )
                 continue
-            key = (row["event_date"], job, row["exercise_type"], row["reps"])
+            job_name_cache[job_id] = job_name
+            key = (row["event_date"], job_id, row["exercise_type"], row["reps"])
             dist[key] = dist.get(key, 0) + 1
         lines = []
-        for (event_date, job, exercise_type, reps), session_count in dist.items():
+        for (event_date, job_id, exercise_type, reps), session_count in dist.items():
             ts = date_to_ns(event_date)
             lines.append(
                 f"lunes_exercise_repetition"
-                f",job={job}"
+                f",job_id={job_id}"
                 f",exercise_type={exercise_type}"
                 f",repetitions_per_session={reps}"
-                f" session_count={session_count}i {ts}"
+                f' job_name="{job_name_cache[job_id]}",session_count={session_count}i {ts}'
             )
             logger.info(
-                "Queued exercise_repetition (training) line: job=%s exercise_type=%s reps=%d date=%s",
-                job,
+                "Queued exercise_repetition (training) line: job_id=%s exercise_type=%s reps=%d date=%s",
+                job_id,
                 exercise_type,
                 reps,
                 event_date,

--- a/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
+++ b/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
@@ -1,3 +1,4 @@
+import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -902,6 +903,10 @@ class DropoutAggregateTests(TestCase):
         self.assertTrue(any("job=unknown_5" in l for l in lines))
 
 
+# 829 Enable cleanup
+@unittest.skip(
+    "Cleanup is temporarily disabled — see issue for re-enabling _delete_old_unprocessed_events"
+)
 class UnprocessedEventCleanupTests(TestCase):
     """
     Tests for deletion of events not covered by batch aggregators.

--- a/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
+++ b/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -6,6 +7,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from lunes_cms.analytics.models import AnalyticsEvent
+from lunes_cms.cmsv2.models import Unit
 from lunes_cms.cmsv2.models.job import Job
 
 PATCH_PUSH = "lunes_cms.analytics.management.commands.aggregate_analytics.push_lines"
@@ -365,6 +367,10 @@ class ModuleDurationAggregateTests(TestCase):
     Tests for module duration event aggregation.
     """
 
+    def setUp(self) -> None:
+        self.unit1 = Unit.objects.create(title="Unit 1")
+        self.unit2 = Unit.objects.create(title="Unit 2")
+
     def _create_standard_event(
         self, exercise_type: str, unit_id: int, timestamp: str, duration_seconds: int
     ) -> AnalyticsEvent:
@@ -401,8 +407,12 @@ class ModuleDurationAggregateTests(TestCase):
 
     def test_aggregates_single_day(self) -> None:
         """Test basic aggregation of standard module duration events into a single day"""
-        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
-        self._create_standard_event("word_choice", 10, "2026-01-15T11:00:00", 90)
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T11:00:00", 90
+        )
 
         with patch(PATCH_PUSH) as mock_push:
             with self.captureOnCommitCallbacks(execute=True):
@@ -414,15 +424,19 @@ class ModuleDurationAggregateTests(TestCase):
         mock_push.assert_called_once()
         [line] = mock_push.call_args[0][0]
         self.assertIn("lunes_module_duration", line)
-        self.assertIn("unit_id=10", line)
+        self.assertIn(r"unit=Unit\ 1", line)
         self.assertIn("exercise_type=word_choice", line)
         self.assertIn("total_sessions=2i", line)
         self.assertIn("total_duration_seconds=150i", line)
 
     def test_aggregates_multiple_days(self) -> None:
         """Test that events on different days create separate lines"""
-        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
-        self._create_standard_event("word_choice", 10, "2026-01-16T10:00:00", 60)
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-16T10:00:00", 60
+        )
 
         with patch(PATCH_PUSH) as mock_push:
             with self.captureOnCommitCallbacks(execute=True):
@@ -433,8 +447,12 @@ class ModuleDurationAggregateTests(TestCase):
 
     def test_aggregates_different_exercise_types(self) -> None:
         """Test that different exercise types create separate lines"""
-        self._create_standard_event("word_list", 10, "2026-01-15T10:00:00", 60)
-        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
+        self._create_standard_event(
+            "word_list", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
 
         with patch(PATCH_PUSH) as mock_push:
             with self.captureOnCommitCallbacks(execute=True):
@@ -447,8 +465,12 @@ class ModuleDurationAggregateTests(TestCase):
 
     def test_aggregates_different_units(self) -> None:
         """Test that different unit IDs create separate lines"""
-        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
-        self._create_standard_event("word_choice", 20, "2026-01-15T10:00:00", 90)
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
+        self._create_standard_event(
+            "word_choice", self.unit2.id, "2026-01-15T10:00:00", 90
+        )
 
         with patch(PATCH_PUSH) as mock_push:
             with self.captureOnCommitCallbacks(execute=True):
@@ -457,19 +479,29 @@ class ModuleDurationAggregateTests(TestCase):
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
         self.assertTrue(
-            any("unit_id=10" in l and "total_duration_seconds=60i" in l for l in lines)
+            any(
+                r"unit=Unit\ 1" in l and "total_duration_seconds=60i" in l
+                for l in lines
+            )
         )
         self.assertTrue(
-            any("unit_id=20" in l and "total_duration_seconds=90i" in l for l in lines)
+            any(
+                r"unit=Unit\ 2" in l and "total_duration_seconds=90i" in l
+                for l in lines
+            )
         )
 
     def test_second_run_pushes_only_new_events(self) -> None:
         """Test that running twice pushes new events in each run separately"""
-        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
         with self.captureOnCommitCallbacks(execute=True):
             call_command("aggregate_analytics")
 
-        self._create_standard_event("word_choice", 10, "2026-01-15T14:00:00", 40)
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T14:00:00", 40
+        )
         with patch(PATCH_PUSH) as mock_push:
             with self.captureOnCommitCallbacks(execute=True):
                 call_command("aggregate_analytics")
@@ -544,7 +576,9 @@ class ModuleDurationAggregateTests(TestCase):
 
     def test_standard_and_training_create_separate_lines(self) -> None:
         """Test that standard and training exercises produce separate lines"""
-        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
+        self._create_standard_event(
+            "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
+        )
         self._create_training_event("image", 5, "2026-01-15T10:00:00", 60)
 
         with patch(PATCH_PUSH) as mock_push:
@@ -553,7 +587,7 @@ class ModuleDurationAggregateTests(TestCase):
 
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
-        self.assertTrue(any("unit_id=10" in l for l in lines))
+        self.assertTrue(any(r"unit=Unit\ 1" in l for l in lines))
         self.assertTrue(any("job=unknown_5" in l for l in lines))
 
 
@@ -562,7 +596,7 @@ class DropoutAggregateTests(TestCase):
     Tests for exercise dropout event aggregation.
     """
 
-    def _create_standard_event(  # pylint: disable=too-many-arguments
+    def _create_standard_event(
         self,
         *,
         exercise_type: str,
@@ -840,11 +874,11 @@ class DropoutAggregateTests(TestCase):
         self.assertIn("exercise_type=image", line)
         self.assertIn("position=2", line)
         self.assertIn("total=8", line)
-        self.assertIn("vocab_id=99", line)
+        self.assertNotIn("vocab_id", line)
         self.assertIn("dropout_count=2i", line)
 
-    def test_different_vocabulary_items_create_separate_lines(self) -> None:
-        """Test that dropouts on different vocabulary items create separate lines"""
+    def test_different_vocabulary_items_are_aggregated_together(self) -> None:
+        """Test that dropouts on different vocabulary items are grouped into one line"""
         self._create_training_event(
             exercise_type="image",
             job_id=5,
@@ -867,13 +901,9 @@ class DropoutAggregateTests(TestCase):
                 call_command("aggregate_analytics")
 
         lines = mock_push.call_args[0][0]
-        self.assertEqual(len(lines), 2)
-        self.assertTrue(
-            any("vocab_id=10" in l and "dropout_count=1i" in l for l in lines)
-        )
-        self.assertTrue(
-            any("vocab_id=20" in l and "dropout_count=1i" in l for l in lines)
-        )
+        self.assertEqual(len(lines), 1)
+        self.assertIn("dropout_count=2i", lines[0])
+        self.assertNotIn("vocab_id", lines[0])
 
     def test_standard_and_training_dropout_separate(self) -> None:
         """Test that standard and training dropouts produce separate lines"""
@@ -903,6 +933,244 @@ class DropoutAggregateTests(TestCase):
         self.assertTrue(any("job=unknown_5" in l for l in lines))
 
 
+class ExerciseRepetitionAggregateTests(TestCase):
+    """
+    Tests for exercise repetition event aggregation.
+    """
+
+    def setUp(self) -> None:
+        self.job = Job.objects.create(name="Test Job")
+
+    def _create_standard_event(
+        self, exercise_type: str, unit_id: int, timestamp: str
+    ) -> AnalyticsEvent:
+        return AnalyticsEvent.objects.create(
+            installation_id="test-install",
+            event_type="exercise_repetition",
+            timestamp=datetime.fromisoformat(timestamp).replace(tzinfo=timezone.utc),
+            payload={
+                "exercise_key": {
+                    "type": "exercise",
+                    "exercise_type": exercise_type,
+                    "unit_id": unit_id,
+                },
+                "session_id": "session-1",
+            },
+        )
+
+    def _create_training_event(
+        self, exercise_type: str, job_id: int, timestamp: str
+    ) -> AnalyticsEvent:
+        return AnalyticsEvent.objects.create(
+            installation_id="test-install",
+            event_type="exercise_repetition",
+            timestamp=datetime.fromisoformat(timestamp).replace(tzinfo=timezone.utc),
+            payload={
+                "exercise_key": {
+                    "type": "training",
+                    "exercise_type": exercise_type,
+                    "job_id": job_id,
+                },
+                "session_id": "session-1",
+            },
+        )
+
+    def test_aggregates_standard_events_by_day(self) -> None:
+        """Multiple standard events from the same session are one bucket with reps=3"""
+        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00")
+        self._create_standard_event("word_choice", 10, "2026-01-15T11:00:00")
+        self._create_standard_event("word_choice", 10, "2026-01-15T12:00:00")
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        self.assertEqual(
+            AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
+        )
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_exercise_repetition", line)
+        self.assertIn("unit_id=10", line)
+        self.assertIn("exercise_type=word_choice", line)
+        self.assertIn("repetitions_per_session=3", line)
+        self.assertIn("session_count=1i", line)
+        self.assertNotIn("session_id", line)
+
+    def test_aggregates_different_days(self) -> None:
+        """Events on different days create separate lines"""
+        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00")
+        self._create_standard_event("word_choice", 10, "2026-01-16T10:00:00")
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(all("repetitions_per_session=1" in l for l in lines))
+        self.assertTrue(all("session_count=1i" in l for l in lines))
+
+    def test_aggregates_different_units(self) -> None:
+        """Events for different unit_ids create separate lines"""
+        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00")
+        self._create_standard_event("word_choice", 20, "2026-01-15T10:00:00")
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any("unit_id=10" in l for l in lines))
+        self.assertTrue(any("unit_id=20" in l for l in lines))
+
+    def test_aggregates_different_exercise_types(self) -> None:
+        """Events for different exercise types create separate lines"""
+        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00")
+        self._create_standard_event("word_list", 10, "2026-01-15T10:00:00")
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+
+    def test_aggregates_training_events(self) -> None:
+        """Training events from the same session are one bucket with reps=2"""
+        self._create_training_event("image", self.job.id, "2026-01-15T10:00:00")
+        self._create_training_event("image", self.job.id, "2026-01-15T11:00:00")
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_exercise_repetition", line)
+        self.assertIn("job=Test\\ Job", line)
+        self.assertIn("exercise_type=image", line)
+        self.assertIn("repetitions_per_session=2", line)
+        self.assertIn("session_count=1i", line)
+        self.assertNotIn("session_id", line)
+
+    def test_different_sessions_same_day_same_reps_are_bucketed(self) -> None:
+        """Two sessions each doing 1 rep land in the same bucket: session_count=2"""
+        AnalyticsEvent.objects.create(
+            installation_id="test-install",
+            event_type="exercise_repetition",
+            timestamp=datetime.fromisoformat("2026-01-15T10:00:00").replace(
+                tzinfo=timezone.utc
+            ),
+            payload={
+                "exercise_key": {
+                    "type": "exercise",
+                    "exercise_type": "word_choice",
+                    "unit_id": 10,
+                },
+                "session_id": "session-A",
+            },
+        )
+        AnalyticsEvent.objects.create(
+            installation_id="test-install",
+            event_type="exercise_repetition",
+            timestamp=datetime.fromisoformat("2026-01-15T11:00:00").replace(
+                tzinfo=timezone.utc
+            ),
+            payload={
+                "exercise_key": {
+                    "type": "exercise",
+                    "exercise_type": "word_choice",
+                    "unit_id": 10,
+                },
+                "session_id": "session-B",
+            },
+        )
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("repetitions_per_session=1", line)
+        self.assertIn("session_count=2i", line)
+        self.assertNotIn("session_id", line)
+
+    def test_distribution_buckets_with_different_rep_counts(self) -> None:
+        """Sessions with different rep counts produce separate distribution lines"""
+
+        def _make(session_id: str, timestamp: str) -> None:
+            AnalyticsEvent.objects.create(
+                installation_id="test-install",
+                event_type="exercise_repetition",
+                timestamp=datetime.fromisoformat(timestamp).replace(
+                    tzinfo=timezone.utc
+                ),
+                payload={
+                    "exercise_key": {
+                        "type": "exercise",
+                        "exercise_type": "word_choice",
+                        "unit_id": 10,
+                    },
+                    "session_id": session_id,
+                },
+            )
+
+        # session-A: 3 reps
+        _make("session-A", "2026-01-15T10:00:00")
+        _make("session-A", "2026-01-15T10:01:00")
+        _make("session-A", "2026-01-15T10:02:00")
+        # session-B: 1 rep
+        _make("session-B", "2026-01-15T11:00:00")
+        # session-C: 3 reps
+        _make("session-C", "2026-01-15T12:00:00")
+        _make("session-C", "2026-01-15T12:01:00")
+        _make("session-C", "2026-01-15T12:02:00")
+
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(
+            any(
+                "repetitions_per_session=3" in l and "session_count=2i" in l
+                for l in lines
+            )
+        )
+        self.assertTrue(
+            any(
+                "repetitions_per_session=1" in l and "session_count=1i" in l
+                for l in lines
+            )
+        )
+
+    def test_second_run_pushes_only_new_events(self) -> None:
+        """Running twice pushes new events in each run separately"""
+        self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00")
+        with self.captureOnCommitCallbacks(execute=True):
+            call_command("aggregate_analytics")
+
+        self._create_standard_event("word_choice", 10, "2026-01-15T14:00:00")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("repetitions_per_session=1", line)
+        self.assertIn("session_count=1i", line)
+
+    def test_no_events(self) -> None:
+        """Running with no events does not push anything"""
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_not_called()
+
+
 # 829 Enable cleanup
 @unittest.skip(
     "Cleanup is temporarily disabled — see issue for re-enabling _delete_old_unprocessed_events"
@@ -910,8 +1178,6 @@ class DropoutAggregateTests(TestCase):
 class UnprocessedEventCleanupTests(TestCase):
     """
     Tests for deletion of events not covered by batch aggregators.
-    exercise_repetition events are aggregated inline on receipt and must be cleaned
-    up by the management command after RETENTION_DAYS days.
     """
 
     OLD_TIMESTAMP = datetime.now(tz=timezone.utc) - timedelta(days=91)

--- a/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
+++ b/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
@@ -1,16 +1,13 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
 
-from lunes_cms.analytics.models import (
-    AnalyticsEvent,
-    DropoutAggregate,
-    JobSelectionAggregate,
-    ModuleDurationAggregate,
-    SessionAggregate,
-)
+from lunes_cms.analytics.models import AnalyticsEvent
 from lunes_cms.cmsv2.models.job import Job
+
+PATCH_PUSH = "lunes_cms.analytics.management.commands.aggregate_analytics.push_lines"
 
 
 class JobSelectionAggregateTests(TestCase):
@@ -36,79 +33,101 @@ class JobSelectionAggregateTests(TestCase):
         self._create_event(self.job1.id, "add", "2026-01-15T11:00:00")
         self._create_event(self.job1.id, "remove", "2026-01-15T12:00:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
         self.assertEqual(AnalyticsEvent.objects.count(), 3)
-        agg = JobSelectionAggregate.objects.get(job_id=self.job1.id)
-        self.assertEqual(agg.selection_count, 1)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_job_selection", line)
+        self.assertIn(r"job=Job\ 1", line)
+        self.assertIn("selection_count=1i", line)
 
     def test_aggregates_multiple_days(self) -> None:
-        """Test that events on different days create separate aggregates"""
+        """Test that events on different days create separate lines"""
         self._create_event(self.job1.id, "add", "2026-01-15T10:00:00")
         self._create_event(self.job1.id, "add", "2026-01-16T10:00:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(JobSelectionAggregate.objects.count(), 2)
+        mock_push.assert_called_once()
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
 
     def test_aggregates_multiple_jobs(self) -> None:
-        """Test that events for different jobs create separate aggregates"""
+        """Test that events for different jobs create separate lines"""
         self._create_event(self.job1.id, "add", "2026-01-15T10:00:00")
         self._create_event(self.job2.id, "add", "2026-01-15T10:00:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(JobSelectionAggregate.objects.count(), 2)
-        self.assertEqual(
-            JobSelectionAggregate.objects.get(job_id=self.job1.id).selection_count, 1
-        )
-        self.assertEqual(
-            JobSelectionAggregate.objects.get(job_id=self.job2.id).selection_count, 1
-        )
+        mock_push.assert_called_once()
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any(r"job=Job\ 1" in l for l in lines))
+        self.assertTrue(any(r"job=Job\ 2" in l for l in lines))
+        self.assertTrue(all("selection_count=1i" in l for l in lines))
 
-    def test_increments_existing_aggregate(self) -> None:
-        """Test that running twice increments existing aggregates"""
+    def test_second_run_pushes_only_new_events(self) -> None:
+        """Test that running twice pushes each batch of new events separately"""
         self._create_event(self.job1.id, "add", "2026-01-15T10:00:00")
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_called_once()
 
         self._create_event(self.job1.id, "add", "2026-01-15T14:00:00")
-        call_command("aggregate_analytics")
-
-        agg = JobSelectionAggregate.objects.get(job_id=self.job1.id)
-        self.assertEqual(agg.selection_count, 2)
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("selection_count=1i", line)
 
     def test_no_events(self) -> None:
-        """Test that running with no events does nothing"""
-        call_command("aggregate_analytics")
-        self.assertEqual(JobSelectionAggregate.objects.count(), 0)
+        """Test that running with no events does not push anything"""
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_not_called()
 
     def test_nonexistent_job_id(self) -> None:
-        """Test that events with nonexistent job_ids are aggregated normally"""
+        """Test that events with nonexistent job_ids are pushed with an unknown_<id> tag"""
         self._create_event(self.job1.id, "add", "2026-01-15T10:00:00")
         self._create_event(99999, "add", "2026-01-15T10:00:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
-        self.assertEqual(JobSelectionAggregate.objects.count(), 2)
-        self.assertEqual(
-            JobSelectionAggregate.objects.get(job_id=99999).selection_count, 1
-        )
+        mock_push.assert_called_once()
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any("job=unknown_99999" in l for l in lines))
 
     def test_only_removes_count(self) -> None:
         """Test aggregation with only remove actions gives negative count"""
         self._create_event(self.job1.id, "remove", "2026-01-15T10:00:00")
         self._create_event(self.job1.id, "remove", "2026-01-15T11:00:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = JobSelectionAggregate.objects.get(job_id=self.job1.id)
-        self.assertEqual(agg.selection_count, -2)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("selection_count=-2i", line)
 
 
 class SessionAggregateTests(TestCase):
@@ -134,134 +153,165 @@ class SessionAggregateTests(TestCase):
             self._create_session_event(session_id, "session_end", end),
         )
 
-    def test_valid_session_creates_aggregate(self) -> None:
-        """A single valid session pair creates a SessionAggregate"""
+    def test_valid_session_creates_line(self) -> None:
+        """A single valid session pair pushes one InfluxDB line"""
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:00:30")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
         self.assertEqual(AnalyticsEvent.objects.count(), 2)
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 1)
-        self.assertEqual(agg.total_duration_seconds, 30)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_sessions", line)
+        self.assertIn("total_sessions=1i", line)
+        self.assertIn("total_duration_seconds=30i", line)
 
     def test_multiple_sessions_same_day(self) -> None:
-        """Multiple valid sessions on the same day are aggregated together"""
+        """Multiple valid sessions on the same day are aggregated into one line"""
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:00:30")
         self._create_session("s2", "2026-01-15T11:00:00", "2026-01-15T11:10:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 2)
-        self.assertEqual(agg.total_duration_seconds, 630)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("total_sessions=2i", line)
+        self.assertIn("total_duration_seconds=630i", line)
 
     def test_sessions_on_different_days(self) -> None:
-        """Sessions on different days create separate aggregates"""
+        """Sessions on different days create separate lines"""
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:02:00")
         self._create_session("s2", "2026-01-16T10:00:00", "2026-01-16T10:02:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(SessionAggregate.objects.count(), 2)
+        mock_push.assert_called_once()
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
 
-    def test_increments_existing_aggregate(self) -> None:
-        """Running the command twice increments existing aggregates"""
+    def test_second_run_pushes_only_new_sessions(self) -> None:
+        """Running the command twice pushes new sessions in each run separately"""
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:00:30")
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_called_once()
 
         self._create_session("s2", "2026-01-15T11:00:00", "2026-01-15T11:00:30")
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 2)
-        self.assertEqual(agg.total_duration_seconds, 60)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("total_sessions=1i", line)
+        self.assertIn("total_duration_seconds=30i", line)
 
-    def test_does_not_double_count_on_rerun(self) -> None:
-        """Re-running on already-aggregated data does not double count"""
+    def test_does_not_push_on_rerun_with_no_new_events(self) -> None:
+        """Re-running with no new events does not push"""
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:00:30")
-        call_command("aggregate_analytics")
-        call_command("aggregate_analytics")
+        with self.captureOnCommitCallbacks(execute=True):
+            call_command("aggregate_analytics")
 
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 1)
-        self.assertEqual(agg.total_duration_seconds, 30)
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        mock_push.assert_not_called()
 
     def test_pairs_session_across_runs(self) -> None:
         """A session_start in run N and session_end in run N+1 still get paired"""
         self._create_session_event("s1", "session_start", "2026-01-15T10:00:00")
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        # Start arrived but no matching end yet -> no aggregate, event left unmarked
-        self.assertEqual(SessionAggregate.objects.count(), 0)
+        # Start arrived but no matching end yet -> no push, event left unmarked
+        mock_push.assert_not_called()
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 1
         )
 
         self._create_session_event("s1", "session_end", "2026-01-15T10:00:30")
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 1)
-        self.assertEqual(agg.total_duration_seconds, 30)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("total_sessions=1i", line)
+        self.assertIn("total_duration_seconds=30i", line)
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
 
     def test_ignores_start_without_end(self) -> None:
-        """A session_start without a matching session_end produces no aggregate"""
+        """A session_start without a matching session_end produces no push"""
         self._create_session_event("s1", "session_start", "2026-01-15T10:00:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(SessionAggregate.objects.count(), 0)
-        # Unpaired start is left unmarked so a later run can still pair it
+        mock_push.assert_not_called()
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 1
         )
 
     def test_ignores_end_without_start(self) -> None:
-        """A session_end without a matching session_start produces no aggregate"""
+        """A session_end without a matching session_start produces no push"""
         self._create_session_event("s1", "session_end", "2026-01-15T10:05:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(SessionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 1
         )
 
     def test_ignores_duplicate_start_events(self) -> None:
-        """A session_id with two start events and one end event produces no aggregate"""
+        """A session_id with two start events and one end event produces no push"""
         self._create_session_event("s1", "session_start", "2026-01-15T10:00:00")
         self._create_session_event("s1", "session_start", "2026-01-15T10:01:00")
         self._create_session_event("s1", "session_end", "2026-01-15T10:05:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(SessionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 3
         )
 
     def test_ignores_duplicate_end_events(self) -> None:
-        """A session_id with one start event and two end events produces no aggregate"""
+        """A session_id with one start event and two end events produces no push"""
         self._create_session_event("s1", "session_start", "2026-01-15T10:00:00")
         self._create_session_event("s1", "session_end", "2026-01-15T10:05:00")
         self._create_session_event("s1", "session_end", "2026-01-15T10:06:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(SessionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 3
         )
 
     def test_invalid_sessions_dont_affect_valid_ones(self) -> None:
-        """Invalid sessions are discarded but valid ones are still aggregated"""
+        """Invalid sessions are discarded but valid ones are still pushed"""
         # Valid session
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:02:00")
         # Invalid: start without end
@@ -271,11 +321,14 @@ class SessionAggregateTests(TestCase):
         self._create_session_event("s3", "session_start", "2026-01-15T12:01:00")
         self._create_session_event("s3", "session_end", "2026-01-15T12:05:00")
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 1)
-        self.assertEqual(agg.total_duration_seconds, 120)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("total_sessions=1i", line)
+        self.assertIn("total_duration_seconds=120i", line)
         # The two valid pair events are marked, the four invalid ones remain unmarked
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 4
@@ -294,11 +347,16 @@ class SessionAggregateTests(TestCase):
             "s6", "2026-01-15T15:00:00", "2026-01-15T15:31:00"
         )  # 1860s
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = SessionAggregate.objects.get(date="2026-01-15")
-        self.assertEqual(agg.total_sessions, 6)
-        self.assertEqual(agg.total_duration_seconds, 60 + 61 + 300 + 301 + 1800 + 1860)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("total_sessions=6i", line)
+        self.assertIn(
+            f"total_duration_seconds={60 + 61 + 300 + 301 + 1800 + 1860}i", line
+        )
 
 
 class ModuleDurationAggregateTests(TestCase):
@@ -345,138 +403,157 @@ class ModuleDurationAggregateTests(TestCase):
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
         self._create_standard_event("word_choice", 10, "2026-01-15T11:00:00", 90)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
-        agg = ModuleDurationAggregate.objects.get(
-            exercise_type="word_choice", unit_id=10, date="2026-01-15"
-        )
-        self.assertEqual(agg.total_sessions, 2)
-        self.assertEqual(agg.total_duration_seconds, 150)
-        self.assertIsNone(agg.job_id)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_module_duration", line)
+        self.assertIn("unit_id=10", line)
+        self.assertIn("exercise_type=word_choice", line)
+        self.assertIn("total_sessions=2i", line)
+        self.assertIn("total_duration_seconds=150i", line)
 
     def test_aggregates_multiple_days(self) -> None:
-        """Test that events on different days create separate aggregates"""
+        """Test that events on different days create separate lines"""
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
         self._create_standard_event("word_choice", 10, "2026-01-16T10:00:00", 60)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 2)
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
 
     def test_aggregates_different_exercise_types(self) -> None:
-        """Test that different exercise types create separate aggregates"""
+        """Test that different exercise types create separate lines"""
         self._create_standard_event("word_list", 10, "2026-01-15T10:00:00", 60)
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 2)
-        self.assertEqual(
-            ModuleDurationAggregate.objects.get(
-                exercise_type="word_list", unit_id=10
-            ).total_sessions,
-            1,
-        )
-        self.assertEqual(
-            ModuleDurationAggregate.objects.get(
-                exercise_type="word_choice", unit_id=10
-            ).total_sessions,
-            1,
-        )
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any("exercise_type=word_list" in l for l in lines))
+        self.assertTrue(any("exercise_type=word_choice" in l for l in lines))
 
     def test_aggregates_different_units(self) -> None:
-        """Test that different unit IDs create separate aggregates"""
+        """Test that different unit IDs create separate lines"""
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
         self._create_standard_event("word_choice", 20, "2026-01-15T10:00:00", 90)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 2)
-        self.assertEqual(
-            ModuleDurationAggregate.objects.get(unit_id=10).total_duration_seconds, 60
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(
+            any("unit_id=10" in l and "total_duration_seconds=60i" in l for l in lines)
         )
-        self.assertEqual(
-            ModuleDurationAggregate.objects.get(unit_id=20).total_duration_seconds, 90
+        self.assertTrue(
+            any("unit_id=20" in l and "total_duration_seconds=90i" in l for l in lines)
         )
 
-    def test_increments_existing_aggregate(self) -> None:
-        """Test that running twice updates existing aggregates"""
+    def test_second_run_pushes_only_new_events(self) -> None:
+        """Test that running twice pushes new events in each run separately"""
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
-        call_command("aggregate_analytics")
+        with self.captureOnCommitCallbacks(execute=True):
+            call_command("aggregate_analytics")
 
         self._create_standard_event("word_choice", 10, "2026-01-15T14:00:00", 40)
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = ModuleDurationAggregate.objects.get(
-            exercise_type="word_choice", unit_id=10, date="2026-01-15"
-        )
-        self.assertEqual(agg.total_sessions, 2)
-        self.assertEqual(agg.total_duration_seconds, 100)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("total_sessions=1i", line)
+        self.assertIn("total_duration_seconds=40i", line)
 
     def test_no_events(self) -> None:
-        """Test that running with no events does nothing"""
-        call_command("aggregate_analytics")
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 0)
+        """Test that running with no events does not push anything"""
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_not_called()
 
     def test_aggregates_training_exercise(self) -> None:
         """Test aggregation of training module duration events"""
         self._create_training_event("image", 5, "2026-01-15T10:00:00", 120)
         self._create_training_event("image", 5, "2026-01-15T11:00:00", 80)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
-        agg = ModuleDurationAggregate.objects.get(
-            exercise_type="image", job_id=5, date="2026-01-15"
-        )
-        self.assertEqual(agg.total_sessions, 2)
-        self.assertEqual(agg.total_duration_seconds, 200)
-        self.assertIsNone(agg.unit_id)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("job=unknown_5", line)
+        self.assertIn("exercise_type=image", line)
+        self.assertIn("total_sessions=2i", line)
+        self.assertIn("total_duration_seconds=200i", line)
 
     def test_aggregates_different_training_types(self) -> None:
-        """Test that different training exercise types create separate aggregates"""
+        """Test that different training exercise types create separate lines"""
         self._create_training_event("image", 5, "2026-01-15T10:00:00", 60)
         self._create_training_event("sentence", 5, "2026-01-15T10:00:00", 60)
         self._create_training_event("speech", 5, "2026-01-15T10:00:00", 60)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 3)
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 3)
 
     def test_aggregates_different_jobs(self) -> None:
-        """Test that different job IDs create separate training aggregates"""
+        """Test that different job IDs create separate training lines"""
         self._create_training_event("image", 5, "2026-01-15T10:00:00", 60)
         self._create_training_event("image", 6, "2026-01-15T10:00:00", 90)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 2)
-        self.assertEqual(
-            ModuleDurationAggregate.objects.get(job_id=5).total_duration_seconds, 60
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(
+            any(
+                "job=unknown_5" in l and "total_duration_seconds=60i" in l
+                for l in lines
+            )
         )
-        self.assertEqual(
-            ModuleDurationAggregate.objects.get(job_id=6).total_duration_seconds, 90
+        self.assertTrue(
+            any(
+                "job=unknown_6" in l and "total_duration_seconds=90i" in l
+                for l in lines
+            )
         )
 
-    def test_standard_and_training_create_separate_aggregates(self) -> None:
-        """Test that standard and training exercises never share an aggregate"""
+    def test_standard_and_training_create_separate_lines(self) -> None:
+        """Test that standard and training exercises produce separate lines"""
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00", 60)
         self._create_training_event("image", 5, "2026-01-15T10:00:00", 60)
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(ModuleDurationAggregate.objects.count(), 2)
-        standard_agg = ModuleDurationAggregate.objects.get(exercise_type="word_choice")
-        self.assertEqual(standard_agg.unit_id, 10)
-        self.assertIsNone(standard_agg.job_id)
-        training_agg = ModuleDurationAggregate.objects.get(exercise_type="image")
-        self.assertIsNone(training_agg.unit_id)
-        self.assertEqual(training_agg.job_id, 5)
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any("unit_id=10" in l for l in lines))
+        self.assertTrue(any("job=unknown_5" in l for l in lines))
 
 
 class DropoutAggregateTests(TestCase):
@@ -551,19 +628,24 @@ class DropoutAggregateTests(TestCase):
             timestamp="2026-01-15T11:00:00",
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
-        agg = DropoutAggregate.objects.get(
-            exercise_type="word_choice", unit_id=10, dropout_position=3, total_items=10
-        )
-        self.assertEqual(agg.dropout_count, 2)
-        self.assertIsNone(agg.job_id)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_dropout", line)
+        self.assertIn("unit_id=10", line)
+        self.assertIn("exercise_type=word_choice", line)
+        self.assertIn("position=3", line)
+        self.assertIn("total=10", line)
+        self.assertIn("dropout_count=2i", line)
 
     def test_aggregates_multiple_days(self) -> None:
-        """Test that events on different days create separate aggregates"""
+        """Test that events on different days create separate lines"""
         self._create_standard_event(
             exercise_type="word_choice",
             unit_id=10,
@@ -579,12 +661,15 @@ class DropoutAggregateTests(TestCase):
             timestamp="2026-01-16T10:00:00",
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 2)
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
 
     def test_aggregates_different_positions(self) -> None:
-        """Test that different dropout positions create separate aggregates"""
+        """Test that different dropout positions create separate lines"""
         self._create_standard_event(
             exercise_type="word_choice",
             unit_id=10,
@@ -600,18 +685,21 @@ class DropoutAggregateTests(TestCase):
             timestamp="2026-01-15T10:00:00",
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 2)
-        self.assertEqual(
-            DropoutAggregate.objects.get(dropout_position=2).dropout_count, 1
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(
+            any("position=2" in l and "dropout_count=1i" in l for l in lines)
         )
-        self.assertEqual(
-            DropoutAggregate.objects.get(dropout_position=5).dropout_count, 1
+        self.assertTrue(
+            any("position=5" in l and "dropout_count=1i" in l for l in lines)
         )
 
     def test_aggregates_different_exercise_types(self) -> None:
-        """Test that different exercise types create separate aggregates"""
+        """Test that different exercise types create separate lines"""
         self._create_standard_event(
             exercise_type="word_list",
             unit_id=10,
@@ -627,12 +715,15 @@ class DropoutAggregateTests(TestCase):
             timestamp="2026-01-15T10:00:00",
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 2)
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
 
     def test_aggregates_training_events_grouped(self) -> None:
-        """Test that training events with the same job_id are grouped into one aggregate"""
+        """Test that training events with the same job_id are grouped into one line"""
         self._create_training_event(
             exercise_type="image",
             job_id=5,
@@ -650,16 +741,17 @@ class DropoutAggregateTests(TestCase):
             vocabulary_item_id=99,
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 1)
-        agg = DropoutAggregate.objects.get()
-        self.assertIsNone(agg.unit_id)
-        self.assertEqual(agg.job_id, 5)
-        self.assertEqual(agg.dropout_count, 2)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("job=unknown_5", line)
+        self.assertIn("dropout_count=2i", line)
 
     def test_training_and_standard_events_separate(self) -> None:
-        """Test that training events (job_id) and standard events (unit_id) create separate aggregates"""
+        """Test that training events (job) and standard events (unit_id) create separate lines"""
         self._create_training_event(
             exercise_type="image",
             job_id=5,
@@ -675,12 +767,15 @@ class DropoutAggregateTests(TestCase):
             timestamp="2026-01-15T10:00:00",
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 2)
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
 
-    def test_increments_existing_aggregate(self) -> None:
-        """Test that running twice increments existing aggregates"""
+    def test_second_run_pushes_only_new_events(self) -> None:
+        """Test that running twice pushes new events in each run separately"""
         self._create_standard_event(
             exercise_type="word_choice",
             unit_id=10,
@@ -688,7 +783,8 @@ class DropoutAggregateTests(TestCase):
             total=10,
             timestamp="2026-01-15T10:00:00",
         )
-        call_command("aggregate_analytics")
+        with self.captureOnCommitCallbacks(execute=True):
+            call_command("aggregate_analytics")
 
         self._create_standard_event(
             exercise_type="word_choice",
@@ -697,20 +793,20 @@ class DropoutAggregateTests(TestCase):
             total=10,
             timestamp="2026-01-15T14:00:00",
         )
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        agg = DropoutAggregate.objects.get(
-            exercise_type="word_choice",
-            unit_id=10,
-            dropout_position=3,
-            total_items=10,
-        )
-        self.assertEqual(agg.dropout_count, 2)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("dropout_count=1i", line)
 
     def test_no_events(self) -> None:
-        """Test that running with no events does nothing"""
-        call_command("aggregate_analytics")
-        self.assertEqual(DropoutAggregate.objects.count(), 0)
+        """Test that running with no events does not push anything"""
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+        mock_push.assert_not_called()
 
     def test_aggregates_training_dropout(self) -> None:
         """Test aggregation of dropout events for training exercises"""
@@ -731,20 +827,23 @@ class DropoutAggregateTests(TestCase):
             vocabulary_item_id=99,
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self.assertEqual(
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
-        agg = DropoutAggregate.objects.get(
-            exercise_type="image", job_id=5, dropout_position=2, total_items=8
-        )
-        self.assertEqual(agg.dropout_count, 2)
-        self.assertIsNone(agg.unit_id)
-        self.assertEqual(agg.vocabulary_item_id, 99)
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("job=unknown_5", line)
+        self.assertIn("exercise_type=image", line)
+        self.assertIn("position=2", line)
+        self.assertIn("total=8", line)
+        self.assertIn("vocab_id=99", line)
+        self.assertIn("dropout_count=2i", line)
 
-    def test_different_vocabulary_items_create_separate_aggregates(self) -> None:
-        """Test that dropouts on different vocabulary items create separate aggregates"""
+    def test_different_vocabulary_items_create_separate_lines(self) -> None:
+        """Test that dropouts on different vocabulary items create separate lines"""
         self._create_training_event(
             exercise_type="image",
             job_id=5,
@@ -762,18 +861,21 @@ class DropoutAggregateTests(TestCase):
             vocabulary_item_id=20,
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 2)
-        self.assertEqual(
-            DropoutAggregate.objects.get(vocabulary_item_id=10).dropout_count, 1
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(
+            any("vocab_id=10" in l and "dropout_count=1i" in l for l in lines)
         )
-        self.assertEqual(
-            DropoutAggregate.objects.get(vocabulary_item_id=20).dropout_count, 1
+        self.assertTrue(
+            any("vocab_id=20" in l and "dropout_count=1i" in l for l in lines)
         )
 
     def test_standard_and_training_dropout_separate(self) -> None:
-        """Test that standard and training dropouts never share an aggregate"""
+        """Test that standard and training dropouts produce separate lines"""
         self._create_standard_event(
             exercise_type="word_choice",
             unit_id=10,
@@ -790,17 +892,19 @@ class DropoutAggregateTests(TestCase):
             vocabulary_item_id=99,
         )
 
-        call_command("aggregate_analytics")
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
-        self.assertEqual(DropoutAggregate.objects.count(), 2)
-        self.assertIsNone(
-            DropoutAggregate.objects.get(exercise_type="word_choice").vocabulary_item_id
-        )
+        lines = mock_push.call_args[0][0]
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(any("unit_id=10" in l for l in lines))
+        self.assertTrue(any("job=unknown_5" in l for l in lines))
 
 
 class UnprocessedEventCleanupTests(TestCase):
     """
-    Tests for deletion of events not covered by batch aggregators (task 3 of #666).
+    Tests for deletion of events not covered by batch aggregators.
     exercise_repetition events are aggregated inline on receipt and must be cleaned
     up by the management command after RETENTION_DAYS days.
     """

--- a/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
+++ b/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
@@ -47,7 +47,8 @@ class JobSelectionAggregateTests(TestCase):
         mock_push.assert_called_once()
         [line] = mock_push.call_args[0][0]
         self.assertIn("lunes_job_selection", line)
-        self.assertIn(r"job=Job\ 1", line)
+        self.assertIn(f"job_id={self.job1.id}", line)
+        self.assertIn('job_name="Job 1"', line)
         self.assertIn("selection_count=1i", line)
 
     def test_aggregates_multiple_days(self) -> None:
@@ -75,8 +76,8 @@ class JobSelectionAggregateTests(TestCase):
         mock_push.assert_called_once()
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
-        self.assertTrue(any(r"job=Job\ 1" in l for l in lines))
-        self.assertTrue(any(r"job=Job\ 2" in l for l in lines))
+        self.assertTrue(any(f"job_id={self.job1.id}" in l for l in lines))
+        self.assertTrue(any(f"job_id={self.job2.id}" in l for l in lines))
         self.assertTrue(all("selection_count=1i" in l for l in lines))
 
     def test_second_run_pushes_only_new_events(self) -> None:
@@ -117,7 +118,8 @@ class JobSelectionAggregateTests(TestCase):
         mock_push.assert_called_once()
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
-        self.assertTrue(any("job=unknown_99999" in l for l in lines))
+        self.assertTrue(any("job_id=99999" in l for l in lines))
+        self.assertTrue(any('job_name="unknown_99999"' in l for l in lines))
 
     def test_only_removes_count(self) -> None:
         """Test aggregation with only remove actions gives negative count"""
@@ -424,7 +426,8 @@ class ModuleDurationAggregateTests(TestCase):
         mock_push.assert_called_once()
         [line] = mock_push.call_args[0][0]
         self.assertIn("lunes_module_duration", line)
-        self.assertIn(r"unit=Unit\ 1", line)
+        self.assertIn(f"unit_id={self.unit1.id}", line)
+        self.assertIn('unit_name="Unit 1"', line)
         self.assertIn("exercise_type=word_choice", line)
         self.assertIn("total_sessions=2i", line)
         self.assertIn("total_duration_seconds=150i", line)
@@ -480,13 +483,13 @@ class ModuleDurationAggregateTests(TestCase):
         self.assertEqual(len(lines), 2)
         self.assertTrue(
             any(
-                r"unit=Unit\ 1" in l and "total_duration_seconds=60i" in l
+                f"unit_id={self.unit1.id}" in l and "total_duration_seconds=60i" in l
                 for l in lines
             )
         )
         self.assertTrue(
             any(
-                r"unit=Unit\ 2" in l and "total_duration_seconds=90i" in l
+                f"unit_id={self.unit2.id}" in l and "total_duration_seconds=90i" in l
                 for l in lines
             )
         )
@@ -532,7 +535,8 @@ class ModuleDurationAggregateTests(TestCase):
         )
         mock_push.assert_called_once()
         [line] = mock_push.call_args[0][0]
-        self.assertIn("job=unknown_5", line)
+        self.assertIn("job_id=5", line)
+        self.assertIn('job_name="unknown_5"', line)
         self.assertIn("exercise_type=image", line)
         self.assertIn("total_sessions=2i", line)
         self.assertIn("total_duration_seconds=200i", line)
@@ -562,16 +566,10 @@ class ModuleDurationAggregateTests(TestCase):
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
         self.assertTrue(
-            any(
-                "job=unknown_5" in l and "total_duration_seconds=60i" in l
-                for l in lines
-            )
+            any("job_id=5" in l and "total_duration_seconds=60i" in l for l in lines)
         )
         self.assertTrue(
-            any(
-                "job=unknown_6" in l and "total_duration_seconds=90i" in l
-                for l in lines
-            )
+            any("job_id=6" in l and "total_duration_seconds=90i" in l for l in lines)
         )
 
     def test_standard_and_training_create_separate_lines(self) -> None:
@@ -587,8 +585,8 @@ class ModuleDurationAggregateTests(TestCase):
 
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
-        self.assertTrue(any(r"unit=Unit\ 1" in l for l in lines))
-        self.assertTrue(any("job=unknown_5" in l for l in lines))
+        self.assertTrue(any(f"unit_id={self.unit1.id}" in l for l in lines))
+        self.assertTrue(any("job_id=5" in l for l in lines))
 
 
 class DropoutAggregateTests(TestCase):
@@ -782,7 +780,7 @@ class DropoutAggregateTests(TestCase):
 
         mock_push.assert_called_once()
         [line] = mock_push.call_args[0][0]
-        self.assertIn("job=unknown_5", line)
+        self.assertIn("job_id=5", line)
         self.assertIn("dropout_count=2i", line)
 
     def test_training_and_standard_events_separate(self) -> None:
@@ -870,7 +868,8 @@ class DropoutAggregateTests(TestCase):
             AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
         )
         [line] = mock_push.call_args[0][0]
-        self.assertIn("job=unknown_5", line)
+        self.assertIn("job_id=5", line)
+        self.assertIn('job_name="unknown_5"', line)
         self.assertIn("exercise_type=image", line)
         self.assertIn("position=2", line)
         self.assertIn("total=8", line)
@@ -930,7 +929,7 @@ class DropoutAggregateTests(TestCase):
         lines = mock_push.call_args[0][0]
         self.assertEqual(len(lines), 2)
         self.assertTrue(any("unit_id=10" in l for l in lines))
-        self.assertTrue(any("job=unknown_5" in l for l in lines))
+        self.assertTrue(any("job_id=5" in l for l in lines))
 
 
 class ExerciseRepetitionAggregateTests(TestCase):
@@ -1049,7 +1048,8 @@ class ExerciseRepetitionAggregateTests(TestCase):
         mock_push.assert_called_once()
         [line] = mock_push.call_args[0][0]
         self.assertIn("lunes_exercise_repetition", line)
-        self.assertIn("job=Test\\ Job", line)
+        self.assertIn(f"job_id={self.job.id}", line)
+        self.assertIn('job_name="Test Job"', line)
         self.assertIn("exercise_type=image", line)
         self.assertIn("repetitions_per_session=2", line)
         self.assertIn("session_count=1i", line)

--- a/lunes_cms/analytics/tests/models/exercise_repetition_event_test.py
+++ b/lunes_cms/analytics/tests/models/exercise_repetition_event_test.py
@@ -1,9 +1,12 @@
 from typing import Any
+from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework.test import APIClient, APITestCase
 
-from lunes_cms.analytics.models import AnalyticsEvent, ExerciseRepetitionAggregate
+from lunes_cms.analytics.models import AnalyticsEvent
+
+PATCH_PUSH = "lunes_cms.analytics.api.views.push_lines"
 
 
 class ExerciseRepetitionEventTests(APITestCase):
@@ -44,9 +47,10 @@ class ExerciseRepetitionEventTests(APITestCase):
     def test_create_valid_standard_event(self) -> None:
         """Test creating a valid standard exercise_repetition event"""
         self.assertEqual(AnalyticsEvent.objects.count(), 0)
-        response = self.client.post(
-            self.url, data=self.valid_standard_payload, format="json"
-        )
+        with patch(PATCH_PUSH):
+            response = self.client.post(
+                self.url, data=self.valid_standard_payload, format="json"
+            )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AnalyticsEvent.objects.count(), 1)
         event = AnalyticsEvent.objects.first()
@@ -57,33 +61,38 @@ class ExerciseRepetitionEventTests(APITestCase):
         self.assertEqual(event.payload["session_id"], "session-1")
 
     def test_creates_standard_aggregate_immediately(self) -> None:
-        """Test that posting a standard event immediately creates an aggregate"""
-        response = self.client.post(
-            self.url, data=self.valid_standard_payload, format="json"
-        )
+        """Test that posting a standard event immediately pushes to InfluxDB"""
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(
+                self.url, data=self.valid_standard_payload, format="json"
+            )
         self.assertEqual(response.status_code, 201)
-        aggregate = ExerciseRepetitionAggregate.objects.get(
-            unit_id=1, job_id=None, exercise_type="word_choice", session_id="session-1"
-        )
-        self.assertEqual(aggregate.repetition_count, 1)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_exercise_repetition", line)
+        self.assertIn("unit_id=1", line)
+        self.assertIn("exercise_type=word_choice", line)
+        self.assertIn("session_id=session-1", line)
+        self.assertIn("repetition_count=1i", line)
 
-    def test_repeated_standard_events_increment_repetition_count(self) -> None:
-        """Test that multiple standard events for the same key increment the count"""
-        self.client.post(self.url, data=self.valid_standard_payload, format="json")
-        self.client.post(self.url, data=self.valid_standard_payload, format="json")
-        self.client.post(self.url, data=self.valid_standard_payload, format="json")
+    def test_repeated_standard_events_each_push_once(self) -> None:
+        """Test that multiple standard events for the same key each push repetition_count=1i"""
+        with patch(PATCH_PUSH) as mock_push:
+            self.client.post(self.url, data=self.valid_standard_payload, format="json")
+            self.client.post(self.url, data=self.valid_standard_payload, format="json")
+            self.client.post(self.url, data=self.valid_standard_payload, format="json")
 
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 1)
-        aggregate = ExerciseRepetitionAggregate.objects.get(
-            unit_id=1, exercise_type="word_choice", session_id="session-1"
-        )
-        self.assertEqual(aggregate.repetition_count, 3)
+        self.assertEqual(mock_push.call_count, 3)
+        for call in mock_push.call_args_list:
+            [line] = call[0][0]
+            self.assertIn("repetition_count=1i", line)
 
     def test_create_valid_training_event(self) -> None:
         """Test creating a valid training exercise_repetition event"""
-        response = self.client.post(
-            self.url, data=self.valid_training_payload, format="json"
-        )
+        with patch(PATCH_PUSH):
+            response = self.client.post(
+                self.url, data=self.valid_training_payload, format="json"
+            )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AnalyticsEvent.objects.count(), 1)
         event = AnalyticsEvent.objects.first()
@@ -92,37 +101,44 @@ class ExerciseRepetitionEventTests(APITestCase):
         self.assertEqual(event.payload["exercise_key"]["exercise_type"], "image")
 
     def test_creates_training_aggregate_immediately(self) -> None:
-        """Test that posting a training event immediately creates an aggregate"""
-        response = self.client.post(
-            self.url, data=self.valid_training_payload, format="json"
-        )
+        """Test that posting a training event immediately pushes to InfluxDB"""
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(
+                self.url, data=self.valid_training_payload, format="json"
+            )
         self.assertEqual(response.status_code, 201)
-        aggregate = ExerciseRepetitionAggregate.objects.get(
-            unit_id=None, job_id=42, exercise_type="image", session_id="session-1"
-        )
-        self.assertEqual(aggregate.repetition_count, 1)
+        mock_push.assert_called_once()
+        [line] = mock_push.call_args[0][0]
+        self.assertIn("lunes_exercise_repetition", line)
+        self.assertIn("job=unknown_42", line)
+        self.assertIn("exercise_type=image", line)
+        self.assertIn("session_id=session-1", line)
+        self.assertIn("repetition_count=1i", line)
 
-    def test_repeated_training_events_increment_repetition_count(self) -> None:
-        """Test that multiple training events for the same key increment the count"""
-        self.client.post(self.url, data=self.valid_training_payload, format="json")
-        self.client.post(self.url, data=self.valid_training_payload, format="json")
+    def test_repeated_training_events_each_push_once(self) -> None:
+        """Test that multiple training events for the same key each push repetition_count=1i"""
+        with patch(PATCH_PUSH) as mock_push:
+            self.client.post(self.url, data=self.valid_training_payload, format="json")
+            self.client.post(self.url, data=self.valid_training_payload, format="json")
 
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 1)
-        aggregate = ExerciseRepetitionAggregate.objects.get(
-            job_id=42, exercise_type="image", session_id="session-1"
-        )
-        self.assertEqual(aggregate.repetition_count, 2)
+        self.assertEqual(mock_push.call_count, 2)
+        for call in mock_push.call_args_list:
+            [line] = call[0][0]
+            self.assertIn("repetition_count=1i", line)
 
-    def test_standard_and_training_create_separate_aggregates(self) -> None:
-        """Test that standard and training events create separate aggregates"""
-        self.client.post(self.url, data=self.valid_standard_payload, format="json")
-        self.client.post(self.url, data=self.valid_training_payload, format="json")
+    def test_standard_and_training_push_different_tags(self) -> None:
+        """Test that standard and training events push with different dimension tags"""
+        with patch(PATCH_PUSH) as mock_push:
+            self.client.post(self.url, data=self.valid_standard_payload, format="json")
+            self.client.post(self.url, data=self.valid_training_payload, format="json")
 
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 2)
+        self.assertEqual(mock_push.call_count, 2)
+        lines = [call[0][0][0] for call in mock_push.call_args_list]
+        self.assertTrue(any("unit_id=1" in l for l in lines))
+        self.assertTrue(any("job=unknown_42" in l for l in lines))
 
-    def test_different_sessions_create_separate_aggregates(self) -> None:
-        """Test that events with different session_ids create separate aggregates"""
-        self.client.post(self.url, data=self.valid_standard_payload, format="json")
+    def test_different_sessions_push_different_tags(self) -> None:
+        """Test that events with different session_ids push with different session tags"""
         payload_session2 = {
             **self.valid_standard_payload,
             "payload": {
@@ -130,13 +146,17 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-2",
             },
         }
-        self.client.post(self.url, data=payload_session2, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            self.client.post(self.url, data=self.valid_standard_payload, format="json")
+            self.client.post(self.url, data=payload_session2, format="json")
 
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 2)
+        self.assertEqual(mock_push.call_count, 2)
+        lines = [call[0][0][0] for call in mock_push.call_args_list]
+        self.assertTrue(any("session_id=session-1" in l for l in lines))
+        self.assertTrue(any("session_id=session-2" in l for l in lines))
 
-    def test_different_units_create_separate_aggregates(self) -> None:
-        """Test that different unit_ids for the same exercise/session create separate aggregates"""
-        self.client.post(self.url, data=self.valid_standard_payload, format="json")
+    def test_different_units_push_different_tags(self) -> None:
+        """Test that different unit_ids push with different unit tags"""
         payload_unit2 = {
             **self.valid_standard_payload,
             "payload": {
@@ -147,9 +167,14 @@ class ExerciseRepetitionEventTests(APITestCase):
                 },
             },
         }
-        self.client.post(self.url, data=payload_unit2, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            self.client.post(self.url, data=self.valid_standard_payload, format="json")
+            self.client.post(self.url, data=payload_unit2, format="json")
 
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 2)
+        self.assertEqual(mock_push.call_count, 2)
+        lines = [call[0][0][0] for call in mock_push.call_args_list]
+        self.assertTrue(any("unit_id=1" in l for l in lines))
+        self.assertTrue(any("unit_id=2" in l for l in lines))
 
     def test_missing_exercise_key(self) -> None:
         """Test that a missing exercise_key is rejected"""
@@ -157,9 +182,10 @@ class ExerciseRepetitionEventTests(APITestCase):
             **self.valid_standard_payload,
             "payload": {"session_id": "session-1"},
         }
-        response = self.client.post(self.url, data=payload, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
 
     def test_invalid_exercise_key_type(self) -> None:
         """Test that an invalid exercise_key type is rejected"""
@@ -174,9 +200,10 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-1",
             },
         }
-        response = self.client.post(self.url, data=payload, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
 
     def test_missing_unit_id_for_standard_key(self) -> None:
         """Test that a standard exercise_key without unit_id is rejected"""
@@ -187,9 +214,10 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-1",
             },
         }
-        response = self.client.post(self.url, data=payload, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
 
     def test_missing_job_id_for_training_key(self) -> None:
         """Test that a training exercise_key without job_id is rejected"""
@@ -200,9 +228,10 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-1",
             },
         }
-        response = self.client.post(self.url, data=payload, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
 
     def test_missing_session_id(self) -> None:
         """Test that a missing session_id is rejected"""
@@ -216,9 +245,10 @@ class ExerciseRepetitionEventTests(APITestCase):
                 },
             },
         }
-        response = self.client.post(self.url, data=payload, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()
 
     def test_missing_payload(self) -> None:
         """Test that a missing payload is rejected"""
@@ -227,6 +257,7 @@ class ExerciseRepetitionEventTests(APITestCase):
             for key, value in self.valid_standard_payload.items()
             if key != "payload"
         }
-        response = self.client.post(self.url, data=payload, format="json")
+        with patch(PATCH_PUSH) as mock_push:
+            response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(ExerciseRepetitionAggregate.objects.count(), 0)
+        mock_push.assert_not_called()

--- a/lunes_cms/analytics/tests/models/exercise_repetition_event_test.py
+++ b/lunes_cms/analytics/tests/models/exercise_repetition_event_test.py
@@ -1,12 +1,9 @@
 from typing import Any
-from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework.test import APIClient, APITestCase
 
 from lunes_cms.analytics.models import AnalyticsEvent
-
-PATCH_PUSH = "lunes_cms.analytics.api.views.push_lines"
 
 
 class ExerciseRepetitionEventTests(APITestCase):
@@ -47,10 +44,9 @@ class ExerciseRepetitionEventTests(APITestCase):
     def test_create_valid_standard_event(self) -> None:
         """Test creating a valid standard exercise_repetition event"""
         self.assertEqual(AnalyticsEvent.objects.count(), 0)
-        with patch(PATCH_PUSH):
-            response = self.client.post(
-                self.url, data=self.valid_standard_payload, format="json"
-            )
+        response = self.client.post(
+            self.url, data=self.valid_standard_payload, format="json"
+        )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AnalyticsEvent.objects.count(), 1)
         event = AnalyticsEvent.objects.first()
@@ -60,39 +56,11 @@ class ExerciseRepetitionEventTests(APITestCase):
         self.assertEqual(event.payload["exercise_key"]["exercise_type"], "word_choice")
         self.assertEqual(event.payload["session_id"], "session-1")
 
-    def test_creates_standard_aggregate_immediately(self) -> None:
-        """Test that posting a standard event immediately pushes to InfluxDB"""
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(
-                self.url, data=self.valid_standard_payload, format="json"
-            )
-        self.assertEqual(response.status_code, 201)
-        mock_push.assert_called_once()
-        [line] = mock_push.call_args[0][0]
-        self.assertIn("lunes_exercise_repetition", line)
-        self.assertIn("unit_id=1", line)
-        self.assertIn("exercise_type=word_choice", line)
-        self.assertIn("session_id=session-1", line)
-        self.assertIn("repetition_count=1i", line)
-
-    def test_repeated_standard_events_each_push_once(self) -> None:
-        """Test that multiple standard events for the same key each push repetition_count=1i"""
-        with patch(PATCH_PUSH) as mock_push:
-            self.client.post(self.url, data=self.valid_standard_payload, format="json")
-            self.client.post(self.url, data=self.valid_standard_payload, format="json")
-            self.client.post(self.url, data=self.valid_standard_payload, format="json")
-
-        self.assertEqual(mock_push.call_count, 3)
-        for call in mock_push.call_args_list:
-            [line] = call[0][0]
-            self.assertIn("repetition_count=1i", line)
-
     def test_create_valid_training_event(self) -> None:
         """Test creating a valid training exercise_repetition event"""
-        with patch(PATCH_PUSH):
-            response = self.client.post(
-                self.url, data=self.valid_training_payload, format="json"
-            )
+        response = self.client.post(
+            self.url, data=self.valid_training_payload, format="json"
+        )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(AnalyticsEvent.objects.count(), 1)
         event = AnalyticsEvent.objects.first()
@@ -100,92 +68,15 @@ class ExerciseRepetitionEventTests(APITestCase):
         self.assertEqual(event.payload["exercise_key"]["job_id"], 42)
         self.assertEqual(event.payload["exercise_key"]["exercise_type"], "image")
 
-    def test_creates_training_aggregate_immediately(self) -> None:
-        """Test that posting a training event immediately pushes to InfluxDB"""
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(
-                self.url, data=self.valid_training_payload, format="json"
-            )
-        self.assertEqual(response.status_code, 201)
-        mock_push.assert_called_once()
-        [line] = mock_push.call_args[0][0]
-        self.assertIn("lunes_exercise_repetition", line)
-        self.assertIn("job=unknown_42", line)
-        self.assertIn("exercise_type=image", line)
-        self.assertIn("session_id=session-1", line)
-        self.assertIn("repetition_count=1i", line)
-
-    def test_repeated_training_events_each_push_once(self) -> None:
-        """Test that multiple training events for the same key each push repetition_count=1i"""
-        with patch(PATCH_PUSH) as mock_push:
-            self.client.post(self.url, data=self.valid_training_payload, format="json")
-            self.client.post(self.url, data=self.valid_training_payload, format="json")
-
-        self.assertEqual(mock_push.call_count, 2)
-        for call in mock_push.call_args_list:
-            [line] = call[0][0]
-            self.assertIn("repetition_count=1i", line)
-
-    def test_standard_and_training_push_different_tags(self) -> None:
-        """Test that standard and training events push with different dimension tags"""
-        with patch(PATCH_PUSH) as mock_push:
-            self.client.post(self.url, data=self.valid_standard_payload, format="json")
-            self.client.post(self.url, data=self.valid_training_payload, format="json")
-
-        self.assertEqual(mock_push.call_count, 2)
-        lines = [call[0][0][0] for call in mock_push.call_args_list]
-        self.assertTrue(any("unit_id=1" in l for l in lines))
-        self.assertTrue(any("job=unknown_42" in l for l in lines))
-
-    def test_different_sessions_push_different_tags(self) -> None:
-        """Test that events with different session_ids push with different session tags"""
-        payload_session2 = {
-            **self.valid_standard_payload,
-            "payload": {
-                **self.valid_standard_payload["payload"],
-                "session_id": "session-2",
-            },
-        }
-        with patch(PATCH_PUSH) as mock_push:
-            self.client.post(self.url, data=self.valid_standard_payload, format="json")
-            self.client.post(self.url, data=payload_session2, format="json")
-
-        self.assertEqual(mock_push.call_count, 2)
-        lines = [call[0][0][0] for call in mock_push.call_args_list]
-        self.assertTrue(any("session_id=session-1" in l for l in lines))
-        self.assertTrue(any("session_id=session-2" in l for l in lines))
-
-    def test_different_units_push_different_tags(self) -> None:
-        """Test that different unit_ids push with different unit tags"""
-        payload_unit2 = {
-            **self.valid_standard_payload,
-            "payload": {
-                **self.valid_standard_payload["payload"],
-                "exercise_key": {
-                    **self.valid_standard_payload["payload"]["exercise_key"],
-                    "unit_id": 2,
-                },
-            },
-        }
-        with patch(PATCH_PUSH) as mock_push:
-            self.client.post(self.url, data=self.valid_standard_payload, format="json")
-            self.client.post(self.url, data=payload_unit2, format="json")
-
-        self.assertEqual(mock_push.call_count, 2)
-        lines = [call[0][0][0] for call in mock_push.call_args_list]
-        self.assertTrue(any("unit_id=1" in l for l in lines))
-        self.assertTrue(any("unit_id=2" in l for l in lines))
-
     def test_missing_exercise_key(self) -> None:
         """Test that a missing exercise_key is rejected"""
         payload = {
             **self.valid_standard_payload,
             "payload": {"session_id": "session-1"},
         }
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(self.url, data=payload, format="json")
+        response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        mock_push.assert_not_called()
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
 
     def test_invalid_exercise_key_type(self) -> None:
         """Test that an invalid exercise_key type is rejected"""
@@ -200,10 +91,9 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-1",
             },
         }
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(self.url, data=payload, format="json")
+        response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        mock_push.assert_not_called()
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
 
     def test_missing_unit_id_for_standard_key(self) -> None:
         """Test that a standard exercise_key without unit_id is rejected"""
@@ -214,10 +104,9 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-1",
             },
         }
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(self.url, data=payload, format="json")
+        response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        mock_push.assert_not_called()
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
 
     def test_missing_job_id_for_training_key(self) -> None:
         """Test that a training exercise_key without job_id is rejected"""
@@ -228,10 +117,9 @@ class ExerciseRepetitionEventTests(APITestCase):
                 "session_id": "session-1",
             },
         }
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(self.url, data=payload, format="json")
+        response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        mock_push.assert_not_called()
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
 
     def test_missing_session_id(self) -> None:
         """Test that a missing session_id is rejected"""
@@ -245,10 +133,9 @@ class ExerciseRepetitionEventTests(APITestCase):
                 },
             },
         }
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(self.url, data=payload, format="json")
+        response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        mock_push.assert_not_called()
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)
 
     def test_missing_payload(self) -> None:
         """Test that a missing payload is rejected"""
@@ -257,7 +144,6 @@ class ExerciseRepetitionEventTests(APITestCase):
             for key, value in self.valid_standard_payload.items()
             if key != "payload"
         }
-        with patch(PATCH_PUSH) as mock_push:
-            response = self.client.post(self.url, data=payload, format="json")
+        response = self.client.post(self.url, data=payload, format="json")
         self.assertEqual(response.status_code, 400)
-        mock_push.assert_not_called()
+        self.assertEqual(AnalyticsEvent.objects.count(), 0)

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
+import configparser
 import os
 
 from django.core.exceptions import ImproperlyConfigured
@@ -24,6 +25,14 @@ from .utils import strtobool
 
 #: Build paths inside the project like this: ``os.path.join(BASE_DIR, ...)``
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Load config from /etc/lunes-cms.ini (production) or a local override file.
+# The local override is never committed and takes precedence over the system file.
+_config = configparser.ConfigParser(interpolation=None)
+_config.read(["/etc/lunes-cms.ini", os.path.join(BASE_DIR, "..", "lunes-cms.ini")])
+for _section in _config.sections():
+    for _key, _value in _config.items(_section):
+        os.environ.setdefault(f"LUNES_CMS_{_key.upper()}", _value)
 
 #: How many documents a training sets needs at least to get released
 TRAININGSET_MIN_DOCS = int(os.environ.get("LUNES_CMS_TRAININGSET_MIN_DOCS", 4))
@@ -68,6 +77,24 @@ MATOMO_SITE_ID = os.environ.get("LUNES_CMS_MATOMO_SITE_ID", "")
 #: Authentication token for Matomo API
 MATOMO_TOKEN = os.environ.get("LUNES_CMS_MATOMO_TOKEN", "")
 
+###########
+# INFLUXDB #
+###########
+
+#: InfluxDB write endpoint
+INFLUX_URL = os.environ.get(
+    "LUNES_CMS_INFLUX_URL", "https://monitoring.tuerantuer.org/write"
+)
+
+#: Path to the client TLS certificate for InfluxDB mTLS auth
+INFLUX_CERT = os.environ.get("LUNES_CMS_INFLUX_CERT", "/etc/pki/client.crt")
+
+#: Path to the client TLS key for InfluxDB mTLS auth
+INFLUX_KEY = os.environ.get("LUNES_CMS_INFLUX_KEY", "/etc/pki/client.key")
+
+#: Path to the CA certificate for verifying the InfluxDB server certificate
+INFLUX_CA = os.environ.get("LUNES_CMS_INFLUX_CA", "/etc/pki/ca.crt")
+
 ########################
 # DJANGO CORE SETTINGS #
 ########################
@@ -77,6 +104,11 @@ MATOMO_TOKEN = os.environ.get("LUNES_CMS_MATOMO_TOKEN", "")
 #: .. warning::
 #:     Never deploy a site into production with :setting:`DEBUG` turned on!
 DEBUG = bool(strtobool(os.environ.get("LUNES_CMS_DEBUG", "False")))
+
+#: InfluxDB database name — defaults to lunes_test in debug mode, lunes_production otherwise
+INFLUX_DB = os.environ.get(
+    "LUNES_CMS_INFLUX_DB", "lunes_test" if DEBUG else "lunes_production"
+)
 
 #: Enabled applications (see :setting:`django:INSTALLED_APPS`)
 INSTALLED_APPS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 	"openai==2.38.0",
 	"pillow==12.2.0",
 	"psycopg2==2.9.12",
+	"requests==2.32.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We decided to send analytics data to grafana instead of keeping it in the lunes backend and add additional views/charts

https://grafana.tuerantuer.org/d/an6wdc9/lunes-test?orgId=1&from=2023-12-31T23:42:33.000Z&to=2026-06-30T23:17:26.000Z&timezone=browser

### Proposed changes
<!-- Describe this PR in more detail. -->

- add influx settings
- send data to influx db instead of writing in database
- disable analytics data cleanup (for testing period)
- add documentation for local testing

### Note
Mind that due to the changes https://github.com/digitalfabrik/lunes-cms/pull/765
We don't have data for these three analytic types because the payload changed.
So only job selection and sessions work currently.
We have to release the new version to get the correct data structure

### How to test
<!-- Please describe how to test this PR -->
- import backup.sql from nextcloud for testing data
- please check if in your `analytics_analytics_event` are already aggregated data, you can reset the aggregation if you run:
```
lunes-cms-cli shell -c "from lunes_cms.analytics.models import AnalyticsEvent; AnalyticsEvent.objects.update(aggregated_at=None)"
```
- checkout the docs how to run aggregation locally


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #820
