### PR TITLE
918: Fix forbidden text numerals

### DIFF
--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -276,10 +276,16 @@ class WordAdmin(BaseAdmin):
         additional_info_html: _StrOrPromise = ""
         if with_additional_info:
             additional_info_html = format_html(
+                '<div class="regen-allow-text-row">'
+                '<label><input type="checkbox" class="regen-allow-text"> {}</label>'
+                "</div>"
                 '<div class="regen-additional-info-row">'
                 "<label>{} "
                 '<input type="text" class="regen-additional-info"></label>'
                 "</div>",
+                _(
+                    "Allow text/numbers in the image (e.g. for a receipt or a clock face)"
+                ),
                 _("Additional info (optional)"),
             )
 

--- a/lunes_cms/cmsv2/services/image_generation.py
+++ b/lunes_cms/cmsv2/services/image_generation.py
@@ -37,10 +37,16 @@ def build_image_prompt(
     unit_title: str | None = None,
     additional_info: str | None = None,
     job_title: str | None = None,
+    allow_text_in_image: bool = False,
 ) -> str:
     """
     Build the German image-generation prompt shared by the on-demand admin
     view and the background import drain.
+
+    Most vocabulary items look wrong with any text/numbers/logos in the
+    picture (issue #918), so that's banned by default. Some items (a receipt,
+    a clock face, a calendar) are inherently defined by the text/numbers on
+    them, so ``allow_text_in_image`` lets an editor lift the ban for those.
     """
     prompt = (
         f"Ein realistisches, professionelles Foto, das eindeutig zeigt: {word_text}."
@@ -55,10 +61,11 @@ def build_image_prompt(
     )
     if additional_info:
         prompt += f" Hinweise zur Bildgestaltung: {additional_info}."
-    prompt += (
-        " Das Bild enthält keinerlei Text, Buchstaben, Zahlen,"
-        " Beschriftungen, Untertitel oder Logos."
-    )
+    if not allow_text_in_image:
+        prompt += (
+            " Das Bild enthält keinerlei Text, Buchstaben, Zahlen,"
+            " Beschriftungen, Untertitel oder Logos."
+        )
     return prompt
 
 

--- a/lunes_cms/cmsv2/templates/admin/generate_image_base.html
+++ b/lunes_cms/cmsv2/templates/admin/generate_image_base.html
@@ -20,7 +20,14 @@
     <div class="module">
         {% block image_info %}{% endblock %}
 
-        <div style="margin-top: 16px; margin-bottom: 16px;">
+        <div style="margin-top: 16px;">
+            <label>
+                <input id="prompt-allow-text" type="checkbox">
+                {% translate "Allow text/numbers in the image (e.g. for a receipt or a clock face)" %}
+            </label>
+        </div>
+
+        <div style="margin-top: 8px; margin-bottom: 16px;">
             <label for="prompt-additional-info">
                <strong>Additional Info (optional):</strong>
             </label>

--- a/lunes_cms/cmsv2/views/generate_image.py
+++ b/lunes_cms/cmsv2/views/generate_image.py
@@ -14,6 +14,23 @@ from lunes_cms.cmsv2.utils import get_openai_client, OpenAIConfigurationError
 from lunes_cms.core import settings
 
 
+def _prompt_from_request(request: HttpRequest) -> str | None:
+    """
+    Builds the image-generation prompt from POST data, or None if the
+    required word text is missing.
+    """
+    word_text = request.POST.get("word_text")
+    if not word_text:
+        return None
+    return build_image_prompt(
+        word_text,
+        request.POST.get("unit_title"),
+        request.POST.get("additional_info"),
+        job_title=request.POST.get("job_title"),
+        allow_text_in_image=request.POST.get("allow_text_in_image") == "true",
+    )
+
+
 @staff_member_required
 @csrf_exempt
 @require_POST
@@ -23,16 +40,9 @@ def generate_image_via_openai(request: HttpRequest) -> JsonResponse:
     Returns the URL/path to the temporary file.
     """
 
-    word_text = request.POST.get("word_text")
-    if not word_text:
+    prompt = _prompt_from_request(request)
+    if prompt is None:
         return JsonResponse({"error": "No word_text provided."}, status=400)
-    additional_info = request.POST.get("additional_info")
-    unit_title = request.POST.get("unit_title")
-    job_title = request.POST.get("job_title")
-
-    prompt = build_image_prompt(
-        word_text, unit_title, additional_info, job_title=job_title
-    )
 
     try:
         client = get_openai_client()

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -841,6 +841,11 @@ msgstr "Beispielsatz"
 msgid "Will be spoken:"
 msgstr "Gesprochen wird:"
 
+#: cmsv2/admins/word_admin.py cmsv2/templates/admin/generate_image_base.html
+msgid "Allow text/numbers in the image (e.g. for a receipt or a clock face)"
+msgstr ""
+"Text/Zahlen im Bild erlauben (z. B. für eine Rechnung oder ein Zifferblatt)"
+
 #: cmsv2/admins/word_admin.py
 msgid "Additional info (optional)"
 msgstr "Zusätzliche Infos (optional)"

--- a/lunes_cms/src/generate_image.ts
+++ b/lunes_cms/src/generate_image.ts
@@ -43,6 +43,8 @@ window.initImageGenerator = function (config: ImageGeneratorConfig): void {
 
         const inputElement = document.getElementById("prompt-additional-info") as HTMLInputElement
         formData.append("additional_info", inputElement.value)
+        const allowTextElement = document.getElementById("prompt-allow-text") as HTMLInputElement
+        formData.append("allow_text_in_image", allowTextElement.checked ? "true" : "false")
         formData.append("csrfmiddlewaretoken", window.getCookie("csrftoken") ?? "")
 
         fetch(config.generateUrl, {

--- a/lunes_cms/src/inline_regenerate.ts
+++ b/lunes_cms/src/inline_regenerate.ts
@@ -37,6 +37,7 @@ function _initRegenerateWidget(widget: HTMLElement): void {
     const newPreview = widget.querySelector<HTMLElement>(".regen-new-preview")
     const decision = widget.querySelector<HTMLElement>(".regen-decision")
     const additionalInfo = widget.querySelector<HTMLInputElement>(".regen-additional-info")
+    const allowText = widget.querySelector<HTMLInputElement>(".regen-allow-text")
 
     if (!generateButton || !keepButton || !discardButton || !newEmpty || !newPreview || !decision) {
         return
@@ -96,6 +97,9 @@ function _initRegenerateWidget(widget: HTMLElement): void {
         formData.append(textField, textValue)
         if (assetType === "image" && additionalInfo) {
             formData.append("additional_info", additionalInfo.value)
+        }
+        if (assetType === "image" && allowText) {
+            formData.append("allow_text_in_image", allowText.checked ? "true" : "false")
         }
         formData.append("csrfmiddlewaretoken", window.getCookie("csrftoken") ?? "")
 

--- a/lunes_cms/static/css/asset_manager.css
+++ b/lunes_cms/static/css/asset_manager.css
@@ -206,6 +206,10 @@
     opacity: 0.85;
 }
 
+.regen-allow-text-row {
+    margin: 8px 0 0;
+}
+
 .regen-additional-info-row {
     margin: 8px 0;
 }

--- a/tests/cmsv2/services/test_image_generation.py
+++ b/tests/cmsv2/services/test_image_generation.py
@@ -237,6 +237,20 @@ def test_build_image_prompt_includes_word_and_optional_hints() -> None:
     assert "Tischler/in" in enriched
 
 
+def test_build_image_prompt_bans_text_by_default() -> None:
+    prompt = image_generation.build_image_prompt("Rechnung")
+
+    assert "keinerlei Text" in prompt
+
+
+def test_build_image_prompt_allows_text_when_requested() -> None:
+    """Issue #918: items like a receipt need text/numbers to look right."""
+    prompt = image_generation.build_image_prompt("Rechnung", allow_text_in_image=True)
+
+    assert "keinerlei Text" not in prompt
+    assert "Rechnung" in prompt
+
+
 @pytest.mark.django_db(transaction=True)
 def test_drain_passes_job_title_to_image_generation(fast_worker: None) -> None:
     imported = _make_word(word="Hammer")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
To allow for specific vocabulary to have texts and literals in the picture, i had to add an additional checkbox
Mind. This won't work for auto generation but has to be triggered manually with checked checkbox

### Proposed changes
<!-- Describe this PR in more detail. -->

- add checkbox to allow text and numerals


### How to test
<!-- Please describe how to test this PR -->

- add a word f.e. "die Rechnung"
- go to image section and set the checkbox allow text/numers and generate the image. See an image with numbers and text
- uncheck the checkbox and try again, see empty invoice


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #918
