### PR TITLE
761: Adjust csv import success message

### DIFF
--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -72,8 +72,8 @@ class RowResult:
     Return object of a single row.
     """
 
-    created: int = 0
-    updated: int = 0
+    unit_created: bool = False
+    word_created: bool = False
     error: Optional[str] = None
     word_id: Optional[int] = None
 
@@ -223,14 +223,13 @@ def process_row(
     Update example sentence
     Add word to newly created unit
     """
-    created = 0
-    updated = 0
+    unit_created = False
 
     unit = created_units.get(parsed.unit)
     if unit is None:
         unit = create_unit(parsed.unit, job)
         created_units[parsed.unit] = unit
-        created += 1
+        unit_created = True
     else:
         if not unit.jobs.filter(pk=job.pk).exists():
             unit.jobs.add(job)
@@ -238,13 +237,12 @@ def process_row(
     article_int = map_article_to_int(parsed.article)
     plural_article_int = map_plural_article_to_int(parsed.plural_article)
     word = create_word(parsed.word, article_int, plural_article_int, parsed.plural)
-    created += 1
 
     update_or_add_example_sentence(word, {"example_sentence": parsed.example})
 
     unit.words.add(word)
 
-    return RowResult(created=created, updated=updated, word_id=word.pk)
+    return RowResult(unit_created=unit_created, word_created=True, word_id=word.pk)
 
 
 def import_words_from_csv(
@@ -252,7 +250,7 @@ def import_words_from_csv(
 ) -> Tuple[int, int, list[str], list[int]]:
     """
     Imports the entire csv dataset to a job.
-    Returns a tuple of created_count, updated_count, error_messages,
+    Returns a tuple of words_created_count, units_created_count, error_messages,
     imported_word_ids
 
     Important: During the import there is a local cache ``created_units`` because of the following scenario:
@@ -261,8 +259,8 @@ def import_words_from_csv(
     What we want to happen is: a second unit "tools" is created, distinct from the one that already exists. All words
     in the CSV file gets imported into that second instance of "tools".
     """
-    total_created = 0
-    total_updated = 0
+    total_words_created = 0
+    total_units_created = 0
     error_messages: list[str] = []
     imported_word_ids: list[int] = []
 
@@ -284,9 +282,11 @@ def import_words_from_csv(
             )
             continue
 
-        total_created += result.created
-        total_updated += result.updated
+        if result.word_created:
+            total_words_created += 1
+        if result.unit_created:
+            total_units_created += 1
         if result.word_id is not None:
             imported_word_ids.append(result.word_id)
 
-    return total_created, total_updated, error_messages, imported_word_ids
+    return total_words_created, total_units_created, error_messages, imported_word_ids

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -7,6 +7,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 from tablib import Dataset
 from tablib.exceptions import InvalidDimensions
 
@@ -33,6 +34,23 @@ class ImportCSVForm(forms.Form):
             'The file should contain the columns "Einheit", "Artikel", "Vokabel" and "Beispielsatz".'
         ),
     )
+
+
+def _build_success_message(words_created: int, units_created: int) -> str:
+    """
+    Builds the pluralized success message shown after a completed CSV import.
+    """
+    words_phrase = ngettext(
+        "%(count)s new word", "%(count)s new words", words_created
+    ) % {"count": words_created}
+    units_phrase = ngettext(
+        "%(count)s new unit", "%(count)s new units", units_created
+    ) % {"count": units_created}
+    return _(
+        "Import successful! %(words)s, %(units)s created. Example "
+        "sentences, audio and images are being generated in the "
+        "background. This may take a few minutes..."
+    ) % {"words": words_phrase, "units": units_phrase}
 
 
 def _build_context(
@@ -85,7 +103,7 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
     try:
         data = Dataset()
         data.load(csv_file.read().decode("utf-8"), format="csv")
-        created_count, updated_count, errors, imported_word_ids = import_words_from_csv(
+        words_created, units_created, errors, imported_word_ids = import_words_from_csv(
             data, selected_job
         )
 
@@ -98,13 +116,7 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
             )
         else:
             messages.success(
-                request,
-                _(
-                    "Import successful! %(created)s new entries, %(updated)s updated. "
-                    "Example sentences, audio and images are being generated in the "
-                    "background. This may take a few minutes..."
-                )
-                % {"created": created_count, "updated": updated_count},
+                request, _build_success_message(words_created, units_created)
             )
 
         if imported_word_ids:

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -1134,6 +1134,30 @@ msgstr ""
 "\"Beispielsatz\" enthalten."
 
 #: cmsv2/views/import_csv_view.py
+#, python-format
+msgid "%(count)s new word"
+msgid_plural "%(count)s new words"
+msgstr[0] "%(count)s neues Wort"
+msgstr[1] "%(count)s neue Wörter"
+
+#: cmsv2/views/import_csv_view.py
+#, python-format
+msgid "%(count)s new unit"
+msgid_plural "%(count)s new units"
+msgstr[0] "%(count)s neue Einheit"
+msgstr[1] "%(count)s neue Einheiten"
+
+#: cmsv2/views/import_csv_view.py
+#, python-format
+msgid ""
+"Import successful! %(words)s, %(units)s created. Example sentences, audio "
+"and images are being generated in the background. This may take a few "
+"minutes..."
+msgstr ""
+"Import erfolgreich! %(words)s, %(units)s erstellt. Beispielsätze, Audio und "
+"Bilder werden im Hintergrund generiert. Dies kann einige Minuten dauern..."
+
+#: cmsv2/views/import_csv_view.py
 msgid "CSV import for vocabulary"
 msgstr "CSV Import für Vokabeln"
 
@@ -1141,17 +1165,6 @@ msgstr "CSV Import für Vokabeln"
 #, python-format
 msgid "Import completed with warnings: %(summary)s"
 msgstr "Import mit folgenden Warnungen abgeschlossen: %(summary)s"
-
-#: cmsv2/views/import_csv_view.py
-#, python-format
-msgid ""
-"Import successful! %(created)s new entries, %(updated)s updated. Example "
-"sentences, audio and images are being generated in the background. This may "
-"take a few minutes..."
-msgstr ""
-"Import erfolgreich! %(created)s neue Einträge, %(updated)s wurden "
-"aktualisiert. Beispielsätze, Audio und Bilder werden im Hintergrund "
-"generiert. Dies kann einige Minuten dauern..."
 
 #: cmsv2/views/import_csv_view.py
 msgid ""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Our csv import success message is very misleading

### Proposed changes
<!-- Describe this PR in more detail. -->

- separate created words and units
- remove updated since it's not used
- update translations


### How to test
<!-- Please describe how to test this PR -->

- use dark mode
- export a job via csv (Berufe -> select item in the list -> select dropdown export words from profession)
- csv importieren -> select profession and select file
- check the amount of words and units that were imported are correct


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #761
