### PR TITLE
834: Dependency version pinning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             else
               python3 -m venv .venv
               source .venv/bin/activate
-              pip install -e .[dev,pinned,dev-pinned]
+              pip install -e .[dev]
             fi
       - save_cache:
           key: pip-{{ checksum "pyproject.toml" }}-v7
@@ -118,7 +118,7 @@ jobs:
           command: lunes-cms-cli migrate
       - run:
           name: Run tests
-          command: pytest --circleci-parallelize --disable-warnings --cov=lunes_cms --cov-report=xml:coverage.xml --junitxml=test-results/junit.xml --ds=lunes_cms.core.settings
+          command: pytest -n auto --disable-warnings --cov=lunes_cms --cov-report=xml:coverage.xml --junitxml=test-results/junit.xml --ds=lunes_cms.core.settings
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -153,7 +153,7 @@ jobs:
             else
               python3 -m venv .venv
               source .venv/bin/activate
-              pip install -e .[dev,pinned,dev-pinned]
+              pip install -e .[dev]
             fi
       - save_cache:
           key: pip-3.13.13-{{ checksum "pyproject.toml" }}-v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,50 +37,6 @@ classifiers = [
     "Natural Language :: German",
 ]
 dependencies = [
-	"django",
-	"django-import-export",
-	"django-jazzmin",
-	"django-mptt",
-	"django-qr-code",
-	"djangorestframework",
-	"drf-spectacular",
-	"ipython",
-	"openai",
-	"pillow",
-	"psycopg2",
-]
-
-[project.optional-dependencies]
-dev = [
-	"black",
-    "build",
-	"bumpver",
-	"isort",
-	"mypy",
-	"pre-commit",
-	"pyjwt",
-	"pylint-django",
-	"pylint-runner",
-	"pytest-circleci-parallelized",
-	"pytest-cov",
-	"pytest-django",
-	"pytest-icdiff",
-	"pytest-xdist",
-	"shellcheck-py",
-	"sphinx",
-	"sphinx-rtd-theme",
-	"sphinx-last-updated-by-git",
-	"sphinxcontrib-django",
-	"twine",
-    "wheel"
-]
-e2e = [
-	"mkdocs>=1.5,<2.0",
-	"mkdocs-material>=9.0,<10.0",
-	"pytest-playwright",
-	"pytest-xdist",
-]
-pinned = [
 	"django==5.2.14",
 	"django-import-export==4.4.1",
 	"django-jazzmin==3.0.4",
@@ -93,15 +49,18 @@ pinned = [
 	"pillow==12.2.0",
 	"psycopg2==2.9.12",
 ]
-dev-pinned = [
+
+[project.optional-dependencies]
+dev = [
 	"black==26.5.1",
-    "build<=1.5.0",
+	"build<=1.5.0",
 	"bumpver==2026.1132",
+	"isort",
+	"mypy",
 	"pre-commit==4.6.0",
 	"pyjwt==2.13.0",
 	"pylint-django==2.7.0",
 	"pylint-runner==0.7.0",
-	"pytest-circleci-parallelized==0.1.0",
 	"pytest-cov==7.1.0",
 	"pytest-django==4.12.0",
 	"pytest-icdiff==0.9",
@@ -113,6 +72,12 @@ dev-pinned = [
 	"sphinxcontrib-django==2.5",
 	"twine==6.2.0",
 	"wheel==0.47.0",
+]
+e2e = [
+	"mkdocs>=1.5,<2.0",
+	"mkdocs-material>=9.0,<10.0",
+	"pytest-playwright",
+	"pytest-xdist",
 ]
 
 [project.urls]

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -69,7 +69,7 @@ activate_venv
 # Install pip dependencies
 echo "Installing Lunes CMS including its python dependencies..." | print_info
 # shellcheck disable=SC2102
-pip install -e .[pinned,dev-pinned]
+pip install -e .[dev]
 
 # Install node dependencies
 echo "Installing Node.js dependencies..." | print_info


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We had some issues on test and prod environment with new django version 6.x
Thats why we directly pin the dependencies because "pinned" installation were only used for local dev

### Proposed changes
<!-- Describe this PR in more detail. -->

- pin dependencies directly
- adjust install scripts

### How to test
<!-- Please describe how to test this PR -->

- run install.sh
- run backend


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #834
