### PR TITLE
896: Fix breadcrumb parent category

### DIFF
--- a/lunes_cms/cms/admin.py
+++ b/lunes_cms/cms/admin.py
@@ -5,7 +5,10 @@ specify autocomplete_fields, search_fields and nested modules
 
 from __future__ import absolute_import, unicode_literals
 
+from typing import Any
+
 from django.contrib import admin
+from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from .admins import (
@@ -19,18 +22,21 @@ from .admins import (
 from .models import Discipline, Document, Feedback, GroupAPIKey, Sponsor, TrainingSet
 
 
-def get_app_list(self, request):
+def get_app_list(
+    self: admin.AdminSite, request: HttpRequest, app_label: str | None = None
+) -> list[dict[str, Any]]:
     """
     Function that returns a sorted list of all the installed apps that have been
     registered in this site.
 
     :param self: A handle to the :class:`admin.AdminSite`
-    :type self: class: `admin.AdminSite`
     :param request: current user request
-    :type request: django.http.request
+    :param app_label: restrict the list to a single app (see
+        :class:`admin.AdminSite`'s ``app_index`` view) - forwarding this is
+        required, or visiting an app's own index page (e.g. via a breadcrumb
+        link) crashes with a ``TypeError`` (issue #896).
 
     :return: list of app dictionaries (e.g. containing models)
-    :rtype: list
     """
     ordering = {
         _("disciplines").capitalize(): 1,
@@ -41,7 +47,7 @@ def get_app_list(self, request):
     }
 
     # pylint: disable=protected-access
-    app_dict = self._build_app_dict(request)
+    app_dict = self._build_app_dict(request, app_label)
 
     # Sort the apps alphabetically.
     app_list = sorted(app_dict.values(), key=lambda x: x["name"].lower())
@@ -55,7 +61,7 @@ def get_app_list(self, request):
     return app_list
 
 
-admin.AdminSite.get_app_list = get_app_list
+admin.AdminSite.get_app_list = get_app_list  # type: ignore[method-assign,assignment]
 admin.site.register(Discipline, DisciplineAdmin)
 admin.site.register(TrainingSet, TrainingSetAdmin)
 admin.site.register(Document, DocumentAdmin)

--- a/tests/cms/test_app_index.py
+++ b/tests/cms/test_app_index.py
@@ -1,0 +1,27 @@
+"""
+Tests for the admin's app-index breadcrumb links (issue #896).
+
+``lunes_cms.cms.admin`` monkey-patches ``AdminSite.get_app_list`` to apply a
+custom app/model ordering. Its signature didn't accept the ``app_label``
+argument Django's ``AdminSite.app_index`` view passes when rendering a
+single app's own index page (e.g. by following the "Vokabelverwaltung v2"
+breadcrumb link) — crashing with a ``TypeError`` that surfaced to users as a
+500 Server Error.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.parametrize("app_label", ["cmsv2", "cms", "auth"])
+@pytest.mark.django_db()
+def test_app_index_page_does_not_error(admin_client: Client, app_label: str) -> None:
+    """Following an app's breadcrumb link (its app-index page) must render,
+    not crash — this is exactly what a user does when clicking the parent
+    category in the breadcrumb trail."""
+    response = admin_client.get(reverse("admin:app_list", args=[app_label]))
+
+    assert response.status_code == 200


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently our breadcrumb navigation is broken on parent level

### Proposed changes
<!-- Describe this PR in more detail. -->

- add app_label parameter to fix breadcrumb

### How to test
<!-- Please describe how to test this PR -->

- see issue description


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #896
