### PR TITLE
Fix: Recreate the CI venv when the cached interpreter is broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,10 @@ commands:
         steps:
             - run:
                 command: |
-                    if [[ -d ".venv" ]]; then
+                    if [[ -x ".venv/bin/python" ]]; then
                       echo "Virtual environment restored from cache, skipping dependency install"
                     else
+                      rm -rf .venv
                       uv sync --extra dev --locked
                     fi
                     # The cache key only depends on uv.lock, so a restored .venv can be

--- a/.circleci/src/commands/sync-venv.yml
+++ b/.circleci/src/commands/sync-venv.yml
@@ -6,9 +6,10 @@ steps:
   - run:
       name: Creating virtual environment
       command: |
-        if [[ -d ".venv" ]]; then
+        if [[ -x ".venv/bin/python" ]]; then
           echo "Virtual environment restored from cache, skipping dependency install"
         else
+          rm -rf .venv
           uv sync --extra dev --locked
         fi
         # The cache key only depends on uv.lock, so a restored .venv can be


### PR DESCRIPTION
A cached .venv is restored by its uv.lock checksum alone, so it survives CI image updates. After a new Python patch release in cimg/python:3.11, .venv/bin/python3 is left as a broken symlink, the directory check still passes and every following uv command aborts with "Failed to inspect Python interpreter from virtual environment". Check the interpreter instead of the directory and rebuild the venv if it no longer works.