### PR TITLE
848: Show version information

### DIFF
--- a/lunes_cms/cms/templates/admin/base.html
+++ b/lunes_cms/cms/templates/admin/base.html
@@ -2,7 +2,7 @@
 
 {% block footer %}
     {% if not is_popup %}
-        <footer class="main-footer {{ jazzmin_ui.footer_classes }}">
+        <footer class="py-1 main-footer {{ jazzmin_ui.footer_classes }}">
             <a href="https://www.tuerantuer.org/digitalfabrik" target="_blank">
                 <strong>Tür an Tür Digitalfabrik gGmbH</strong>
             </a>

--- a/lunes_cms/cms/templates/admin/base.html
+++ b/lunes_cms/cms/templates/admin/base.html
@@ -6,6 +6,7 @@
             <a href="https://www.tuerantuer.org/digitalfabrik" target="_blank">
                 <strong>Tür an Tür Digitalfabrik gGmbH</strong>
             </a>
+            <span class="float-right">v{{ jazzmin_settings.site_version }}</span>
         </footer>
     {% endif %}
 {% endblock %}

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from importlib.metadata import PackageNotFoundError, version as get_package_version
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
@@ -490,6 +491,11 @@ SPECTACULAR_SETTINGS = {
 # DJANGO JAZZMIN #
 ##################
 
+try:
+    _cms_version = get_package_version("lunes-cms")
+except PackageNotFoundError:
+    _cms_version = "unknown"
+
 #: Basic settings for Django Jazzmin
 JAZZMIN_SETTINGS = {
     "site_brand": _("Lunes Administration"),
@@ -518,6 +524,7 @@ JAZZMIN_SETTINGS = {
         "cmsv2.Word": "fab fa-amilia",
         "cmsv2.Feedback": "fas fa-comment",
     },
+    "site_version": _cms_version,
 }
 
 #: UI tweaks for Django Jazzmin

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 18:21+0000\n"
+"POT-Creation-Date: 2026-06-22 18:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1085,19 +1085,19 @@ msgstr "Import fehlgeschlagen: %(e)s"
 msgid "Invalid audio file"
 msgstr "Ungültige Audiodatei"
 
-#: core/settings.py:237
+#: core/settings.py:238
 msgid "German"
 msgstr "Deutsch"
 
-#: core/settings.py:238
+#: core/settings.py:239
 msgid "English"
 msgstr "Englisch"
 
-#: core/settings.py:495 core/settings.py:496 core/settings.py:498
+#: core/settings.py:501 core/settings.py:502 core/settings.py:504
 msgid "Lunes Administration"
 msgstr "Lunes-Verwaltung"
 
-#: core/settings.py:497
+#: core/settings.py:503
 msgid "Welcome to the vocabulary management of Lunes!"
 msgstr "Willkommen bei der Vokabelverwaltung von Lunes!"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
With this pr we show the particular release version and sha commit

### Proposed changes
<!-- Describe this PR in more detail. -->

- add version information on the right side of the footer


### How to test
<!-- Please describe how to test this PR -->

- run backend

### Note
- we would have to override the sidebar to add there the version information. I think this place is easier and also good to find
- on production the local build part `(...+local build info`), will not be shown in version information, so in production for the current state it would just be `v2026.4.8`

<img width="762" height="739" alt="image" src="https://github.com/user-attachments/assets/60e331ab-e58e-4d27-822b-15a599fb87e3" />


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #848
