### PR TITLE
893: Update upload image button icon

### DIFF
--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -664,7 +664,7 @@ class WordAdmin(BaseAdmin):
                 <span class="audio-add">+</span>
             </button>
             <button type="button" class="replace-audio-btn" style="display: {'inline-flex' if obj.audio else 'none'};">
-                <span class="audio-replace">↻</span>
+                <span class="audio-replace"><i class="fas fa-upload"></i></span>
             </button>
             <button type="button" class="delete-audio-btn" style="display: {'inline-flex' if obj.audio else 'none'};">
                 <span class="audio-delete">×</span>
@@ -745,7 +745,7 @@ class WordAdmin(BaseAdmin):
                 <span class="image-add">+</span>
             </button>
             <button type="button" class="replace-image-btn" style="display: {'inline-flex' if obj.image else 'none'};">
-                <span class="image-replace">↻</span>
+                <span class="image-replace"><i class="fas fa-upload"></i></span>
             </button>
             <button type="button" class="delete-image-btn" style="display: {'inline-flex' if obj.image else 'none'};">
                 <span class="image-delete">×</span>
@@ -815,7 +815,7 @@ class WordAdmin(BaseAdmin):
                 <span class="unitword-image-add">+</span>
             </button>
             <button type="button" class="replace-unitword-image-btn" style="display: {'inline-flex' if relation.image else 'none'};">
-                <span class="unitword-image-replace">↻</span>
+                <span class="unitword-image-replace"><i class="fas fa-upload"></i></span>
             </button>
             <button type="button" class="delete-unitword-image-btn" style="display: {'inline-flex' if relation.image else 'none'};">
                 <span class="unitword-image-delete">×</span>


### PR DESCRIPTION
### Short description
Replace the misleading `↻` icon on the replace buttons with the Font Awesome upload icon, as agreed in #893.

### Proposed changes

- Replace `↻` with `<i class="fas fa-upload"></i>` on the image, unit-specific image and audio replace buttons in the words overview
- The `+` add buttons are left unchanged, and no new dependency is needed (Font Awesome ships with Jazzmin)

### How to test

- Open the words overview in the v2 admin
- For a word with an image/audio, the replace button now shows an upload icon instead of `↻`

### Resolved issues

Fixes: #893