### PR TITLE
Improve loading times of units

### DIFF
--- a/docs/src/dev-tools.rst
+++ b/docs/src/dev-tools.rst
@@ -49,6 +49,11 @@ Import test data into the database :github-source:`tools/load_test_data.sh`::
 
     ./tools/load_test_data.sh
 
+Debug Toolbar
+=============
+
+The `Django Debug Toolbar <https://django-debug-toolbar.readthedocs.io>`_ is available to inspect SQL queries (and their timing) when debug mode is enabled (``LUNES_CMS_DEBUG=True``) and the ``dev`` dependencies are installed.
+
 Documentation
 =============
 

--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -27,6 +27,7 @@ class UnitInline(admin.TabularInline):
 
     model = Unit.jobs.through
     extra = 1
+    autocomplete_fields = ["unit"]
 
 
 class MigratedFilter(admin.SimpleListFilter):

--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -24,6 +24,7 @@ class WordInline(admin.TabularInline):
 
     model = UnitWordRelation
     extra = 1
+    autocomplete_fields = ["word"]
     fields = [
         "word",
         "image_with_controls",

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -155,6 +155,7 @@ class UnitInline(admin.TabularInline):
 
     model = UnitWordRelation
     extra = 1
+    autocomplete_fields = ["unit"]
     fields = [
         "unit",
         "image_with_controls",

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -115,6 +115,29 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
+########################
+# DJANGO DEBUG TOOLBAR #
+########################
+
+#: Whether the Django Debug Toolbar is enabled. Dev-only: requires :setting:`DEBUG`
+#: and the optional ``django-debug-toolbar`` dependency (part of the ``dev`` extra).
+DEBUG_TOOLBAR_ENABLED = False
+if DEBUG:
+    try:
+        import debug_toolbar  # noqa: F401  pylint: disable=unused-import
+    except ImportError:
+        pass
+    else:
+        DEBUG_TOOLBAR_ENABLED = True
+        INSTALLED_APPS.append("debug_toolbar")
+        MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+
+#: Configuration of the Django Debug Toolbar
+DEBUG_TOOLBAR_CONFIG = {
+    # Keep history so JSON API requests can be inspected at /__debug__/.
+    "RESULTS_CACHE_SIZE": 100,
+}
+
 #: Default URL dispatcher (see :setting:`django:ROOT_URLCONF`)
 ROOT_URLCONF = "lunes_cms.core.urls"
 

--- a/lunes_cms/core/urls.py
+++ b/lunes_cms/core/urls.py
@@ -47,3 +47,6 @@ urlpatterns += i18n_patterns(path("", include("lunes_cms.cms.urls")))
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if getattr(settings, "DEBUG_TOOLBAR_ENABLED", False):
+    urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]

--- a/lunes_cms/static/css/asset_manager.css
+++ b/lunes_cms/static/css/asset_manager.css
@@ -158,3 +158,11 @@
     border-radius: 4px;
     display: block;
 }
+
+/* The autocomplete (Select2) word/unit field in tabular inlines initialises
+   with width "resolve", which collapses to a sliver in the narrow inline cell
+   and hides the selected value. A min-width keeps it readable (min-width wins
+   over Select2's inline width style). */
+.inline-group .select2-container {
+    min-width: 18em;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
 	"black==26.5.1",
 	"build<=1.5.0",
 	"bumpver==2026.1132",
+	"django-debug-toolbar==7.0.0",
 	"isort",
 	"mypy",
 	"pre-commit==4.6.0",


### PR DESCRIPTION
Opening a unit's admin change page fired 28 queries. Multiple identical full table scans on `cmsv2_word`. Caused by the plain `<select>` for the foreign key to word.

**Changes**
- Added the Django Debug Toolbar (dev-only) to profile DB queries
- Actual fix: Use `autocomplete_fields = ["word"]` so the word field loads matches on demand

### How to test
- login and go to `unit` and check the loading time should be reasonable (not around 20-30s)