### PR TITLE
898: Align the clear-sort icon with the cell it's meant to clear

### DIFF
--- a/lunes_cms/static/css/corporate_identity.css
+++ b/lunes_cms/static/css/corporate_identity.css
@@ -350,6 +350,12 @@ fieldset.module {
     color: #0F1419;
 }
 
+/* Jazzmin floats its clear-sorting icon to the cell's right edge, making it look like it's for the next cell */
+.app-cmsv2 #result_list thead th .text .fa-times {
+    float: none !important;
+    margin-left: 0.4em;
+}
+
 /* tbody cells: specificity (0,3,3) beats Bootstrap's striped (0,2,2) and base (0,1,1) */
 .app-cmsv2 .table-striped tbody tr > td,
 .app-cmsv2 .table-striped tbody tr > th {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The icon to clear the sorting on a list in the CMS was floated all the way to the right of the sorted column, making it look like it's for the next column. This fixes that.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Override the float on the ❌ that removes the sorting


### How to test
<!-- Please describe how to test this PR -->

- Go to http://localhost:8080/de/admin/cmsv2/job/?o=1, see that the ❌ is now on the left of the column


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #898 
