### PR TITLE
fix: resolve n+1 problems for words and jobs to increase loading time

### DIFF
--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -4,7 +4,8 @@ import io
 from zipfile import ZipFile
 
 from django.contrib import admin, messages
-from django.http import HttpResponse
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.html import format_html
@@ -12,7 +13,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
-from ..models import Unit, Word
+from ..models import Job, Unit, Word
 from ..utils import make_safe_filename
 from .base import BaseAdmin
 from .word_export_resource import WordExportResource
@@ -117,7 +118,11 @@ class JobAdmin(BaseAdmin):
         js = ["js/job_icon_asset_config.js", "js/asset_manager.js"]
         css = {"all": ["css/asset_manager.css"]}
 
-    def related_units(self, obj):
+    def get_queryset(self, request: HttpRequest) -> QuerySet[Job]:
+        """Prefetch units to avoid N+1 queries in related_units"""
+        return super().get_queryset(request).prefetch_related("units")
+
+    def related_units(self, obj: Job) -> str:
         """
         Get a comma-separated list of unit titles related to this job.
 

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -626,7 +626,7 @@ class WordAdmin(BaseAdmin):
         """
         unit_word_images = ""
 
-        for relation in obj.unit_word_relations.all():
+        for relation in obj.unit_word_relations.select_related("unit").all():
             unit_word_images += self._generate_unit_word_image(relation)
 
         return unit_word_images


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR resolves the n+1 problem for word_admin and job_admin by prefetching the related tables. This reduces the DB queries from n+1 to 1 respectively 2. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix n+1 for job_admin
- Fix n+1 for word_admin


### How to test
<!-- Please describe how to test this PR -->

- Compare the number of queries in the django toolbar


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -
