### PR TITLE
738: Align word import export

### DIFF
--- a/lunes_cms/cmsv2/admins/job_admin.py
+++ b/lunes_cms/cmsv2/admins/job_admin.py
@@ -267,7 +267,7 @@ class JobAdmin(BaseAdmin):
         csvs = {}
 
         for profession in queryset:
-            resource = WordExportResource()
+            resource = WordExportResource(for_profession=profession)
             units = Unit.objects.filter(jobs=profession)
             words = (
                 Word.objects.filter(units__in=units)

--- a/lunes_cms/cmsv2/admins/word_export_resource.py
+++ b/lunes_cms/cmsv2/admins/word_export_resource.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from django.utils.translation import gettext_lazy as _
 from import_export import fields, resources
 from import_export.admin import ExportActionMixin
 
-from ..models import Word
+from ..models import Job, Word
 from ..models.static import PluralArticle, SingularArticle
 
 if TYPE_CHECKING:
@@ -22,10 +22,12 @@ class WordExportResource(resources.ModelResource):
     ExportActionMixin.export_admin_action
 
     # pylint: disable=super-init-not-called
-    def __init__(self, for_profession: Any = None) -> None:
+    def __init__(self, for_profession: Job | None = None) -> None:
         self.for_profession = for_profession
         self.relevant_units = (
-            for_profession.get_nested_units() if for_profession else None
+            for_profession.units.values_list("id", flat=True)
+            if for_profession
+            else None
         )
 
     word = fields.Field(column_name=_("Word"), attribute="word")

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -77,7 +77,7 @@ class RowResult:
     Return object of a single row.
     """
 
-    unit_created: bool = False
+    units_created: int = 0
     word_created: bool = False
     error: Optional[str] = None
     word_id: Optional[int] = None
@@ -258,6 +258,41 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
         )
 
 
+def _split_unit_titles(unit_column: str) -> list[str]:
+    """
+    Splits the "unit" column into individual unit titles. The exporter joins
+    a word's units with " | " when it belongs to several units of the same
+    job (see ``WordExportResource.dehydrate_units``) — on re-import that
+    joined string must resolve back to each of those units individually,
+    not to one new unit literally named e.g. "Werkzeuge | Baustelle".
+    """
+    titles = (part.strip() for part in unit_column.split("|"))
+    return [title for title in titles if title]
+
+
+def _resolve_unit(
+    unit_title: str,
+    job: Job,
+    created_units: Dict[str, Unit],
+    creator_fields: dict,
+) -> Tuple[Unit, bool]:
+    """
+    Looks up ``unit_title`` in the ``created_units`` cache, creating it (even
+    if a unit with the same title already exists elsewhere) if this is the
+    first time this import encounters it. Returns the unit and whether it
+    was newly created.
+    """
+    unit = created_units.get(unit_title)
+    if unit is None:
+        unit = create_unit(unit_title, job, creator_fields)
+        created_units[unit_title] = unit
+        return unit, True
+
+    if not unit.jobs.filter(pk=job.pk).exists():
+        unit.jobs.add(job)
+    return unit, False
+
+
 def process_row(
     parsed: ParsedRow,
     job: Job,
@@ -267,21 +302,18 @@ def process_row(
     """
     Processes a single parsed row.
 
-    If unit is not yet in ``created_units`` cache, a new unit gets created, even if there is already one in the system with the same name.
-    If there is a unit in the cache, use that one
-    Update example sentence
-    Add word to newly created unit
+    The "unit" column may name more than one unit (see
+    ``_split_unit_titles``); each one is resolved/created and linked to the
+    word individually. Update example sentence. Add word to newly created
+    unit(s).
     """
-    unit_created = False
-
-    unit = created_units.get(parsed.unit)
-    if unit is None:
-        unit = create_unit(parsed.unit, job, creator_fields)
-        created_units[parsed.unit] = unit
-        unit_created = True
-    else:
-        if not unit.jobs.filter(pk=job.pk).exists():
-            unit.jobs.add(job)
+    units_created = 0
+    units = []
+    for unit_title in _split_unit_titles(parsed.unit):
+        unit, created = _resolve_unit(unit_title, job, created_units, creator_fields)
+        units.append(unit)
+        if created:
+            units_created += 1
 
     attributes = WordAttributes(
         singular_article=map_article_to_int(parsed.article),
@@ -293,9 +325,10 @@ def process_row(
 
     update_or_add_example_sentence(word, {"example_sentence": parsed.example})
 
-    unit.words.add(word)
+    for unit in units:
+        unit.words.add(word)
 
-    return RowResult(unit_created=unit_created, word_created=True, word_id=word.pk)
+    return RowResult(units_created=units_created, word_created=True, word_id=word.pk)
 
 
 def import_words_from_csv(
@@ -338,8 +371,7 @@ def import_words_from_csv(
 
         if result.word_created:
             total_words_created += 1
-        if result.unit_created:
-            total_units_created += 1
+        total_units_created += result.units_created
         if result.word_id is not None:
             imported_word_ids.append(result.word_id)
 

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -52,7 +52,7 @@ def _build_column_mapping() -> dict[str, str]:
 
 
 def _lowered_column_mapping() -> dict[str, str]:
-    return {k.lower(): v for k, v in _build_column_mapping().items()}
+    return {key.lower(): value for key, value in _build_column_mapping().items()}
 
 
 #: Internal fields without which a row can't be imported at all — every

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
-from ..models import Job, PluralArticle, SingularArticle, Unit, Word
+from ..models import Job, PluralArticle, SingularArticle, Unit, Word, WordType
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,9 @@ def _build_column_mapping() -> dict[str, str]:
         # word
         "Word": "word",
         "Vokabel": "word",
+        # word type
+        "Word type": "word_type",
+        "Wortart": "word_type",
         # singular article
         "Singular Article": "article",
         "Singularartikel": "article",
@@ -57,6 +60,7 @@ class ParsedRow:
     plural: str = ""
     plural_article: str = ""
     example: str = ""
+    word_type: str = ""
 
 
 class InvalidRowError(ValueError):
@@ -104,6 +108,16 @@ def map_plural_article_to_int(plural_article: str) -> int | None:
     return ARTICLE_MAP.get(normalized)
 
 
+def map_word_type(word_type: str) -> str:
+    """
+    Validates a word type string (as produced by the exporter) against the
+    known ``WordType`` values, case-insensitively. Returns "" (the model
+    default) for empty or unrecognised values, rather than failing the row.
+    """
+    WORD_TYPE_MAP: dict[str, str] = {value.lower(): value for value in WordType.values}
+    return WORD_TYPE_MAP.get(word_type.lower().strip(), "")
+
+
 def create_unit(unit_title: str, job: Job, creator_fields: dict) -> Unit:
     """
     Create a new unit - even if one already exists with the same title.
@@ -113,21 +127,28 @@ def create_unit(unit_title: str, job: Job, creator_fields: dict) -> Unit:
     return unit
 
 
+@dataclass(frozen=True)
+class WordAttributes:
+    """The (already converted/validated) word fields a CSV row contributes."""
+
+    singular_article: int
+    plural_article: int | None
+    plural: str = ""
+    word_type: str = ""
+
+
 def create_word(
-    word_text: str,
-    singular_article: int,
-    plural_article: int | None,
-    creator_fields: dict,
-    plural: str = "",
+    word_text: str, attributes: WordAttributes, creator_fields: dict
 ) -> Word:
     """
     Creates a new word object.
     """
     return Word.objects.create(
         word=word_text,
-        singular_article=singular_article,
-        plural_article=plural_article,
-        plural=plural,
+        singular_article=attributes.singular_article,
+        plural_article=attributes.plural_article,
+        plural=attributes.plural,
+        word_type=attributes.word_type,
         **creator_fields,
     )
 
@@ -208,6 +229,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
         plural = mapped.get("plural", "")
         plural_article = mapped.get("plural_article", "")
         example = mapped.get("example", "")
+        word_type = mapped.get("word_type", "")
 
         return ParsedRow(
             unit=unit,
@@ -216,6 +238,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
             plural=plural,
             plural_article=plural_article,
             example=example,
+            word_type=word_type,
         )
 
     except (AttributeError, TypeError) as exc:
@@ -260,11 +283,13 @@ def process_row(
         if not unit.jobs.filter(pk=job.pk).exists():
             unit.jobs.add(job)
 
-    article_int = map_article_to_int(parsed.article)
-    plural_article_int = map_plural_article_to_int(parsed.plural_article)
-    word = create_word(
-        parsed.word, article_int, plural_article_int, creator_fields, parsed.plural
+    attributes = WordAttributes(
+        singular_article=map_article_to_int(parsed.article),
+        plural_article=map_plural_article_to_int(parsed.plural_article),
+        plural=parsed.plural,
+        word_type=map_word_type(parsed.word_type),
     )
+    word = create_word(parsed.word, attributes, creator_fields)
 
     update_or_add_example_sentence(word, {"example_sentence": parsed.example})
 

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -1,12 +1,15 @@
 import logging
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
 from ..models import Job, PluralArticle, SingularArticle, Unit, Word, WordType
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrOrPromise
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +49,38 @@ def _build_column_mapping() -> dict[str, str]:
         "Sinneinheit": "unit",
         "Sinneseinheit": "unit",
     }
+
+
+def _lowered_column_mapping() -> dict[str, str]:
+    return {k.lower(): v for k, v in _build_column_mapping().items()}
+
+
+#: Internal fields without which a row can't be imported at all — every
+#: other recognised column (article, plural, example sentence, word type)
+#: has a usable default and doesn't need to be filled in.
+REQUIRED_FIELDS = ("unit", "word")
+
+
+def validate_header_structure(
+    headers: Optional[list[str]],
+) -> "Optional[_StrOrPromise]":
+    """
+    Checks that the dataset's header row contains the structurally required
+    columns (unit and word). Returns a translated error message if the file
+    doesn't look like an import file at all, or ``None`` if the required
+    columns were found. The expected columns themselves are already named in
+    ``ImportCSVForm``'s ``csv_file`` help text, so the message doesn't repeat
+    them.
+    """
+    column_mapping = _lowered_column_mapping()
+    mapped_fields = {
+        column_mapping[header.strip().lower()]
+        for header in headers or []
+        if header and column_mapping.get(header.strip().lower())
+    }
+    if set(REQUIRED_FIELDS) <= mapped_fields:
+        return None
+    return _("The file is not in the correct format.")
 
 
 @dataclass(frozen=True)
@@ -186,7 +221,7 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
     Parses a single row and returns either a ParsedRow or a RowResult (error).
     """
     try:
-        column_mapping = {k.lower(): v for k, v in _build_column_mapping().items()}
+        column_mapping = _lowered_column_mapping()
         mapped = {
             column_mapping[key.strip().lower()]: (
                 value.strip() if isinstance(value, str) else value

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -11,7 +11,10 @@ from django.utils.translation import ngettext
 from tablib import Dataset
 from tablib.exceptions import InvalidDimensions
 
-from ..admins.word_import_resource import import_words_from_csv
+from ..admins.word_import_resource import (
+    import_words_from_csv,
+    validate_header_structure,
+)
 from ..models import Job
 from ..services.audio_generation import drain_pending_audio
 from ..services.image_generation import drain_pending_images
@@ -51,6 +54,25 @@ def _build_success_message(words_created: int, units_created: int) -> str:
         "sentences, audio and images are being generated in the "
         "background. This may take a few minutes..."
     ) % {"words": words_phrase, "units": units_phrase}
+
+
+def _report_dataset_issue(request: HttpRequest, data: Dataset) -> bool:
+    """
+    Checks whether the uploaded dataset can be imported at all, adding the
+    appropriate user-facing message if not. Returns True if the caller
+    should stop (nothing to import), False if the dataset is ready for
+    ``import_words_from_csv``.
+    """
+    format_error = validate_header_structure(data.headers)
+    if format_error:
+        messages.error(request, format_error)
+        return True
+    if len(data) == 0:
+        messages.warning(
+            request, _("The file contains no entries. Nothing was imported.")
+        )
+        return True
+    return False
 
 
 def _build_context(
@@ -103,6 +125,14 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
     try:
         data = Dataset()
         data.load(csv_file.read().decode("utf-8"), format="csv")
+
+        if _report_dataset_issue(request, data):
+            return render(
+                request,
+                "admin/csv_form.html",
+                _build_context(request, form, job, job_id),
+            )
+
         # request.user is `User | AnonymousUser`, but this view is only
         # reachable by authenticated staff users.
         words_created, units_created, errors, imported_word_ids = import_words_from_csv(

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -939,9 +939,13 @@ msgid "Units"
 msgstr "Einheit"
 
 #: cmsv2/admins/word_import_resource.py
+msgid "The file is not in the correct format."
+msgstr "Die Datei hat nicht das richtige Format."
+
+#: cmsv2/admins/word_import_resource.py
 #, python-format
 msgid "Row %(n)s: No recognised columns – row will be skipped."
-msgstr "Zeile %(n)s: Die Spalte Einheit ist leer, wird übersprungen."
+msgstr "Zeile %(n)s: Keine erkannten Spalten – Zeile wird übersprungen."
 
 #: cmsv2/admins/word_import_resource.py
 #, python-format
@@ -1240,6 +1244,10 @@ msgid ""
 msgstr ""
 "Import erfolgreich! %(words)s, %(units)s erstellt. Beispielsätze, Audio und "
 "Bilder werden im Hintergrund generiert. Dies kann einige Minuten dauern..."
+
+#: cmsv2/views/import_csv_view.py
+msgid "The file contains no entries. Nothing was imported."
+msgstr "Die Datei enthält keine Einträge. Es wurde nichts importiert."
 
 #: cmsv2/views/import_csv_view.py
 msgid "CSV import for vocabulary"

--- a/tests/cmsv2/admins/test_job_admin_export.py
+++ b/tests/cmsv2/admins/test_job_admin_export.py
@@ -1,0 +1,61 @@
+"""
+Tests for the "Export all vocabulary for these jobs to CSV" admin action
+(issue #738) — specifically that the exported "Units" column only lists
+units of the job being exported, not units of unrelated jobs.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+from django.contrib import admin
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.http import HttpRequest
+from django.test import RequestFactory
+
+from lunes_cms.cmsv2.admins.job_admin import JobAdmin
+from lunes_cms.cmsv2.models import Job, Unit, Word
+from lunes_cms.cmsv2.models.unit import UnitWordRelation
+
+
+@pytest.fixture
+def request_factory() -> RequestFactory:
+    return RequestFactory()
+
+
+@pytest.fixture
+def job_admin() -> JobAdmin:
+    return JobAdmin(Job, admin.site)
+
+
+def _post_request(request_factory: RequestFactory) -> HttpRequest:
+    request = request_factory.post("/")
+    request.session = {}  # type: ignore[assignment]
+    request._messages = FallbackStorage(request)  # type: ignore[attr-defined]
+    return request
+
+
+@pytest.mark.django_db()
+def test_export_to_csv_only_lists_units_of_the_exported_job(
+    job_admin: JobAdmin, request_factory: RequestFactory
+) -> None:
+    job_a = Job.objects.create(name="Bäcker/-in")
+    job_b = Job.objects.create(name="Kfz-Mechatroniker/-in")
+    unit_a = Unit.objects.create(title="Backofen")
+    unit_a.jobs.add(job_a)
+    unit_b = Unit.objects.create(title="Bremsen")
+    unit_b.jobs.add(job_b)
+    word = Word.objects.create(word="Schraubenzieher", singular_article=1)
+    UnitWordRelation.objects.create(unit=unit_a, word=word)
+    UnitWordRelation.objects.create(unit=unit_b, word=word)
+
+    request = _post_request(request_factory)
+    response = job_admin.export_to_csv(request, Job.objects.filter(pk=job_a.pk))
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        csv_content = archive.read(archive.namelist()[0]).decode()
+
+    assert "Backofen" in csv_content
+    assert "Bremsen" not in csv_content

--- a/tests/cmsv2/admins/test_word_export_resource.py
+++ b/tests/cmsv2/admins/test_word_export_resource.py
@@ -1,0 +1,80 @@
+"""
+Tests for scoping the "Units" export column to the exported job (issue #738).
+
+``WordExportResource`` used to fall back to a word's *entire* global unit
+list whenever it wasn't scoped to a profession — and the only real caller
+(``JobAdmin.export_to_csv``) never passed a profession in the first place
+(it called ``for_profession.get_nested_units()``, a method that doesn't
+exist on ``Job`` and was therefore dead code). The practical effect: a CSV
+exported for one job could list unit names belonging to a completely
+unrelated job in its "Units" column.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lunes_cms.cmsv2.admins.word_export_resource import WordExportResource
+from lunes_cms.cmsv2.models import Job, Unit, Word
+from lunes_cms.cmsv2.models.unit import UnitWordRelation
+
+
+def _link(unit: Unit, word: Word) -> UnitWordRelation:
+    return UnitWordRelation.objects.create(unit=unit, word=word)
+
+
+@pytest.mark.django_db()
+def test_dehydrate_units_only_lists_units_of_the_exported_job() -> None:
+    """A word taught in units of two unrelated jobs must only show the
+    exported job's own unit — not the other job's."""
+    job_a = Job.objects.create(name="Bäcker/-in")
+    job_b = Job.objects.create(name="Kfz-Mechatroniker/-in")
+    unit_a = Unit.objects.create(title="Backofen")
+    unit_a.jobs.add(job_a)
+    unit_b = Unit.objects.create(title="Bremsen")
+    unit_b.jobs.add(job_b)
+    word = Word.objects.create(word="Schraubenzieher", singular_article=1)
+    _link(unit_a, word)
+    _link(unit_b, word)
+
+    resource = WordExportResource(for_profession=job_a)
+
+    assert resource.dehydrate_units(word) == "Backofen"
+
+
+@pytest.mark.django_db()
+def test_dehydrate_units_still_lists_multiple_units_of_the_same_job() -> None:
+    """A word in two units of the *same* exported job still shows both —
+    only cross-job leakage is what's being fixed here, not this (intentional,
+    see issue #531) same-job multi-unit case."""
+    job = Job.objects.create(name="Bäcker/-in")
+    unit_1 = Unit.objects.create(title="Backofen")
+    unit_1.jobs.add(job)
+    unit_2 = Unit.objects.create(title="Küchengeräte")
+    unit_2.jobs.add(job)
+    word = Word.objects.create(word="Ofenhandschuh", singular_article=1)
+    _link(unit_1, word)
+    _link(unit_2, word)
+
+    resource = WordExportResource(for_profession=job)
+
+    assert resource.dehydrate_units(word) == "Backofen | Küchengeräte"
+
+
+@pytest.mark.django_db()
+def test_dehydrate_units_without_a_profession_lists_all_units() -> None:
+    """Without a ``for_profession`` scope, every unit the word belongs to is
+    still listed — this is the pre-existing, unscoped fallback behaviour."""
+    job_a = Job.objects.create(name="Bäcker/-in")
+    job_b = Job.objects.create(name="Kfz-Mechatroniker/-in")
+    unit_a = Unit.objects.create(title="Backofen")
+    unit_a.jobs.add(job_a)
+    unit_b = Unit.objects.create(title="Bremsen")
+    unit_b.jobs.add(job_b)
+    word = Word.objects.create(word="Schraubenzieher", singular_article=1)
+    _link(unit_a, word)
+    _link(unit_b, word)
+
+    resource = WordExportResource()
+
+    assert resource.dehydrate_units(word) == "Backofen | Bremsen"

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -213,8 +213,12 @@ def user(db: None) -> User:
 
 
 def _job_words(job: Job) -> QuerySet[Word]:
-    """Return queryset of words imported into the given job."""
-    return Word.objects.filter(units__jobs=job)
+    """
+    Return queryset of words imported into the given job. ``distinct()`` is
+    required because a word linked to more than one unit of the same job
+    would otherwise join into more than one row.
+    """
+    return Word.objects.filter(units__jobs=job).distinct()
 
 
 @pytest.mark.django_db
@@ -292,21 +296,40 @@ def test_plural_article_dash_stored_as_none(job: Job, user: User) -> None:
 
 @pytest.mark.django_db
 def test_extra_export_columns_are_ignored(job: Job, user: User) -> None:
-    """Extra columns from the export (Word type, Has audio?, Creation date) don't cause errors."""
+    """Has audio? and Creation date are export-only metadata columns with no
+    matching field to import into — they must not cause errors."""
     ds = _make_dataset(
-        [
-            "Units",
-            "Word",
-            "Singular Article",
-            "Word type",
-            "Has audio?",
-            "Creation date",
-        ],
-        [["Werkzeug", "Hammer", "der", "noun", "No", "01.01.2026 10:00"]],
+        ["Units", "Word", "Singular Article", "Has audio?", "Creation date"],
+        [["Werkzeug", "Hammer", "der", "No", "01.01.2026 10:00"]],
     )
     _, _, errors, _ = import_words_from_csv(ds, job, user)
     assert errors == []
     assert _job_words(job).count() == 1
+
+
+@pytest.mark.django_db
+def test_word_type_column_is_imported(job: Job, user: User) -> None:
+    """Word type — previously silently dropped on re-import — is now stored."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Word type"],
+        [["Werkzeug", "Hammer", "der", "Nomen"]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    assert errors == []
+    assert _job_words(job).get(word="Hammer").word_type == "Nomen"
+
+
+@pytest.mark.django_db
+def test_unrecognised_word_type_defaults_to_empty(job: Job, user: User) -> None:
+    """An unrecognised word type value doesn't fail the row, just falls back
+    to the model default instead of being stored verbatim."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Word type"],
+        [["Werkzeug", "Hammer", "der", "not-a-real-type"]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    assert errors == []
+    assert _job_words(job).get(word="Hammer").word_type == ""
 
 
 @pytest.mark.django_db
@@ -373,3 +396,64 @@ def test_import_raises_if_user_has_no_group_and_is_not_superuser(
     )
     with pytest.raises(IndexError):
         import_words_from_csv(ds, job, orphan_user)
+
+
+# ---------------------------------------------------------------------------
+# Multi-unit words ("Units" column joined with " | ", see issue #738)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_pipe_separated_units_are_split_and_both_linked(job: Job, user: User) -> None:
+    """A word exported from two units of the same job (joined with " | " by
+    ``WordExportResource.dehydrate_units``) must re-import into *both* of
+    those units, not into one new unit literally named "A | B"."""
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["Werkzeuge | Baustelle", "Hammer", "der"]],
+    )
+    _, units_created, errors, _ = import_words_from_csv(ds, job, user)
+    assert errors == []
+    word = _job_words(job).get(word="Hammer")
+    assert set(word.units.values_list("title", flat=True)) == {
+        "Werkzeuge",
+        "Baustelle",
+    }
+    assert units_created == 2
+
+
+@pytest.mark.django_db
+def test_pipe_separated_units_tolerate_missing_spaces(job: Job, user: User) -> None:
+    """The split is lenient about whitespace around the "|" separator, not
+    just the exact " | " the exporter happens to produce."""
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["Werkzeuge|Baustelle", "Hammer", "der"]],
+    )
+    import_words_from_csv(ds, job, user)
+    word = _job_words(job).get(word="Hammer")
+    assert set(word.units.values_list("title", flat=True)) == {
+        "Werkzeuge",
+        "Baustelle",
+    }
+
+
+@pytest.mark.django_db
+def test_pipe_separated_units_reuse_the_row_cache(job: Job, user: User) -> None:
+    """Two rows naming the same multi-unit combination reuse the same two
+    units (via the ``created_units`` cache) instead of creating duplicates."""
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [
+            ["Werkzeuge | Baustelle", "Hammer", "der"],
+            ["Werkzeuge | Baustelle", "Säge", "die"],
+        ],
+    )
+    _, units_created, errors, _ = import_words_from_csv(ds, job, user)
+    assert errors == []
+    assert units_created == 2
+    hammer = _job_words(job).get(word="Hammer")
+    saege = _job_words(job).get(word="Säge")
+    assert set(hammer.units.values_list("pk", flat=True)) == set(
+        saege.units.values_list("pk", flat=True)
+    )

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -17,6 +17,7 @@ from lunes_cms.cmsv2.admins.word_import_resource import (
     _build_column_mapping,
     import_words_from_csv,
     map_plural_article_to_int,
+    map_word_type,
     parse_row,
     ParsedRow,
     RowResult,
@@ -45,10 +46,16 @@ def test_english_export_columns_are_mapped() -> None:
     mapping = _build_column_mapping()
     assert mapping["Units"] == "unit"
     assert mapping["Word"] == "word"
+    assert mapping["Word type"] == "word_type"
     assert mapping["Singular Article"] == "article"
     assert mapping["Plural"] == "plural"
     assert mapping["Plural Article"] == "plural_article"
     assert mapping["Example sentence"] == "example"
+
+
+def test_german_word_type_column_is_mapped() -> None:
+    """The German "Wortart" header produced by the exporter is recognised."""
+    assert _build_column_mapping()["Wortart"] == "word_type"
 
 
 def test_legacy_column_names_are_mapped() -> None:
@@ -84,6 +91,26 @@ def test_map_plural_article_to_int(value: str, expected: int | None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# map_word_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("Nomen", "Nomen"),
+        ("NOMEN", "Nomen"),
+        (" verb ", "Verb"),
+        ("", ""),
+        ("unknown", ""),
+        ("noun", ""),  # English label isn't a stored value, unlike Nomen
+    ],
+)
+def test_map_word_type(value: str, expected: str) -> None:
+    assert map_word_type(value) == expected
+
+
+# ---------------------------------------------------------------------------
 # parse_row
 # ---------------------------------------------------------------------------
 
@@ -112,6 +139,12 @@ def test_parse_row_parses_example_sentence() -> None:
     result = parse_row(_make_row(Beispielsatz="Der Hammer ist schwer."), 1)
     assert isinstance(result, ParsedRow)
     assert result.example == "Der Hammer ist schwer."
+
+
+def test_parse_row_parses_word_type() -> None:
+    result = parse_row(_make_row(Wortart="Nomen"), 1)
+    assert isinstance(result, ParsedRow)
+    assert result.word_type == "Nomen"
 
 
 def test_parse_row_english_column_names() -> None:

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -21,6 +21,7 @@ from lunes_cms.cmsv2.admins.word_import_resource import (
     parse_row,
     ParsedRow,
     RowResult,
+    validate_header_structure,
 )
 from lunes_cms.cmsv2.models import Word
 from lunes_cms.cmsv2.models.job import Job
@@ -66,6 +67,46 @@ def test_legacy_column_names_are_mapped() -> None:
     assert mapping["Fachbegriff"] == "word"
     assert mapping["Begriff"] == "word"
     assert mapping["Artikel"] == "article"
+
+
+# ---------------------------------------------------------------------------
+# validate_header_structure
+# ---------------------------------------------------------------------------
+
+
+def test_validate_header_structure_accepts_german_headers() -> None:
+    assert validate_header_structure(["Einheit", "Vokabel", "Artikel"]) is None
+
+
+def test_validate_header_structure_accepts_english_headers() -> None:
+    assert validate_header_structure(["Units", "Word", "Singular Article"]) is None
+
+
+def test_validate_header_structure_does_not_require_optional_columns() -> None:
+    """Article, plural, plural article, example sentence and word type all
+    have usable defaults — only unit and word are structurally required."""
+    assert validate_header_structure(["Einheit", "Vokabel"]) is None
+
+
+def test_validate_header_structure_rejects_missing_unit_column() -> None:
+    assert validate_header_structure(["Vokabel", "Artikel"]) is not None
+
+
+def test_validate_header_structure_rejects_missing_word_column() -> None:
+    error = validate_header_structure(["Einheit", "Artikel"])
+    assert error is not None
+
+
+def test_validate_header_structure_rejects_unrecognised_headers() -> None:
+    """A file whose header row matches none of the known columns at all
+    (e.g. a non-CSV text file tablib parsed as one giant header) is rejected."""
+    error = validate_header_structure(["this is not a csv file at all"])
+    assert error is not None
+
+
+def test_validate_header_structure_rejects_no_headers_at_all() -> None:
+    """A completely empty file (tablib reports ``headers=None``) is rejected."""
+    assert validate_header_structure(None) is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cmsv2/views/test_import_csv_view.py
+++ b/tests/cmsv2/views/test_import_csv_view.py
@@ -1,0 +1,77 @@
+"""
+Tests for the CSV import view's up-front validation: an empty file must
+notify the user that nothing was imported, and a file with the wrong header
+structure must be rejected with a clear format error, before any row-level
+processing happens.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import Client
+from django.urls import reverse
+
+from lunes_cms.cmsv2.models import Job, Word
+
+
+def _upload(content: str) -> SimpleUploadedFile:
+    return SimpleUploadedFile(
+        "vocabulary.csv", content.encode("utf-8"), content_type="text/csv"
+    )
+
+
+@pytest.fixture
+def job(db: None) -> Job:
+    return Job.objects.create(name="Test Job")
+
+
+@pytest.mark.django_db()
+def test_header_only_file_reports_no_entries(admin_client: Client, job: Job) -> None:
+    response = admin_client.post(
+        reverse("cmsv2:import_csv"),
+        {"job": job.pk, "csv_file": _upload("Einheit,Vokabel,Artikel\n")},
+        follow=True,
+    )
+
+    messages = [str(m) for m in response.context["messages"]]
+    assert any("no entries" in m.lower() for m in messages)
+    assert not Word.objects.filter(units__jobs=job).exists()
+
+
+@pytest.mark.django_db()
+def test_wrong_header_structure_is_rejected_before_any_row_processing(
+    admin_client: Client, job: Job
+) -> None:
+    """A file whose headers don't match the expected structure at all must
+    be rejected up front with a format error, not processed row by row."""
+    response = admin_client.post(
+        reverse("cmsv2:import_csv"),
+        {
+            "job": job.pk,
+            "csv_file": _upload(
+                "this is not a csv file at all\njust some random text\n"
+            ),
+        },
+        follow=True,
+    )
+
+    messages = [str(m) for m in response.context["messages"]]
+    assert any("not in the correct format" in m.lower() for m in messages)
+    assert not Word.objects.filter(units__jobs=job).exists()
+
+
+@pytest.mark.django_db()
+def test_valid_file_still_imports_successfully(admin_client: Client, job: Job) -> None:
+    response = admin_client.post(
+        reverse("cmsv2:import_csv"),
+        {
+            "job": job.pk,
+            "csv_file": _upload("Einheit,Vokabel,Artikel\nWerkzeug,Hammer,der\n"),
+        },
+        follow=True,
+    )
+
+    messages = [str(m) for m in response.context["messages"]]
+    assert any("import successful" in m.lower() for m in messages)
+    assert Word.objects.filter(units__jobs=job, word="Hammer").exists()


### PR DESCRIPTION
### Short description
There are some small issues for the csv import/export alignment that have to be fixed

### Proposed changes
<!-- Describe this PR in more detail. -->

- import missing attribute `word type`
- fix job export should not contain units from other jobs (see further information in how to test)
- fix import creates units with wrong names using `|` instead of creating them separatly
- add proper csv import validation for wrong csv format and empty csv

### How to test
<!-- Please describe how to test this PR -->

1. Fix export should not contain units from other jobs:
- Go to "jobs" (use "Elektroniker/-in"), select a job in the list and use the dropdown menu and select "Alle Vokabeln dieser Berufe als CSV exportieren 
- Check the word "Schere", the csv should only contain the unit "Grundlagen Werkzeuge" not "Grundlagen Rezeption". The latter is not related to a unit that is related to "Elektroniker:in". You can also check under "word" for "Schere" and see that there are two units related but only one that belongs to the job you exported
2. Import "word type"
- export a job or use the recently exported job and check if the words `word type` (Wortart)
- import the csv and check that the `word type` was also imported correctly (which was not the case before this pr)

3. fix import creates units with wrong names using | instead of creating them separatly
- Take your exported CSV from "Elektroniker:in
- If you check the csv in the column unit. There should be multiple units separated with a "|"
- Import the csv and check that each unit is created separately and the word is related correctly (f.e.
```csv
Werkzeugkiste,Nomen,die,,-,Ja,,27.05.2021 14:35,Kleben und Schreiben | Grundlagen Arbeitsmittel
```
- this should not anymore create a unit called `Kleben und Schreiben | Grundlagen Arbeitsmittel` but each unit separately

4. add proper csv import validation
- take your exported csv file and remove all entries except of the header
- import it
- you should get a warning that the file is empty
- take a random csv file that has not the correct file structure and import it
- you should get an error that the file format is not supported

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #738
