### PR TITLE
fix: cast width parameter to int in get_image_tag to prevent XSS

### DIFF
--- a/lunes_cms/cms/utils.py
+++ b/lunes_cms/cms/utils.py
@@ -138,7 +138,7 @@ def get_image_tag(image, width=330):
     # Hide preview if image is empty or has invalid type
     html_cls = "" if src else 'class="hidden"'
     # HTML image tag for previews
-    return mark_safe(f'<img src="{src}" width={width} height="auto" {html_cls} />')
+    return mark_safe(f'<img src="{src}" width={int(width)} height="auto" {html_cls} />')
 
 
 # pylint: disable=redefined-builtin

--- a/lunes_cms/cmsv2/utils.py
+++ b/lunes_cms/cmsv2/utils.py
@@ -8,8 +8,10 @@ import warnings
 from html import escape
 from typing import Optional
 
+from django.db.models.fields.files import ImageFieldFile
 from django.utils.crypto import get_random_string
 from django.utils.html import mark_safe
+from django.utils.safestring import SafeString
 from django.utils.translation import gettext as _
 from openai import OpenAI
 
@@ -100,16 +102,16 @@ def cache_busted_url(file):
     return f"{file.url}?v={version}"
 
 
-def get_image_tag(image, width=330):
+def get_image_tag(image: ImageFieldFile, width: int = 330) -> SafeString:
     """
     Generate an HTML image tag for the given image.
 
     Args:
         image: The image object to render
-        width (int, optional): The width of the image in pixels. Defaults to 330.
+        width: The width of the image in pixels. Defaults to 330.
 
     Returns:
-        str: An HTML img tag with the appropriate attributes
+        SafeString (str): An HTML img tag with the appropriate attributes
     """
     src = ""
     if (
@@ -119,7 +121,7 @@ def get_image_tag(image, width=330):
     ):
         src = escape(f"{settings.MEDIA_URL}{image}")
     html_cls = "" if src else 'class="hidden"'
-    return mark_safe(f'<img src="{src}" width={width} height="auto" {html_cls} />')
+    return mark_safe(f'<img src="{src}" width={int(width)} height="auto" {html_cls} />')
 
 
 # pylint: disable=redefined-builtin


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes a small, currently only theoretical security vulnerability. Width is given straight to mark_safe. Currently only integers are used, but in theory one might also use a different parameter. This PR erases the theoretical possibility of that  happening.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Cast width to an integer to prevent XSS.

### How to test
<!-- Please describe how to test this PR -->

-


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -
