### PR TITLE
Fix e2e unit autocomplete improve cleanup

### DIFF
--- a/e2e-tests/test_bulk_delete_jobs.py
+++ b/e2e-tests/test_bulk_delete_jobs.py
@@ -2,6 +2,8 @@
 E2E test: Mehrere Jobs löschen — generates user_docs/bulk_delete_jobs.md
 """
 
+from functools import partial
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -9,7 +11,17 @@ JOB_NAMES = ["Schlosser/-in", "Klempner/-in", "Dachdecker/-in"]
 
 
 @pytest.mark.e2e
-def test_bulk_delete_jobs(page: Page, document, base_url: str, login, add_job) -> None:
+def test_bulk_delete_jobs(
+    page: Page,
+    document,
+    base_url: str,
+    login,
+    add_job,
+    delete_job,
+    request: pytest.FixtureRequest,
+) -> None:
+    for job_name in JOB_NAMES:
+        request.addfinalizer(partial(delete_job, job_name))
     for job_name in JOB_NAMES:
         add_job(job_name)
 

--- a/e2e-tests/test_bulk_delete_units.py
+++ b/e2e-tests/test_bulk_delete_units.py
@@ -2,6 +2,7 @@
 E2E test: Mehrere Einheiten löschen — generates user_docs/bulk_delete_units.md
 """
 
+from functools import partial
 from typing import Callable
 
 import pytest
@@ -23,10 +24,13 @@ def test_bulk_delete_units(
     login,
     add_job: Callable,
     add_unit: Callable,
+    delete_unit: Callable,
     delete_job: Callable,
     request: pytest.FixtureRequest,
 ) -> None:
     request.addfinalizer(lambda: delete_job(JOB_NAME))
+    for unit_name in UNIT_NAMES:
+        request.addfinalizer(partial(delete_unit, unit_name))
     add_job(JOB_NAME)
     for unit_name in UNIT_NAMES:
         add_unit(unit_name, f"Vokabeln zu {unit_name}", JOB_NAME)

--- a/e2e-tests/test_delete_group.py
+++ b/e2e-tests/test_delete_group.py
@@ -17,7 +17,10 @@ def test_delete_group(
     base_url: str,
     login,
     add_group: Callable,
+    delete_group: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_group(GROUP_NAME))
     add_group(GROUP_NAME)
 
     with document.step(

--- a/e2e-tests/test_delete_job.py
+++ b/e2e-tests/test_delete_job.py
@@ -12,8 +12,15 @@ JOB_NAME = "Reinigungskraft"
 
 @pytest.mark.e2e
 def test_delete_job(
-    page: Page, document, base_url: str, login, add_job: Callable
+    page: Page,
+    document,
+    base_url: str,
+    login,
+    add_job: Callable,
+    delete_job: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_job(JOB_NAME))
     add_job(JOB_NAME)
 
     with document.step(

--- a/e2e-tests/test_delete_unit.py
+++ b/e2e-tests/test_delete_unit.py
@@ -21,7 +21,9 @@ def test_delete_unit(
     add_job: Callable,
     add_unit: Callable,
     delete_job: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_job(JOB_NAME))
     add_job(JOB_NAME)
     add_unit(UNIT_NAME, UNIT_DESCRIPTION, JOB_NAME)
 
@@ -55,5 +57,3 @@ def test_delete_unit(
         page.locator("input[type=submit]").click()
         expect(page).to_have_url(f"{base_url}/de/admin/cmsv2/unit/")
         expect(page.locator("th.field-title a", has_text=UNIT_NAME)).to_have_count(0)
-
-    delete_job(JOB_NAME)

--- a/e2e-tests/test_delete_user.py
+++ b/e2e-tests/test_delete_user.py
@@ -18,7 +18,10 @@ def test_delete_user(
     base_url: str,
     login,
     add_user: Callable,
+    delete_user: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_user(USERNAME))
     add_user(USERNAME, PASSWORD)
 
     page.get_by_role("link", name="Benutzer", exact=True).click()

--- a/e2e-tests/test_delete_word.py
+++ b/e2e-tests/test_delete_word.py
@@ -25,7 +25,10 @@ def test_delete_word(
     add_word: Callable,
     delete_unit: Callable,
     delete_job: Callable,
+    request: pytest.FixtureRequest,
 ) -> None:
+    request.addfinalizer(lambda: delete_job(JOB_NAME))
+    request.addfinalizer(lambda: delete_unit(UNIT_NAME))
     add_job(JOB_NAME)
     add_unit(UNIT_NAME, UNIT_DESCRIPTION, JOB_NAME)
     add_word(WORD, WORD_PLURAL, UNIT_NAME)
@@ -67,6 +70,3 @@ def test_delete_word(
         page.locator("input[type=submit]").click()
         expect(page).to_have_url(f"{base_url}/de/admin/cmsv2/word/?q={WORD}")
         expect(page.locator("th.field-word a", has_text=WORD)).to_have_count(0)
-
-    delete_unit(UNIT_NAME)
-    delete_job(JOB_NAME)


### PR DESCRIPTION
### Short description
I realized that we still have some cleanup issues, if one test fails, data remains in the database and tests will fail in you start e2e test once again


### Proposed changes
<!-- Describe this PR in more detail. -->

- add missing cleanups in e2e tests


### How to test
<!-- Please describe how to test this PR -->

- run e2e tests


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
