### PR TITLE
fix: improve word list section headings

### DIFF
--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from django.contrib import admin
 from django.urls import reverse
+from django.utils.functional import lazy
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe, SafeString
 from django.utils.translation import gettext_lazy as _
@@ -31,6 +32,8 @@ if TYPE_CHECKING:
     # `_StrOrPromise` only exists in django-stubs, not at runtime.
     from django.utils.functional import _StrOrPromise
 
+_format_html_lazy = lazy(format_html, SafeString)
+
 
 class AlternativeWordInline(admin.TabularInline):
     """
@@ -43,7 +46,7 @@ class AlternativeWordInline(admin.TabularInline):
     extra = 1
     can_delete = False
     verbose_name = _("alternative word")
-    verbose_name_plural = _("So heißt das auch")
+    verbose_name_plural = _format_html_lazy("<h2>{}</h2>", _("Alternative Words"))
     fields = [
         "grammatical_gender",
         "singular_article",
@@ -96,6 +99,7 @@ class UnitInline(admin.TabularInline):
     """
 
     model = UnitWordRelation
+    verbose_name_plural = _format_html_lazy("<h2>{}</h2>", _("Unit-Word Relations"))
     extra = 1
     autocomplete_fields = ["unit"]
     fields = [

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -128,7 +128,7 @@ class WordAdmin(BaseAdmin):
 
     fieldsets = (
         (
-            _("Word Information"),
+            _format_html_lazy("<h2>{}</h2>", _("Word Information")),
             {
                 "fields": (
                     "word_type",
@@ -142,11 +142,11 @@ class WordAdmin(BaseAdmin):
             },
         ),
         (
-            _("Pronunciation"),
+            _format_html_lazy("<h2>{}</h2>", _("Pronunciation")),
             {"fields": ("pronunciation",)},
         ),
         (
-            _("Audio"),
+            _format_html_lazy("<h2>{}</h2>", _("Audio")),
             {
                 "fields": (
                     "audio",
@@ -157,7 +157,7 @@ class WordAdmin(BaseAdmin):
             },
         ),
         (
-            _("Image"),
+            _format_html_lazy("<h2>{}</h2>", _("Image")),
             {
                 "fields": (
                     "image",
@@ -168,7 +168,7 @@ class WordAdmin(BaseAdmin):
             },
         ),
         (
-            _("Example Sentence"),
+            _format_html_lazy("<h2>{}</h2>", _("Example Sentence")),
             {
                 "fields": (
                     "example_sentence",

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -802,7 +802,7 @@ msgid "assigned units"
 msgstr "Zugewiesene Einheiten"
 
 #: cmsv2/admins/word_admin.py
-msgid "So heißt das auch"
+msgid "Alternative Words"
 msgstr "So heißt das auch"
 
 #: cmsv2/admins/word_admin.py
@@ -816,6 +816,10 @@ msgstr "Alternatives Wort speichern"
 #: cmsv2/admins/word_admin.py
 msgid "Delete alternative word"
 msgstr "Alternatives Wort löschen"
+
+#: cmsv2/admins/word_admin.py cmsv2/models/unit.py
+msgid "Unit-Word Relations"
+msgstr "Einheit-Wort Beziehungen"
 
 #: cmsv2/admins/word_admin.py
 msgid "Word Information"
@@ -1147,10 +1151,6 @@ msgstr "Beispielsatz generieren"
 #: cmsv2/models/unit.py
 msgid "Unit-Word Relation"
 msgstr "Einheit-Wort Beziehung"
-
-#: cmsv2/models/unit.py
-msgid "Unit-Word Relations"
-msgstr "Einheit-Wort Beziehungen"
 
 #: cmsv2/models/unit.py
 msgid "Unit"

--- a/tests/cmsv2/test_alternative_word.py
+++ b/tests/cmsv2/test_alternative_word.py
@@ -1,6 +1,6 @@
 """
 Tests for alternative words (issue #573): serialization in the v2 API
-and the "So heißt das auch" inline on the word admin page.
+and the alternative-word inline on the word admin page.
 """
 
 from __future__ import annotations
@@ -64,7 +64,8 @@ def test_word_admin_page_shows_alternative_words_section(
     response = admin_client.get(f"/en/admin/cmsv2/word/{word.pk}/change/")
     assert response.status_code == 200
     content = response.content.decode()
-    assert "So heißt das auch" in content
+    assert "<h2>Alternative Words</h2>" in content
+    assert "<h2>Unit-Word Relations</h2>" in content
     assert "Semmel" in content
     assert "Miscellaneous" not in content
     assert "save-alternative-word-btn" in content

--- a/tests/cmsv2/test_alternative_word.py
+++ b/tests/cmsv2/test_alternative_word.py
@@ -64,8 +64,16 @@ def test_word_admin_page_shows_alternative_words_section(
     response = admin_client.get(f"/en/admin/cmsv2/word/{word.pk}/change/")
     assert response.status_code == 200
     content = response.content.decode()
-    assert "<h2>Alternative Words</h2>" in content
-    assert "<h2>Unit-Word Relations</h2>" in content
+    for heading in (
+        "Word Information",
+        "Pronunciation",
+        "Audio",
+        "Image",
+        "Example Sentence",
+        "Alternative Words",
+        "Unit-Word Relations",
+    ):
+        assert f"<h2>{heading}</h2>" in content
     assert "Semmel" in content
     assert "Miscellaneous" not in content
     assert "save-alternative-word-btn" in content


### PR DESCRIPTION
### Short description

Make the word edit page inline sections use consistent semantic headings and provide an English source label for alternative words.

### Proposed changes

- Render Alternative Words and Unit-Word Relations as second-level headings.
- Preserve the German So heißt das auch translation while using an English source label.
- Extend the admin page regression test to cover both headings.

### How to test

- Run: LUNES_CMS_DB_BACKEND=sqlite LUNES_CMS_SECRET_KEY=test-key pytest --ds=lunes_cms.core.settings tests/cmsv2/test_alternative_word.py -q
- Open a word change page and verify both inline section headings in English and German.

### Resolved issues

Fixes: #949