### PR TITLE
Install syft

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,9 @@ jobs:
                       --repo "${CIRCLE_PROJECT_REPONAME}"
                 name: Upload package to GitHub release
             - run:
+                command: curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
+                name: Install syft
+            - run:
                 command: |
                     npx --no app-toolbelt v0 generate sbom \
                       --version-name "${NEW_VERSION}" \

--- a/.circleci/src/jobs/create-release.yml
+++ b/.circleci/src/jobs/create-release.yml
@@ -30,6 +30,9 @@ steps:
           --owner "${CIRCLE_PROJECT_USERNAME}" \
           --repo "${CIRCLE_PROJECT_REPONAME}"
   - run:
+      name: Install syft
+      command: curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
+  - run:
       name: Generate SBOM
       command: |
         npx --no app-toolbelt v0 generate sbom \


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This should fix the build where the installation of syft failed
https://app.circleci.com/pipelines/gh/digitalfabrik/lunes-cms/2476/details?useNewPipelines=true&job=dd1e24ca-4928-42c9-a5b9-4cd4d97b78e5&workflowId=77baf16e-a776-4816-8119-5676706aa20c&buildNumber=25045&jobType=build#step-107-


Compare [integreat-app](https://github.com/digitalfabrik/integreat-app/blob/main/.circleci/src/commands/generate_sbom.yml)

Installing on my local Docker worked
<img width="474" height="260" alt="image" src="https://github.com/user-attachments/assets/e2c94297-7a9c-4ffd-bfd3-4a3d90aec7ff" />
