### PR TITLE
910: Rollback analytics aggregation

### DIFF
--- a/lunes_cms/analytics/influx.py
+++ b/lunes_cms/analytics/influx.py
@@ -45,8 +45,9 @@ def resolve_unit(unit_id: int | str | None, unit_names: dict[int, str]) -> str |
 def push_lines(lines: list[str]) -> None:
     """Push InfluxDB line protocol lines to the configured write endpoint.
 
-    Failures are logged but never raise, so a monitoring outage cannot break
-    the aggregation pipeline.
+    Raises on failure so callers that push before committing their DB
+    transaction (see aggregate_analytics) can roll back the corresponding
+    ``aggregated_at`` markers instead of losing data silently.
     """
     if not lines:
         return
@@ -63,5 +64,6 @@ def push_lines(lines: list[str]) -> None:
         logger.debug(
             "Pushed %d lines to InfluxDB (db=%s)", len(lines), settings.INFLUX_DB
         )
-    except Exception as exc:  # pylint: disable=broad-exception-caught
+    except Exception as exc:
         logger.error("InfluxDB push failed (%d lines): %s", len(lines), exc)
+        raise

--- a/lunes_cms/analytics/management/commands/aggregate_analytics.py
+++ b/lunes_cms/analytics/management/commands/aggregate_analytics.py
@@ -539,7 +539,20 @@ class Command(BaseCommand):
         job_names: dict[int, str] = dict(Job.objects.values_list("id", "name"))
         unit_names: dict[int, str] = dict(Unit.objects.values_list("id", "title"))
         for aggregator_class in EVENT_AGGREGATORS:
-            self._aggregate_event_type(aggregator_class, dry_run, job_names, unit_names)
+            try:
+                self._aggregate_event_type(
+                    aggregator_class, dry_run, job_names, unit_names
+                )
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                # The InfluxDB push (see push_lines) already logged the details;
+                # @transaction.atomic rolled back the aggregated_at markers for
+                # this event type, so it will be retried on the next run.
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Aggregation failed for {aggregator_class.event_types}, "
+                        f"rolled back and will retry on the next run: {exc}"
+                    )
+                )
 
     # Will be uncommented with #829
     # self._delete_old_unprocessed_events(dry_run)
@@ -618,13 +631,17 @@ class Command(BaseCommand):
                 f"[DRY RUN] Would aggregate and mark {marked_count} {event_types} events "
                 f"({len(lines)} InfluxDB lines skipped)."
             )
-        else:
-            # Push after the transaction commits so we only push data that was successfully marked.
-            if lines:
-                transaction.on_commit(lambda: push_lines(lines))
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f"Aggregated and marked {marked_count} {event_types} events "
-                    f"({len(lines)} InfluxDB lines queued)."
-                )
+            return
+
+        # Push before the transaction commits: if the push fails, push_lines
+        # raises, so @transaction.atomic rolls back the aggregated_at markers
+        # too and the events are retried on the next run instead of being
+        # stuck marked-but-never-sent.
+        if lines:
+            push_lines(lines)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Aggregated and marked {marked_count} {event_types} events "
+                f"({len(lines)} InfluxDB lines pushed)."
             )
+        )

--- a/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
+++ b/lunes_cms/analytics/tests/commands/aggregate_analytics_test.py
@@ -134,6 +134,28 @@ class JobSelectionAggregateTests(TestCase):
         [line] = mock_push.call_args[0][0]
         self.assertIn("selection_count=-2i", line)
 
+    def test_rolls_back_marking_when_push_fails(self) -> None:
+        """If the InfluxDB push fails, the events are not left marked as aggregated"""
+        self._create_event(self.job1.id, "add", "2026-01-15T10:00:00")
+
+        with patch(PATCH_PUSH, side_effect=RuntimeError("boom")):
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        self.assertEqual(
+            AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 1
+        )
+
+        # A subsequent run (once InfluxDB is reachable again) picks the event back up.
+        with patch(PATCH_PUSH) as mock_push:
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
+
+        mock_push.assert_called_once()
+        self.assertEqual(
+            AnalyticsEvent.objects.filter(aggregated_at__isnull=True).count(), 0
+        )
+
 
 class SessionAggregateTests(TestCase):
     """
@@ -224,8 +246,9 @@ class SessionAggregateTests(TestCase):
     def test_does_not_push_on_rerun_with_no_new_events(self) -> None:
         """Re-running with no new events does not push"""
         self._create_session("s1", "2026-01-15T10:00:00", "2026-01-15T10:00:30")
-        with self.captureOnCommitCallbacks(execute=True):
-            call_command("aggregate_analytics")
+        with patch(PATCH_PUSH):
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         with patch(PATCH_PUSH) as mock_push:
             with self.captureOnCommitCallbacks(execute=True):
@@ -499,8 +522,9 @@ class ModuleDurationAggregateTests(TestCase):
         self._create_standard_event(
             "word_choice", self.unit1.id, "2026-01-15T10:00:00", 60
         )
-        with self.captureOnCommitCallbacks(execute=True):
-            call_command("aggregate_analytics")
+        with patch(PATCH_PUSH):
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self._create_standard_event(
             "word_choice", self.unit1.id, "2026-01-15T14:00:00", 40
@@ -816,8 +840,9 @@ class DropoutAggregateTests(TestCase):
             total=10,
             timestamp="2026-01-15T10:00:00",
         )
-        with self.captureOnCommitCallbacks(execute=True):
-            call_command("aggregate_analytics")
+        with patch(PATCH_PUSH):
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self._create_standard_event(
             exercise_type="word_choice",
@@ -1150,8 +1175,9 @@ class ExerciseRepetitionAggregateTests(TestCase):
     def test_second_run_pushes_only_new_events(self) -> None:
         """Running twice pushes new events in each run separately"""
         self._create_standard_event("word_choice", 10, "2026-01-15T10:00:00")
-        with self.captureOnCommitCallbacks(execute=True):
-            call_command("aggregate_analytics")
+        with patch(PATCH_PUSH):
+            with self.captureOnCommitCallbacks(execute=True):
+                call_command("aggregate_analytics")
 
         self._create_standard_event("word_choice", 10, "2026-01-15T14:00:00")
         with patch(PATCH_PUSH) as mock_push:


### PR DESCRIPTION
### Short description
See issue descriptions


### Proposed changes
<!-- Describe this PR in more detail. -->

- add roleback of aggregation if influx db push fails


### How to test
<!-- Please describe how to test this PR -->

- You can follow the instructions in `analytics.rst` and adjust the `LUNES_CMS_INFLUX_URL` to sth invalid


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #910
