### PR TITLE
917: Fix example sentence checked default

### DIFF
--- a/lunes_cms/cmsv2/migrations/0028_backfill_null_check_status.py
+++ b/lunes_cms/cmsv2/migrations/0028_backfill_null_check_status.py
@@ -1,0 +1,50 @@
+from django.db import migrations
+
+
+# pylint: disable=unused-argument
+def backfill_not_checked(apps, schema_editor):
+    """
+    Existing rows may have a check-status column left as NULL (e.g. words
+    imported before issue #917 was fixed). The admin's check-status dropdown
+    has no option for NULL, so it silently falls back to displaying its
+    first choice ("Confirmed") - fix this by making the "nothing to check
+    yet" state explicit as NOT_CHECKED everywhere.
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    Word = apps.get_model("cmsv2", "Word")
+    UnitWordRelation = apps.get_model("cmsv2", "UnitWordRelation")
+
+    Word.objects.filter(audio_check_status__isnull=True).update(
+        audio_check_status="NOT_CHECKED"
+    )
+    Word.objects.filter(image_check_status__isnull=True).update(
+        image_check_status="NOT_CHECKED"
+    )
+    Word.objects.filter(example_sentence_check_status__isnull=True).update(
+        example_sentence_check_status="NOT_CHECKED"
+    )
+    UnitWordRelation.objects.filter(image_check_status__isnull=True).update(
+        image_check_status="NOT_CHECKED"
+    )
+    UnitWordRelation.objects.filter(example_sentence_check_status__isnull=True).update(
+        example_sentence_check_status="NOT_CHECKED"
+    )
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file to backfill NULL check-status columns with NOT_CHECKED.
+    """
+
+    dependencies = [
+        ("cmsv2", "0027_remove_word_additional_meaning_1_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_not_checked, migrations.RunPython.noop),
+    ]

--- a/lunes_cms/cmsv2/migrations/0029_backfill_null_check_status.py
+++ b/lunes_cms/cmsv2/migrations/0029_backfill_null_check_status.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ("cmsv2", "0027_remove_word_additional_meaning_1_and_more"),
+        ("cmsv2", "0028_word_pronunciation"),
     ]
 
     operations = [

--- a/lunes_cms/cmsv2/models/unit.py
+++ b/lunes_cms/cmsv2/models/unit.py
@@ -97,10 +97,10 @@ class UnitWordRelation(models.Model):
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         """
-        Override the save method to handle image check status.
+        Override the save method to handle image and example sentence check status.
 
-        This method ensures that when an image is updated, its check status is set to
-        "NOT_CHECKED", and when an image is removed, its check status is set to None.
+        This method ensures that when an image or example sentence is
+        updated or removed, its check status is (re)set to "NOT_CHECKED".
         """
         previous_relation = (
             UnitWordRelation.objects.get(pk=self.pk) if self.pk else None
@@ -129,10 +129,10 @@ class UnitWordRelation(models.Model):
             self.image_check_status = CheckStatus.NOT_CHECKED
 
         if not self.image:
-            self.image_check_status = None
+            self.image_check_status = CheckStatus.NOT_CHECKED
 
         if not self.example_sentence or not self.example_sentence.strip():
-            self.example_sentence_check_status = None
+            self.example_sentence_check_status = CheckStatus.NOT_CHECKED
 
         super().save(*args, **kwargs)
         if image_updated and convert_image_to_webp(self.image):

--- a/lunes_cms/cmsv2/models/word.py
+++ b/lunes_cms/cmsv2/models/word.py
@@ -245,7 +245,7 @@ class Word(models.Model):
             self.audio_check_status = CheckStatus.NOT_CHECKED
             self.audio_checked_identifier = self.assemble_audio_checked_identifier()
         if not self.audio:
-            self.audio_check_status = None
+            self.audio_check_status = CheckStatus.NOT_CHECKED
             self.audio_checked_identifier = None
         elif (
             previous_word
@@ -257,7 +257,7 @@ class Word(models.Model):
         if image_updated:
             self.image_check_status = CheckStatus.NOT_CHECKED
         if not self.image:
-            self.image_check_status = None
+            self.image_check_status = CheckStatus.NOT_CHECKED
 
     def _handle_example_sentence_change(self, previous_word: "Word | None") -> None:
         example_sentence_changed = bool(
@@ -272,7 +272,7 @@ class Word(models.Model):
                 self.example_sentence_audio = None
             self.example_sentence_check_status = CheckStatus.NOT_CHECKED
         if not self.example_sentence or not self.example_sentence.strip():
-            self.example_sentence_check_status = None
+            self.example_sentence_check_status = CheckStatus.NOT_CHECKED
 
     def _pronunciation_changed(self, previous_word: "Word | None") -> bool:
         return bool(

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -288,6 +288,26 @@ def test_reimport_with_english_headers(job: Job, user: User) -> None:
 
 
 @pytest.mark.django_db
+def test_imported_word_with_example_sentence_is_not_checked(
+    job: Job, user: User
+) -> None:
+    """Issue #917: a word imported with an example sentence must not appear
+    pre-confirmed — its example_sentence_check_status must persist as
+    NOT_CHECKED, matching the default a manually created word gets."""
+    ds = _make_dataset(
+        ["Units", "Word", "Singular Article", "Example sentence"],
+        [["Werkzeug", "Hammer", "der", "Der Hammer ist schwer."]],
+    )
+    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    assert errors == []
+    word = _job_words(job).get(word="Hammer")
+    assert word.example_sentence == "Der Hammer ist schwer."
+    assert word.example_sentence_check_status == "NOT_CHECKED"
+    assert word.audio_check_status == "NOT_CHECKED"
+    assert word.image_check_status == "NOT_CHECKED"
+
+
+@pytest.mark.django_db
 def test_reimport_with_german_headers(job: Job, user: User) -> None:
     """Re-import of a CSV exported with German admin locale works (issue #775)."""
     ds = _make_dataset(

--- a/tests/cmsv2/models/test_word.py
+++ b/tests/cmsv2/models/test_word.py
@@ -1,0 +1,38 @@
+"""
+Tests for Word.save()'s check-status bookkeeping (issue #917).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lunes_cms.cmsv2.models import Word
+
+
+@pytest.mark.django_db
+def test_new_word_without_assets_defaults_to_not_checked_everywhere() -> None:
+    """A freshly created word with no audio, image or example sentence must
+    report NOT_CHECKED (not None) for all three check statuses, so the admin
+    dropdown never silently falls back to displaying "Confirmed"."""
+    word = Word.objects.create(word="Hammer", singular_article=1)
+    assert word.audio_check_status == "NOT_CHECKED"
+    assert word.image_check_status == "NOT_CHECKED"
+    assert word.example_sentence_check_status == "NOT_CHECKED"
+
+
+@pytest.mark.django_db
+def test_unrelated_save_does_not_reset_confirmed_example_sentence_status() -> None:
+    """Saving a word again without touching its example sentence or audio
+    must not disturb a manually confirmed check status."""
+    word = Word.objects.create(
+        word="Hammer", singular_article=1, example_sentence="Der Hammer ist schwer."
+    )
+    word.example_sentence_check_status = "CONFIRMED"
+    word.save()
+
+    word.plural = "Hämmer"
+    word.save()
+
+    word.refresh_from_db()
+    assert word.example_sentence_check_status == "CONFIRMED"
+    assert word.plural == "Hämmer"

--- a/tests/cmsv2/models/test_word_pronunciation.py
+++ b/tests/cmsv2/models/test_word_pronunciation.py
@@ -80,8 +80,8 @@ def test_pronunciation_change_does_not_invent_a_status_without_audio() -> None:
     word.save()
 
     word.refresh_from_db()
-    assert word.audio_check_status is None
-    assert word.example_sentence_check_status is None
+    assert word.audio_check_status == CheckStatus.NOT_CHECKED
+    assert word.example_sentence_check_status == CheckStatus.NOT_CHECKED
 
 
 @pytest.mark.django_db()
@@ -94,7 +94,7 @@ def test_pronunciation_change_respects_the_no_sentence_no_status_rule() -> None:
     word.save()
 
     word.refresh_from_db()
-    assert word.example_sentence_check_status is None
+    assert word.example_sentence_check_status == CheckStatus.NOT_CHECKED
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently we have the issue that a new created word, sets the check status (image, sentence, audio) to `null`
In the frontend the checkbox uses for a null value the first option that exists (which is `checked`)
That indicates the user the word is checked even its not set (in the database)

### Proposed changes
<!-- Describe this PR in more detail. -->

- set default to `not_checked`
- run migration to fix possible `null` values in the database to set also `not_checked`


### How to test
<!-- Please describe how to test this PR -->

- Create a vocabulary or import via csv and save it without changing the check status anywhere
- the check status should be "not checked" not "checked" (as before)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #917 
