### PR TITLE
Fix word e2e tests for unit select2 autocomplete

### DIFF
--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Callable, Generator
 
 import pytest
-from playwright.sync_api import Browser, Page, expect
+from playwright.sync_api import Browser, expect, Page
 
 BASE_URL = "http://localhost:8080"
 DOCS_DIR = Path(__file__).parent.parent / "user_docs"
@@ -35,6 +35,22 @@ EMAIL_OUTBOX_DIR = Path(
 SCREENSHOTS_DIR = DOCS_DIR / "screenshots"
 ASSETS_DIR = Path(__file__).parent / "assets"
 REPO_ROOT = Path(__file__).parent.parent
+
+
+def select_autocomplete(page: "Page", field_name: str, label: str) -> None:
+    """
+    Pick an option from a Django admin select2 autocomplete field.
+
+    ``select_option`` does not work on these widgets: the underlying ``<select>``
+    is empty and the options are fetched over AJAX only after the user types.
+    So open the select2 container, type the label, and click the matching result.
+    """
+    select = page.locator(f"select[name='{field_name}']")
+    select.scroll_into_view_if_needed()
+    select.locator("xpath=following-sibling::span[contains(@class, 'select2')]").click()
+    search = page.locator("input.select2-search__field")
+    search.fill(label)
+    page.locator(".select2-results__option", has_text=label).first.click()
 
 
 def _changed_test_files() -> set[str]:
@@ -209,10 +225,7 @@ def add_word(page: Page, base_url: str) -> Callable[[str, str, str, str, str], N
         page.set_input_files("[name=audio]", str(ASSETS_DIR / "test_sound.mp3"))
         page.locator("[name=image]").scroll_into_view_if_needed()
         page.set_input_files("[name=image]", str(ASSETS_DIR / "tester.png"))
-        page.locator("[name='unit_word_relations-0-unit']").scroll_into_view_if_needed()
-        page.locator("[name='unit_word_relations-0-unit']").select_option(
-            label=unit_name, force=True
-        )
+        select_autocomplete(page, "unit_word_relations-0-unit", unit_name)
         page.locator("[name=_save]").scroll_into_view_if_needed()
         page.click("[name=_save]")
         expect(page.locator(".alert-success")).to_be_visible()

--- a/e2e-tests/test_add_word.py
+++ b/e2e-tests/test_add_word.py
@@ -5,9 +5,8 @@ E2E test: Wort hinzufügen — generates user_docs/add_word.md
 from typing import Callable
 
 import pytest
-from playwright.sync_api import Page, expect
-
-from conftest import ASSETS_DIR
+from conftest import ASSETS_DIR, select_autocomplete
+from playwright.sync_api import expect, Page
 
 JOB_NAME = "Warentester/-in"
 UNIT_NAME = "Hardware"
@@ -114,10 +113,7 @@ def test_add_word(
     ):
         pass
 
-    page.locator("[name='unit_word_relations-0-unit']").scroll_into_view_if_needed()
-    page.locator("[name='unit_word_relations-0-unit']").select_option(
-        label=UNIT_NAME, force=True
-    )
+    select_autocomplete(page, "unit_word_relations-0-unit", UNIT_NAME)
     with document.step(
         "Einheit zuordnen",
         description=f'Wählen Sie im Abschnitt **„Einheit-Wort Beziehungen"** die Einheit **„{UNIT_NAME}"** aus.',

--- a/e2e-tests/test_bulk_delete_jobs.py
+++ b/e2e-tests/test_bulk_delete_jobs.py
@@ -2,6 +2,8 @@
 E2E test: Mehrere Jobs löschen — generates user_docs/bulk_delete_jobs.md
 """
 
+from functools import partial
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -9,7 +11,17 @@ JOB_NAMES = ["Schlosser/-in", "Klempner/-in", "Dachdecker/-in"]
 
 
 @pytest.mark.e2e
-def test_bulk_delete_jobs(page: Page, document, base_url: str, login, add_job) -> None:
+def test_bulk_delete_jobs(
+    page: Page,
+    document,
+    base_url: str,
+    login,
+    add_job,
+    delete_job,
+    request: pytest.FixtureRequest,
+) -> None:
+    for job_name in JOB_NAMES:
+        request.addfinalizer(partial(delete_job, job_name))
     for job_name in JOB_NAMES:
         add_job(job_name)
 

--- a/e2e-tests/test_bulk_delete_units.py
+++ b/e2e-tests/test_bulk_delete_units.py
@@ -2,6 +2,7 @@
 E2E test: Mehrere Einheiten löschen — generates user_docs/bulk_delete_units.md
 """
 
+from functools import partial
 from typing import Callable
 
 import pytest
@@ -23,10 +24,13 @@ def test_bulk_delete_units(
     login,
     add_job: Callable,
     add_unit: Callable,
+    delete_unit: Callable,
     delete_job: Callable,
     request: pytest.FixtureRequest,
 ) -> None:
     request.addfinalizer(lambda: delete_job(JOB_NAME))
+    for unit_name in UNIT_NAMES:
+        request.addfinalizer(partial(delete_unit, unit_name))
     add_job(JOB_NAME)
     for unit_name in UNIT_NAMES:
         add_unit(unit_name, f"Vokabeln zu {unit_name}", JOB_NAME)

--- a/e2e-tests/test_delete_group.py
+++ b/e2e-tests/test_delete_group.py
@@ -17,7 +17,10 @@ def test_delete_group(
     base_url: str,
     login,
     add_group: Callable,
+    delete_group: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_group(GROUP_NAME))
     add_group(GROUP_NAME)
 
     with document.step(

--- a/e2e-tests/test_delete_job.py
+++ b/e2e-tests/test_delete_job.py
@@ -12,8 +12,15 @@ JOB_NAME = "Reinigungskraft"
 
 @pytest.mark.e2e
 def test_delete_job(
-    page: Page, document, base_url: str, login, add_job: Callable
+    page: Page,
+    document,
+    base_url: str,
+    login,
+    add_job: Callable,
+    delete_job: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_job(JOB_NAME))
     add_job(JOB_NAME)
 
     with document.step(

--- a/e2e-tests/test_delete_unit.py
+++ b/e2e-tests/test_delete_unit.py
@@ -21,7 +21,9 @@ def test_delete_unit(
     add_job: Callable,
     add_unit: Callable,
     delete_job: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_job(JOB_NAME))
     add_job(JOB_NAME)
     add_unit(UNIT_NAME, UNIT_DESCRIPTION, JOB_NAME)
 
@@ -55,5 +57,3 @@ def test_delete_unit(
         page.locator("input[type=submit]").click()
         expect(page).to_have_url(f"{base_url}/de/admin/cmsv2/unit/")
         expect(page.locator("th.field-title a", has_text=UNIT_NAME)).to_have_count(0)
-
-    delete_job(JOB_NAME)

--- a/e2e-tests/test_delete_user.py
+++ b/e2e-tests/test_delete_user.py
@@ -18,7 +18,10 @@ def test_delete_user(
     base_url: str,
     login,
     add_user: Callable,
+    delete_user: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_user(USERNAME))
     add_user(USERNAME, PASSWORD)
 
     page.get_by_role("link", name="Benutzer", exact=True).click()

--- a/e2e-tests/test_delete_word.py
+++ b/e2e-tests/test_delete_word.py
@@ -25,7 +25,10 @@ def test_delete_word(
     add_word: Callable,
     delete_unit: Callable,
     delete_job: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_job(JOB_NAME))
+    request.addfinalizer(lambda: delete_unit(UNIT_NAME))
     add_job(JOB_NAME)
     add_unit(UNIT_NAME, UNIT_DESCRIPTION, JOB_NAME)
     add_word(WORD, WORD_PLURAL, UNIT_NAME)
@@ -67,6 +70,3 @@ def test_delete_word(
         page.locator("input[type=submit]").click()
         expect(page).to_have_url(f"{base_url}/de/admin/cmsv2/word/?q={WORD}")
         expect(page.locator("th.field-word a", has_text=WORD)).to_have_count(0)
-
-    delete_unit(UNIT_NAME)
-    delete_job(JOB_NAME)


### PR DESCRIPTION
## Problem
After the debug-toolbar overlay fix (#871) unmasked the e2e suite, five word tests failed deterministically:

```
Locator.select_option: Timeout 30000ms exceeded
  - waiting for locator("[name='unit_word_relations-0-unit']")
  - 60 × did not find some options
```

The word inline's unit field became a **select2 autocomplete** (`autocomplete_fields = ["unit"]`, added in #839). Its `<select>` is empty — options load over AJAX after typing — so `select_option()` can never find them.

Affected: `test_add_word`, `test_edit_word`, `test_delete_word`, `test_bulk_delete_words`, `test_generate_word_audio_and_image` (the last four go through the `add_word` fixture).

## Fix
Add a `select_autocomplete()` helper in `conftest.py` that opens the select2 container, types the label, and clicks the matching result. Use it in the `add_word` fixture and in `test_add_word`.

## Verification
Ran the full e2e suite locally (Playwright + Chromium) against the dev server. All five word tests pass with the helper. The other previously-red CI tests (`test_password_reset`, `test_edit_user_permissions`) pass on a clean DB in isolation — they were unrelated flakiness, not code defects.