### PR TITLE
Disable Django Debug Toolbar in e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ jobs:
         docker:
             - environment:
                 LUNES_CMS_DEBUG: "True"
+                LUNES_CMS_DEBUG_TOOLBAR: "False"
                 LUNES_CMS_SECRET_KEY: circleci-dummy-key
               image: cimg/python:3.11
             - environment:

--- a/docs/src/dev-tools.rst
+++ b/docs/src/dev-tools.rst
@@ -54,6 +54,8 @@ Debug Toolbar
 
 The `Django Debug Toolbar <https://django-debug-toolbar.readthedocs.io>`_ is available to inspect SQL queries (and their timing) when debug mode is enabled (``LUNES_CMS_DEBUG=True``) and the ``dev`` dependencies are installed.
 
+It can be turned off independently of debug mode by setting ``LUNES_CMS_DEBUG_TOOLBAR=False``. This is used by the end-to-end tests, which need ``LUNES_CMS_DEBUG=True`` (so the dev server serves static files) but cannot have the toolbar's overlay intercepting pointer events.
+
 Documentation
 =============
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -15,8 +15,9 @@ E2E tests using pytest-playwright that automatically generate a user manual (Mar
 ## Running tests
 
 ```sh
-# Start the dev server first: 
-./tools/run.sh
+# Start the dev server first, with the Django Debug Toolbar disabled.
+# Its overlay intercepts pointer events and makes every click time out:
+LUNES_CMS_DEBUG_TOOLBAR=False ./tools/run.sh
 ```
 
 ```bash

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -121,8 +121,12 @@ MIDDLEWARE = [
 
 #: Whether the Django Debug Toolbar is enabled. Dev-only: requires :setting:`DEBUG`
 #: and the optional ``django-debug-toolbar`` dependency (part of the ``dev`` extra).
+#: Can be turned off independently of :setting:`DEBUG` via
+#: ``LUNES_CMS_DEBUG_TOOLBAR`` — the e2e tests run with ``DEBUG=True`` (so the
+#: dev server serves static files) but disable the toolbar, whose overlay
+#: intercepts pointer events and breaks browser interactions.
 DEBUG_TOOLBAR_ENABLED = False
-if DEBUG:
+if DEBUG and bool(strtobool(os.environ.get("LUNES_CMS_DEBUG_TOOLBAR", "True"))):
     try:
         import debug_toolbar  # noqa: F401  pylint: disable=unused-import
     except ImportError:


### PR DESCRIPTION
## Problem
Every e2e test on `develop` fails with `Locator.click: Timeout 30000ms exceeded` and the call log shows:

```
<div id="djDebugRoot">…</div> intercepts pointer events
```

The Django Debug Toolbar (added in #839) injects a `#djDebugRoot` overlay on every page when `DEBUG` is on. The e2e CircleCI job runs the dev server with `LUNES_CMS_DEBUG=True` (needed so `runserver` serves static files) and the toolbar is present in the cached dev venv, so the overlay sat on top of the admin UI and intercepted every Playwright click.

## Fix
- Gate the toolbar behind a new `LUNES_CMS_DEBUG_TOOLBAR` env var (default `True` → dev behaviour unchanged).
- Set `LUNES_CMS_DEBUG_TOOLBAR=False` in the e2e job, keeping `DEBUG=True` for static serving.
- Document the new var in `dev-tools.rst`.

Verified locally: with the var unset + toolbar installed → enabled; with the var `False` → not enabled and not added to `INSTALLED_APPS`.