### PR TITLE
Fix e2e CI job (4 independent failures)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,6 +668,7 @@ workflows:
                     - install
             - e2e:
                 requires:
+                    - build-js
                     - compile-translations
         when:
             or:
@@ -695,6 +696,7 @@ workflows:
             - e2e:
                 persist_docs: true
                 requires:
+                    - build-js
                     - compile-translations
             - build-package:
                 requires:

--- a/.circleci/src/workflows/commit_main.yml
+++ b/.circleci/src/workflows/commit_main.yml
@@ -12,4 +12,5 @@ jobs:
         - install
   - e2e:
       requires:
+        - build-js
         - compile-translations

--- a/.circleci/src/workflows/delivery_beta.yml
+++ b/.circleci/src/workflows/delivery_beta.yml
@@ -12,6 +12,7 @@ jobs:
   - e2e:
       persist_docs: true
       requires:
+        - build-js
         - compile-translations
   - build-package:
       requires:

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -15,9 +15,14 @@ E2E tests using pytest-playwright that automatically generate a user manual (Mar
 ## Running tests
 
 ```sh
-# Start the dev server first, with the Django Debug Toolbar disabled.
-# Its overlay intercepts pointer events and makes every click time out:
-LUNES_CMS_DEBUG_TOOLBAR=False ./tools/run.sh
+# Start the dev server first. Two settings matter for the e2e suite:
+#   LUNES_CMS_DEBUG=True         — enables the file-based email backend that
+#                                  test_password_reset reads emails from; without
+#                                  it the SMTP backend is used and no email file
+#                                  is written (test times out waiting for it).
+#   LUNES_CMS_DEBUG_TOOLBAR=False — the Django Debug Toolbar overlay intercepts
+#                                  pointer events and makes every click time out.
+LUNES_CMS_DEBUG=True LUNES_CMS_DEBUG_TOOLBAR=False ./tools/run.sh
 ```
 
 ```bash

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Generator
+from urllib.parse import quote
 
 import pytest
 from playwright.sync_api import Browser, expect, Page
@@ -238,15 +239,19 @@ def delete_word(page: Page, base_url: str) -> Callable[[str], None]:
     """Returns a function that deletes a word by its singular form from the CMS admin."""
 
     def _delete(word: str) -> None:
-        page.goto(f"{base_url}/de/admin/cmsv2/word/")
-        page.fill("#searchbar", word)
-        page.get_by_role("button", name="Suchen").click()
-        locator = page.locator("th.field-word a", has_text=re.compile(f"^{word}$"))
-        if locator.count() == 0:
-            return
-        locator.first.click()
-        page.get_by_role("link", name="Löschen").click()
-        page.locator("input[type=submit]").click()
+        matching = page.locator(
+            "th.field-word a", has_text=re.compile(f"^{re.escape(word)}$")
+        )
+        # Delete every match: leftovers from a failed test would otherwise make
+        # the next search return multiple rows and break strict-mode locators.
+        # goto() waits for load, so count() does not race the search results.
+        while True:
+            page.goto(f"{base_url}/de/admin/cmsv2/word/?q={quote(word)}")
+            if matching.count() == 0:
+                return
+            matching.first.click()
+            page.get_by_role("link", name="Löschen").click()
+            page.locator("input[type=submit]").click()
 
     return _delete
 

--- a/e2e-tests/test_delete_word.py
+++ b/e2e-tests/test_delete_word.py
@@ -25,10 +25,12 @@ def test_delete_word(
     add_word: Callable,
     delete_unit: Callable,
     delete_job: Callable,
+    delete_word: Callable,
     request: pytest.FixtureRequest,
 ) -> None:
     request.addfinalizer(lambda: delete_job(JOB_NAME))
     request.addfinalizer(lambda: delete_unit(UNIT_NAME))
+    request.addfinalizer(lambda: delete_word(WORD))
     add_job(JOB_NAME)
     add_unit(UNIT_NAME, UNIT_DESCRIPTION, JOB_NAME)
     add_word(WORD, WORD_PLURAL, UNIT_NAME)
@@ -49,7 +51,7 @@ def test_delete_word(
 
     page.fill("#searchbar", WORD)
     page.get_by_role("button", name="Suchen").click()
-    page.locator("th.field-word a", has_text=WORD).scroll_into_view_if_needed()
+    page.locator("th.field-word a", has_text=WORD).first.scroll_into_view_if_needed()
     with document.step(
         "Vokabel öffnen",
         description=f'Suchen Sie nach **„{WORD}"** und klicken Sie auf den Eintrag in der Liste.',

--- a/e2e-tests/test_edit_word.py
+++ b/e2e-tests/test_edit_word.py
@@ -36,10 +36,10 @@ def test_edit_word(
     request: pytest.FixtureRequest,
 ) -> None:
     def _delete_word() -> None:
-        try:
-            delete_word(WORD_UPDATED)
-        except Exception:
-            delete_word(WORD)
+        # delete_word removes every match and is a no-op when none exist, so
+        # clean up both names regardless of how far the test got before failing.
+        delete_word(WORD)
+        delete_word(WORD_UPDATED)
 
     request.addfinalizer(lambda: delete_job(JOB_NAME))
     request.addfinalizer(lambda: delete_unit(UNIT_NAME))
@@ -64,7 +64,7 @@ def test_edit_word(
 
     page.fill("#searchbar", WORD)
     page.get_by_role("button", name="Suchen").click()
-    page.locator("th.field-word a", has_text=WORD).scroll_into_view_if_needed()
+    page.locator("th.field-word a", has_text=WORD).first.scroll_into_view_if_needed()
     with document.step(
         "Vokabel öffnen",
         description=f'Suchen Sie nach einem Wort z.B. **„{WORD}"** und klicken Sie auf den Eintrag in der Liste.',

--- a/e2e-tests/test_password_reset.py
+++ b/e2e-tests/test_password_reset.py
@@ -6,10 +6,9 @@ import re
 from typing import Generator
 
 import pytest
-from playwright.sync_api import Browser, Page, expect
+from playwright.sync_api import Page, expect
 
 NEW_PASSWORD = "Lunes-Test-2024!"
-TEST_USERNAME = "max.mustermann"
 TEST_EMAIL = "max.mustermann@berufsschule-musterstadt.de"
 
 
@@ -22,32 +21,10 @@ def context(browser):
 
 
 @pytest.fixture
-def password_reset_user(
-    browser: Browser, browser_context_args: dict, base_url: str
-) -> Generator[None, None, None]:
-    """Creates max.mustermann with a known email via admin UI, then deletes him."""
-    ctx = browser.new_context(**browser_context_args)
-    p = ctx.new_page()
-    p.goto(f"{base_url}/de/admin/auth/user/add/")
-    p.fill("[name=username]", TEST_USERNAME)
-    p.fill("[name=password1]", "Lunes-Init-2024!")
-    p.fill("[name=password2]", "Lunes-Init-2024!")
-    p.click("[name=_save]")
-    p.fill("[name=email]", TEST_EMAIL)
-    p.click("[name=_save]")
-    ctx.close()
-
+def password_reset_user() -> Generator[None, None, None]:
+    """max.mustermann is provided by the seed fixture (cms/fixtures/test_data.json)
+    with email TEST_EMAIL, so the password reset flow needs no extra setup."""
     yield
-
-    ctx2 = browser.new_context(**browser_context_args)
-    p2 = ctx2.new_page()
-    p2.goto(f"{base_url}/de/admin/auth/user/")
-    p2.fill("#searchbar", TEST_USERNAME)
-    p2.get_by_role("button", name="Suchen").click()
-    p2.get_by_role("link", name=TEST_USERNAME).first.click()
-    p2.get_by_role("link", name="Löschen").click()
-    p2.locator("input[type=submit]").click()
-    ctx2.close()
 
 
 @pytest.mark.e2e

--- a/lunes_cms/cms/fixtures/test_data.json
+++ b/lunes_cms/cms/fixtures/test_data.json
@@ -64,6 +64,14 @@
     }
   },
   {
+    "model": "auth.group",
+    "fields": {
+      "name": "Vokabelverwalter:innen",
+      "icon": "",
+      "permissions": []
+    }
+  },
+  {
     "model": "cms.groupapikey",
     "pk": 1,
     "fields": {


### PR DESCRIPTION
The `e2e` job has never passed on `main`. Four independent root causes:

**1. `test_generate_word_audio_and_image`** — the e2e job `requires: compile-translations` but not `build-js`. Since `static/js/` is gitignored, the compiled `inline_regenerate.js` only lives in `build-js`'s workspace and was never attached to e2e, so the inline regenerate widget had no click handler and the generate request never fired (30s timeout). Added `build-js` to the e2e `requires` in both workflows.

**2. `test_edit_user_permissions`** (failing every run) — the test assigns the group `Vokabelverwalter:innen`, which was absent from the seed fixture, so `select_option` never found the option. Seeded the group in `cms/fixtures/test_data.json`.

**3. `test_password_reset`** (erroring every run) — the `password_reset_user` fixture re-created `max.mustermann`, but the seed already provides that user (same email, `is_staff`). The add form raised a duplicate-username error, so the email field never appeared. Fixture now relies on the seeded user.

**4. `test_delete_word` / `test_edit_word`** — once #872 made `add_word` work, words were actually created, exposing a race in `delete_word` (`count()` ran before the search results loaded, silently skipping deletes). Leftover `Maus` rows then broke strict-mode locators. `delete_word` now navigates via `?q=` (goto waits for load) and deletes every match; added a `delete_word` finalizer to `test_delete_word`, cleaned up both names in `test_edit_word`, and anchored the changelist row locators with `.first`.

Note: these e2e fixes build on #872, which went straight to `main`; `develop` lacks those changes and will need a forward-port so a later `develop`→`main` merge doesn't regress this.