### PR TITLE
842: Hash statics files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,6 +638,7 @@ workflows:
           name: build-dev-package
           requires:
             - bump-dev-version
+            - build-js
       - publish-package:
           name: publish-dev-package
           context: pypi-test

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -283,6 +283,20 @@ STATIC_URL = "/static/"
 #: In debug mode, this is not required since :mod:`django.contrib.staticfiles` can directly serve these files.
 STATIC_ROOT = os.environ.get("LUNES_CMS_STATIC_ROOT")
 
+#: Use ManifestStaticFilesStorage in production to append content hashes to static file names.
+#: This ensures browsers always load the latest version after a deploy (cache busting).
+#: In debug mode the default storage is used so that no STATIC_ROOT or manifest is required.
+#: See :class:`lunes_cms.core.utils.LaxManifestStaticFilesStorage`.
+if STATIC_ROOT:
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "lunes_cms.core.utils.LaxManifestStaticFilesStorage",
+        },
+    }
+
 #: URL that handles the media served from :setting:`MEDIA_ROOT` (see :setting:`django:MEDIA_URL`)
 MEDIA_URL = "/media/"
 
@@ -453,7 +467,6 @@ LOGGING = {
     },
 }
 
-
 #########################
 # DJANGO REST FRAMEWORK #
 #########################
@@ -564,7 +577,6 @@ JAZZMIN_UI_TWEAKS = {
         "success": "btn-success",
     },
 }
-
 
 ############
 # QR CODES #

--- a/lunes_cms/core/utils.py
+++ b/lunes_cms/core/utils.py
@@ -1,3 +1,25 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class LaxManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    """ManifestStaticFilesStorage that silently skips unresolvable references.
+
+    Third-party minified files (e.g. Bootstrap bundles) may contain
+    sourceMappingURL comments pointing to .map files that are not part of our
+    static files collection.  Django's ``manifest_strict = False`` does not
+    cover all code paths in newer versions, so we also override ``hashed_name``
+    to return the original name when a referenced file cannot be found.
+    """
+
+    manifest_strict = False
+
+    def hashed_name(self, name, content=None, filename=None):
+        try:
+            return super().hashed_name(name, content, filename)
+        except ValueError:
+            return name
+
+
 def strtobool(val):
     """Convert a string representation of truth to true (1) or false (0).
 


### PR DESCRIPTION
### Short description
Currently js and css updates in static files may be not reflected in the browser due to browser caching, because the filenames are static. I think we don't need an additional bundler for this because django has some included functions

### Proposed changes
<!-- Describe this PR in more detail. -->                
- enable static file hashing with `ManifestStaticFilesStorage`                                                                                                                                                                                                                                                          
- override `hashed_name` to avoid breaking third party files with missing local source maps    
- fix test runner in pipeline                                                                                                                                                                                                        

### How to test
<!-- Please describe how to test this PR -->
### Note: I already pushed a deployment to lunes test. So it works :)
Only dev 

Before you run please define your own `LUNES_CMS_STATIC_ROOT` (this will be defined in salt already for deployment)
- run `LUNES_CMS_DEBUG=True LUNES_CMS_STATIC_ROOT=/tmp/lunes-static lunes-cms-cli collectstatic --no-input`
- check the js and css files. They now should have hashes and should be found in `staticfiles.json`

Mind: we already run collectstatic in salt but without proper hashing

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #842