### PR TITLE
Add missing pyaudio dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Natural Language :: German",
 ]
 dependencies = [
+  "audioop-lts; python_version>='3.13'",
 	"django",
 	"django-import-export",
 	"django-jazzmin",


### PR DESCRIPTION
### Short description
Add missing pyaudio dependency, fixes:

```
Traceback (most recent call last):
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/pydub/utils.py", line 14, in <module>
    import audioop
ModuleNotFoundError: No module named 'audioop'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/lunes-cms/.venv/bin/lunes-cms-cli", line 34, in <module>
    main()
    ~~~~^^
  File "/opt/lunes-cms/.venv/bin/lunes-cms-cli", line 30, in main
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/django/core/management/__init__.py", line 417, in execute
    django.setup()
    ~~~~~~~~~~~~^^
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/django/apps/config.py", line 193, in create
    import_module(entry)
    ~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/pydub/__init__.py", line 1, in <module>
    from .audio_segment import AudioSegment
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/pydub/audio_segment.py", line 11, in <module>
    from .utils import mediainfo_json, fsdecode
  File "/opt/lunes-cms/.venv/lib/python3.13/site-packages/pydub/utils.py", line 16, in <module>
    import pyaudioop as audioop
ModuleNotFoundError: No module named 'pyaudioop'
```


### Proposed changes
Add audioop-lts to pyproject.toml

### How to test

pip install

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: https://chat.tuerantuer.org/digitalfabrik/pl/u4dreq636tgi5fh3b7iqb3jhry
