### PR TITLE
831: Job cannot be loaded

### DIFF
--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
@@ -154,11 +155,11 @@ class JobAdmin(BaseAdmin):
             str: HTML formatted badge showing migration status
         """
         if obj.v1_id is not None:
-            return format_html(
+            return mark_safe(
                 '<span style="background-color: #28a745; color: white; padding: 3px 8px; '
                 'border-radius: 3px; font-size: 13px; font-weight: 500;">Migrated</span>'
             )
-        return format_html(
+        return mark_safe(
             '<span style="background-color: #007bff; color: white; padding: 3px 8px; '
             'border-radius: 3px; font-size: 13px; font-weight: 500;">New</span>'
         )

--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.template.response import TemplateResponse
-from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from lunes_cms.cmsv2.admins.base import BaseAdmin
@@ -291,11 +291,11 @@ class UnitAdmin(BaseAdmin):
             str: HTML formatted badge showing migration status
         """
         if obj.v1_id is not None:
-            return format_html(
+            return mark_safe(
                 '<span style="background-color: #28a745; color: white; padding: 3px 8px; '
                 'border-radius: 3px; font-size: 13px; font-weight: 500;">Migrated</span>'
             )
-        return format_html(
+        return mark_safe(
             '<span style="background-color: #007bff; color: white; padding: 3px 8px; '
             'border-radius: 3px; font-size: 13px; font-weight: 500;">New</span>'
         )

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -700,11 +700,11 @@ class WordAdmin(BaseAdmin):
             str: HTML formatted badge showing migration status
         """
         if obj.v1_id is not None:
-            return format_html(
+            return mark_safe(
                 '<span style="background-color: #28a745; color: white; padding: 3px 8px; '
                 'border-radius: 3px; font-size: 13px; font-weight: 500;">Migrated</span>'
             )
-        return format_html(
+        return mark_safe(
             '<span style="background-color: #007bff; color: white; padding: 3px 8px; '
             'border-radius: 3px; font-size: 13px; font-weight: 500;">New</span>'
         )


### PR DESCRIPTION
### Short description
Looks like we recently updated test server to django 6.1a1 (with latest package), since the packages are only pinned for local dev.
Actually in python 6.x the `format_html` function changed and stopped allowing the usage without argument.
This function was designed to be used for html with dynamic values f.e. with an url or sth similar. But we also used it for static values and that breaks now


### Proposed changes
<!-- Describe this PR in more detail. -->

- use mark_safe for html strings with static values, since its the appropiate function

### How to test
<!-- Please describe how to test this PR -->
Prerequisite:
- `pip install "django>=6.1a1" --pre`
Then you can reproduce the bug
- go to jobs/units/words

After testing
- go back to `pip install django==5.2.14`


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #831
