### PR TITLE
Fix csv export translation

### DIFF
--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -146,11 +146,11 @@ msgstr "Wortart"
 
 #: cms/admins/document_resource.py cmsv2/admins/word_export_resource.py
 msgid "Singular Article"
-msgstr "Singular Artikel"
+msgstr "Singularartikel"
 
 #: cms/admins/document_resource.py cmsv2/admins/word_export_resource.py
 msgid "Plural Article"
-msgstr "Plural Artikel"
+msgstr "Pluralartikel"
 
 #: cms/admins/document_resource.py cmsv2/admins/word_export_resource.py
 msgid "Has audio?"


### PR DESCRIPTION
### Short description
When exporting job to csv for german we had some translation inconsistencies. 
Therefore the import was not working, since the headers couldn't be mapped correctly


### Proposed changes
<!-- Describe this PR in more detail. -->

- Use correct translation for later import mapping


### How to test
<!-- Please describe how to test this PR -->

- export a job via csv (with existing articles)
- import job via csv
- check that articles will be exported and imported correctly


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
