### PR TITLE
Show a friendly error for non-UTF-8 CSV uploads

### DIFF
--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -126,7 +126,7 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
     selected_job = form.cleaned_data["job"]
     try:
         data = Dataset()
-        data.load(csv_file.read().decode("utf-8"), format="csv")
+        data.load(csv_file.read().decode("utf-8-sig"), format="csv")
 
         if _report_dataset_issue(request, data):
             return render(

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -34,7 +34,8 @@ class ImportCSVForm(forms.Form):
     csv_file = forms.FileField(
         label=_("Select CSV file"),
         help_text=_(
-            'The file should contain the columns "Einheit", "Artikel", "Vokabel" '
+            "The file must be UTF-8 encoded and comma-separated. It should "
+            'contain the columns "Einheit", "Artikel", "Vokabel" '
             'and "Beispielsatz", optionally also "Aussprache".'
         ),
     )
@@ -176,6 +177,16 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
             request,
             _(
                 "Import failed. The size of the column or row doesn't fit the table dimensions. Please adjust your table and try again."
+            ),
+        )
+        return render(
+            request, "admin/csv_form.html", _build_context(request, form, job, job_id)
+        )
+    except UnicodeDecodeError:
+        messages.error(
+            request,
+            _(
+                "Import failed. The CSV file must be UTF-8 encoded. Please save it with UTF-8 encoding and try again."
             ),
         )
         return render(

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -1242,11 +1242,13 @@ msgstr "CSV Datei auswählen"
 
 #: cmsv2/views/import_csv_view.py
 msgid ""
-"The file should contain the columns \"Einheit\", \"Artikel\", \"Vokabel\" "
-"and \"Beispielsatz\", optionally also \"Aussprache\"."
+"The file must be UTF-8 encoded and comma-separated. It should contain the "
+"columns \"Einheit\", \"Artikel\", \"Vokabel\" and \"Beispielsatz\", "
+"optionally also \"Aussprache\"."
 msgstr ""
-"Die Datei sollte die Spalten \"Einheit\", \"Artikel\", \"Vokabel\" und "
-"\"Beispielsatz\" enthalten, optional zusätzlich \"Aussprache\"."
+"Die Datei muss UTF-8-kodiert und kommagetrennt sein. Sie sollte die Spalten "
+"\"Einheit\", \"Artikel\", \"Vokabel\" und \"Beispielsatz\" enthalten, "
+"optional zusätzlich \"Aussprache\"."
 
 #: cmsv2/views/import_csv_view.py
 #, python-format
@@ -1292,6 +1294,14 @@ msgid ""
 msgstr ""
 "Der Import ist fehlgeschlagen. Die Anzahl der Spalten oder Zeilen passen "
 "nicht zur Tabelle. Bitte passe die Tabelle an und versuche es erneut."
+
+#: cmsv2/views/import_csv_view.py
+msgid ""
+"Import failed. The CSV file must be UTF-8 encoded. Please save it with UTF-8 "
+"encoding and try again."
+msgstr ""
+"Der Import ist fehlgeschlagen. Die CSV-Datei muss UTF-8-kodiert sein. Bitte "
+"speichere sie im Format UTF-8 und versuche es erneut."
 
 #: cmsv2/views/import_csv_view.py
 #, python-format

--- a/tests/cmsv2/views/test_import_csv_view.py
+++ b/tests/cmsv2/views/test_import_csv_view.py
@@ -62,6 +62,30 @@ def test_wrong_header_structure_is_rejected_before_any_row_processing(
 
 
 @pytest.mark.django_db()
+def test_non_utf8_file_shows_friendly_encoding_error(
+    admin_client: Client, job: Job
+) -> None:
+    """A CSV file that isn't UTF-8 encoded must show a friendly message
+    telling the user to save it as UTF-8, not the raw Python decoding
+    error."""
+    non_utf8_csv = SimpleUploadedFile(
+        "vocabulary.csv",
+        "Einheit,Vokabel,Artikel\nWerkzeug,Hämmer,der\n".encode("latin-1"),
+        content_type="text/csv",
+    )
+    response = admin_client.post(
+        reverse("cmsv2:import_csv"),
+        {"job": job.pk, "csv_file": non_utf8_csv},
+        follow=True,
+    )
+
+    messages = [str(m) for m in response.context["messages"]]
+    assert any("utf-8" in m.lower() for m in messages)
+    assert not any("codec can't decode" in m.lower() for m in messages)
+    assert not Word.objects.filter(units__jobs=job).exists()
+
+
+@pytest.mark.django_db()
 def test_valid_file_still_imports_successfully(admin_client: Client, job: Job) -> None:
     response = admin_client.post(
         reverse("cmsv2:import_csv"),


### PR DESCRIPTION
### Short description
Shows a friendly error message when a CSV upload isn't UTF-8 encoded, instead of leaking the raw Python decode error.

### Proposed changes
Added a specific except UnicodeDecodeError: handler in import_from_csv, placed before the generic except (AttributeError, IndexError, TypeError, ValueError) as e: handler (UnicodeDecodeError is a subclass of ValueError and was being swallowed by it), showing a friendly message telling the user the file must be UTF-8 encoded.

Updated the CSV upload form's help text to mention the file must be UTF-8 encoded and comma-separated, per the issue's additional hint.

Added a test that uploads a CSV encoded in latin-1 and checks the friendly message appears and the raw "codec can't decode" text does not.

### How to test
Go to the CSV import page and upload a CSV file saved with a non-UTF-8 encoding (e.g. latin-1 or Windows-1252). Confirm the message says the file must be UTF-8 encoded instead of showing a raw Python error. Also run pytest tests/cmsv2/views/test_import_csv_view.py.

### Resolved issues

Fixes: #895
