### PR TITLE
836: Generate example sentences during CSV import

### DIFF
--- a/lunes_cms/cmsv2/services/sentence_generation.py
+++ b/lunes_cms/cmsv2/services/sentence_generation.py
@@ -1,10 +1,29 @@
 """
 Example sentence generation for Word objects via OpenAI.
+
+Besides the on-demand admin endpoints, this module provides a background drain
+(mirroring ``audio_generation`` / ``image_generation``): a Word created by a CSV
+import that has an empty ``example_sentence`` is "pending"; a worker thread picks
+pending rows, asks OpenAI for a sentence, and saves it. It is triggered from
+``import_csv_view`` *before* the audio drain, so the generated sentence gets its
+own audio in the same import.
 """
 
-from django.conf import settings
+import logging
+import threading
+import time
 
-from ..utils import get_openai_client
+from django.conf import settings
+from django.db import connection
+from django.db.models import Q
+from openai import RateLimitError
+
+from ..models import Job, Word
+from ..utils import get_openai_client, OpenAIConfigurationError
+
+logger = logging.getLogger(__name__)
+
+_drain_lock = threading.Lock()
 
 
 def build_example_sentence_prompt(word: str, job: str, unit: str | None = None) -> str:
@@ -68,3 +87,122 @@ def openai_example_sentence(word: str, job: str, unit: str | None = None) -> str
     if not sentence:
         raise ValueError("OpenAI returned an empty example sentence.")
     return sentence
+
+
+def _job_context_for_word(word: Word, job_title: str | None) -> str:
+    """
+    Determine the professional context for a word's example sentence.
+
+    A CSV import targets a single job and passes it via ``job_title``. Without
+    it (generic drain), the context is derived from every job the word's units
+    belong to — same logic as the on-demand word endpoint.
+    """
+    if job_title:
+        return job_title
+    job_names = list(
+        Job.objects.filter(units__words=word)
+        .distinct()
+        .order_by("name")
+        .values_list("name", flat=True)
+    )
+    return ", ".join(job_names)
+
+
+def _generate_for_word_sentence(word: Word, job_title: str | None = None) -> bool:
+    """
+    Generate and save a missing example sentence for a single Word.
+
+    Returns True if a sentence was generated and saved, False if the word was
+    skipped (already has a sentence, or no job context to build a prompt from).
+    """
+    if word.example_sentence and word.example_sentence.strip():
+        return False
+    job = _job_context_for_word(word, job_title)
+    if not job:
+        logger.info(
+            "Skipping sentence generation for word_id=%s (%s) — no job context",
+            word.pk,
+            word.word,
+        )
+        return False
+    unit_title = word.units.values_list("title", flat=True).first()
+    sentence = openai_example_sentence(word.word, job, unit_title)
+    word.example_sentence = sentence
+    # ``Word.save()`` flips ``example_sentence_check_status`` to NOT_CHECKED when
+    # the sentence changes, so it must be in ``update_fields`` to be persisted.
+    word.save(update_fields=["example_sentence", "example_sentence_check_status"])
+    logger.info("Generated example sentence for word_id=%s (%s)", word.pk, word.word)
+    return True
+
+
+def _pending_sentence_filter(word_ids: list[int] | None = None) -> Q:
+    pending = (Q(example_sentence="") | Q(example_sentence__isnull=True)) & ~Q(word="")
+    if word_ids is not None:
+        pending &= Q(pk__in=word_ids)
+    return pending
+
+
+def drain_pending_sentences(
+    word_ids: list[int] | None = None,
+    throttle_seconds: float = 1.0,
+    job_title: str | None = None,
+) -> None:
+    """
+    Process Words that need an example sentence, one at a time, until none remain.
+
+    ``word_ids`` restricts the drain to those Word rows (the ones a CSV import
+    just created). ``job_title`` supplies the single job a CSV import targets.
+
+    Mirrors the audio/image drains: single-flight within the process, per-row
+    failure isolation, and a back-off on rate limits. Triggered from
+    ``import_csv_view`` *before* the audio drain so generated sentences get audio.
+    """
+    # Non-blocking single-flight guard; released in the finally below.
+    if not _drain_lock.acquire(blocking=False):  # pylint: disable=consider-using-with
+        return
+    failed_pks: set[int] = set()
+    try:
+        pending = Word.objects.filter(_pending_sentence_filter(word_ids)).count()
+        logger.info(
+            "Sentence drain starting: %s word(s) pending — "
+            "up to %s OpenAI request(s)",
+            pending,
+            pending,
+        )
+        while True:
+            word = (
+                Word.objects.filter(_pending_sentence_filter(word_ids))
+                .exclude(pk__in=failed_pks)
+                .first()
+            )
+            if word is None:
+                return
+            try:
+                generated = _generate_for_word_sentence(word, job_title=job_title)
+            except OpenAIConfigurationError:
+                logger.warning("OpenAI not configured — sentence worker exiting")
+                return
+            except RateLimitError:
+                # Org RPM limit hit. Back off and retry the same row — the
+                # SDK already did its own short retries before raising.
+                logger.warning("OpenAI rate limit — backing off 30s")
+                time.sleep(30)
+                continue
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception(
+                    "Sentence generation failed for word_id=%s — leaving for retry",
+                    word.pk,
+                )
+                # Don't re-pick this row in this pass; it'll be retried on the
+                # next drain (import / app restart).
+                failed_pks.add(word.pk)
+                continue
+            if not generated:
+                # Skipped (no job context) but still matches the pending filter;
+                # park it so the loop doesn't spin on the same row forever.
+                failed_pks.add(word.pk)
+                continue
+            time.sleep(throttle_seconds)
+    finally:
+        _drain_lock.release()
+        connection.close()

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -14,6 +14,7 @@ from ..admins.word_import_resource import import_words_from_csv
 from ..models import Job
 from ..services.audio_generation import drain_pending_audio
 from ..services.image_generation import drain_pending_images
+from ..services.sentence_generation import drain_pending_sentences
 
 
 class ImportCSVForm(forms.Form):
@@ -100,22 +101,27 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
                 request,
                 _(
                     "Import successful! %(created)s new entries, %(updated)s updated. "
-                    "Audio and images are being generated in the background. This may "
-                    "take a few minutes..."
+                    "Example sentences, audio and images are being generated in the "
+                    "background. This may take a few minutes..."
                 )
                 % {"created": created_count, "updated": updated_count},
             )
 
         if imported_word_ids:
+            # Run the three drains sequentially in one thread:
+            #   1. sentences  — audio can only be made once the sentence exists
+            #   2. audio
+            #   3. images
+            # They must not run in parallel: each does a full ``Word.save()``,
+            # so concurrent drains would write back stale in-memory copies and
+            # clobber each other's file fields (re-triggering generation).
+            def _generate_word_assets() -> None:
+                drain_pending_sentences(imported_word_ids, job_title=selected_job.name)
+                drain_pending_audio(imported_word_ids)
+                drain_pending_images(imported_word_ids, job_title=selected_job.name)
+
             threading.Thread(
-                target=drain_pending_audio,
-                args=(imported_word_ids,),
-                daemon=True,
-            ).start()
-            threading.Thread(
-                target=drain_pending_images,
-                args=(imported_word_ids,),
-                kwargs={"job_title": selected_job.name},
+                target=_generate_word_assets,
                 daemon=True,
             ).start()
         return redirect(reverse("admin:cmsv2_job_change", args=[selected_job.pk]))

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -1074,12 +1074,13 @@ msgstr "Import mit folgenden Warnungen abgeschlossen: %(summary)s"
 #: cmsv2/views/import_csv_view.py
 #, python-format
 msgid ""
-"Import successful! %(created)s new entries, %(updated)s updated. Audio and "
-"images are being generated in the background. This may take a few minutes..."
+"Import successful! %(created)s new entries, %(updated)s updated. Example "
+"sentences, audio and images are being generated in the background. This may "
+"take a few minutes..."
 msgstr ""
 "Import erfolgreich! %(created)s neue Einträge, %(updated)s wurden "
-"aktualisiert. Audio und Bilder werden im Hintergrund generiert. Dies kann "
-"einige Minuten dauern..."
+"aktualisiert. Beispielsätze, Audio und Bilder werden im Hintergrund "
+"generiert. Dies kann einige Minuten dauern..."
 
 #: cmsv2/views/import_csv_view.py
 msgid ""

--- a/tests/cmsv2/services/test_sentence_generation.py
+++ b/tests/cmsv2/services/test_sentence_generation.py
@@ -2,12 +2,15 @@
 Tests for example sentence generation via OpenAI.
 """
 
+import threading
 from unittest import mock
 
 import pytest
 from django.conf import settings
 
+from lunes_cms.cmsv2.models import Job, Unit, Word
 from lunes_cms.cmsv2.services import sentence_generation
+from lunes_cms.cmsv2.utils import OpenAIConfigurationError
 
 
 def _fake_openai_client(content="Der Hammer liegt auf der Werkbank."):
@@ -81,3 +84,225 @@ def test_generation_raises_on_empty_response(content):
     ):
         with pytest.raises(ValueError):
             sentence_generation.openai_example_sentence("Hammer", "Tischler")
+
+
+# ---------------------------------------------------------------------------
+# Background drain (CSV import)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fast_worker(transactional_db):
+    """
+    Strip the throttle so tests don't sleep, and start from an empty Word table.
+
+    The worker scans the *whole* Word table. The session-scoped ``test_data``
+    fixture plus ``transaction=True`` (no rollback between tests) can leave rows
+    around, so wipe them first to keep these tests isolated.
+    """
+    Word.objects.all().delete()
+    with mock.patch.object(sentence_generation, "time") as mocked_time:
+        mocked_time.sleep = lambda _seconds: None
+        yield
+
+
+def _run_drain(word_ids=None, job_title=None):
+    """
+    Run the worker in a thread, like it runs in production.
+
+    ``drain_pending_sentences`` calls ``connection.close()`` on exit (it returns
+    the DB connection of its worker thread); calling it inline would close the
+    *test's* connection. All worker tests are ``transaction=True`` so the worker
+    thread sees committed data.
+    """
+    thread = threading.Thread(
+        target=sentence_generation.drain_pending_sentences,
+        kwargs={
+            "word_ids": word_ids,
+            "throttle_seconds": 0,
+            "job_title": job_title,
+        },
+    )
+    thread.start()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+
+
+def _make_word(**overrides) -> Word:
+    defaults = {"word": "Hammer", "singular_article": 1}
+    defaults.update(overrides)
+    return Word.objects.create(**defaults)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_generates_sentence_with_job_title(fast_worker):
+    word = _make_word(word="Hammer")
+
+    with mock.patch.object(
+        sentence_generation,
+        "openai_example_sentence",
+        return_value="Der Hammer liegt auf der Werkbank.",
+    ) as gen:
+        _run_drain(job_title="Tischler")
+
+    word.refresh_from_db()
+    assert word.example_sentence == "Der Hammer liegt auf der Werkbank."
+    assert word.example_sentence_check_status == "NOT_CHECKED"
+    assert gen.call_count == 1
+    # word, job passed positionally
+    assert gen.call_args[0][0] == "Hammer"
+    assert gen.call_args[0][1] == "Tischler"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_skips_word_that_already_has_a_sentence(fast_worker):
+    _make_word(word="Hammer", example_sentence="Schon vorhanden.")
+
+    with mock.patch.object(sentence_generation, "openai_example_sentence") as gen:
+        _run_drain(job_title="Tischler")
+
+    assert gen.call_count == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_passes_unit_title_to_generation(fast_worker):
+    job = Job.objects.create(name="Tischler")
+    unit = Unit.objects.create(title="Werkzeuge")
+    unit.jobs.add(job)
+    word = _make_word(word="Hammer")
+    unit.words.add(word)
+
+    with mock.patch.object(
+        sentence_generation,
+        "openai_example_sentence",
+        return_value="Ein Satz.",
+    ) as gen:
+        _run_drain(job_title="Tischler")
+
+    assert gen.call_args[0][2] == "Werkzeuge"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_derives_job_from_units_when_no_job_title(fast_worker):
+    job = Job.objects.create(name="Maler")
+    unit = Unit.objects.create(title="Farben")
+    unit.jobs.add(job)
+    word = _make_word(word="Pinsel")
+    unit.words.add(word)
+
+    with mock.patch.object(
+        sentence_generation,
+        "openai_example_sentence",
+        return_value="Ein Satz.",
+    ) as gen:
+        _run_drain()
+
+    assert gen.call_count == 1
+    assert gen.call_args[0][1] == "Maler"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_skips_word_without_job_context(fast_worker):
+    word = _make_word(word="Hammer")
+
+    with mock.patch.object(sentence_generation, "openai_example_sentence") as gen:
+        # No job_title and no units -> no context, must not loop forever.
+        _run_drain()
+
+    word.refresh_from_db()
+    assert gen.call_count == 0
+    assert word.example_sentence == ""
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_only_processes_given_word_ids(fast_worker):
+    imported = _make_word(word="Hammer")
+    other = _make_word(word="Säge")
+
+    with mock.patch.object(
+        sentence_generation,
+        "openai_example_sentence",
+        return_value="Ein Satz.",
+    ) as gen:
+        _run_drain(word_ids=[imported.pk], job_title="Tischler")
+
+    imported.refresh_from_db()
+    other.refresh_from_db()
+    assert imported.example_sentence == "Ein Satz."
+    assert other.example_sentence == ""
+    assert gen.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_isolates_failures_per_row(fast_worker):
+    failing = _make_word(word="Schraubenzieher")
+    succeeding = _make_word(word="Säge")
+
+    def maybe_fail(word, _job, _unit=None):
+        if word == "Schraubenzieher":
+            raise ValueError("simulated openai 5xx")
+        return "Ein Satz."
+
+    with mock.patch.object(
+        sentence_generation, "openai_example_sentence", side_effect=maybe_fail
+    ):
+        _run_drain(job_title="Tischler")
+
+    failing.refresh_from_db()
+    succeeding.refresh_from_db()
+    assert failing.example_sentence == ""
+    assert succeeding.example_sentence == "Ein Satz."
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_does_not_repick_a_failed_row(fast_worker):
+    word = _make_word(word="Hammer")
+
+    with mock.patch.object(
+        sentence_generation,
+        "openai_example_sentence",
+        side_effect=ValueError("boom"),
+    ) as gen:
+        _run_drain(job_title="Tischler")
+
+    word.refresh_from_db()
+    assert word.example_sentence == ""
+    # Tried exactly once, then parked in failed_pks (no money-burning loop).
+    assert gen.call_count == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_exits_quietly_when_openai_not_configured(fast_worker):
+    _make_word(word="Hammer")
+
+    with mock.patch.object(
+        sentence_generation,
+        "openai_example_sentence",
+        side_effect=OpenAIConfigurationError("missing key"),
+    ):
+        # Should return without raising.
+        _run_drain(job_title="Tischler")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_skips_words_with_empty_word(fast_worker):
+    Word.objects.create(word="", singular_article=0)
+
+    with mock.patch.object(sentence_generation, "openai_example_sentence") as gen:
+        _run_drain(job_title="Tischler")
+
+    assert gen.call_count == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drain_is_single_flight(fast_worker):
+    _make_word(word="Hammer")
+
+    sentence_generation._drain_lock.acquire()  # pylint: disable=protected-access
+    try:
+        with mock.patch.object(sentence_generation, "openai_example_sentence") as gen:
+            # Lock already held -> should return immediately, doing nothing.
+            _run_drain(job_title="Tischler")
+        assert gen.call_count == 0
+    finally:
+        sentence_generation._drain_lock.release()  # pylint: disable=protected-access


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Generates example sentences via OpenAI during a CSV job import for words that don't already have one (from the Beispielsatz column).

### Proposed changes
<!-- Describe this PR in more detail. -->

- New background drain `drain_pending_sentences` in `sentence_generation.py`, mirroring the audio/image drains: single-flight lock, per-row failure isolation, rate-limit backoff. Job context comes from the import's job (falls back to the word's units' jobs); unit context from the word's unit.
- The three drains now run **sequentially in one thread**: sentences → audio → images.
  - Sentences must finish before audio so a generated sentence gets its own TTS audio in the same import.
  - Serializing audio and images also fixes a pre-existing lost-update race: both drains did a full `Word.save()` in parallel, so a stale in-memory copy could clobber the other's file fields and re-trigger generation (observed as a word getting audio generated twice).
- Updated the import success message + German translation.
- Added drain tests (generate with job_title, derive job from units, unit title passed to prompt, skip existing/empty-word/no-context rows, word_id scoping, failure isolation, no-repick, OpenAI-unconfigured, single-flight). All `cmsv2` service/admin/view suites pass.

### How to test
<!-- Please describe how to test this PR -->

- Make sure OpenAI is configured (an API key is set) so generation can run.
- Prepare a CSV for import that contains at least:
  - one word row with an **empty** `Beispielsatz` (example sentence) column, and
  - one word row that **already has** a `Beispielsatz` value.
- In the admin, run the CSV import for a job.
- Wait for the background generation to finish, then open the imported words and verify:
  - words that had an **empty** `Beispielsatz` now have a **generated** example sentence (and matching TTS audio for it),
  - words that **already had** a sentence keep their original one (no overwrite),
  - no word gets its audio generated twice.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #836
