### PR TITLE
Hide 'Add another' link for alternative words on the change page

### DIFF
--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -63,11 +63,12 @@ class AlternativeWordInline(admin.TabularInline):
         self, request: HttpRequest, obj: Word | None = None, **kwargs: Any
     ) -> int | None:
         """
-        Limit the formset to the existing rows plus one empty row on the
-        change page, so Django hides its "Add another" link there. New rows
-        are added instantly via the "+" button instead, which reloads the
-        page with a fresh empty row. On the add page (no ``obj``), the
-        default is kept so multiple rows can be added before the first save.
+        Limit the formset to the existing rows plus the ``extra`` empty rows
+        on the change page, so Django hides its "Add another" link there.
+        New rows are added instantly via the "+" button instead, which
+        reloads the page with a fresh empty row. On the add page (no
+        ``obj``), the default is kept so multiple rows can be added before
+        the first save.
 
         Args:
             request: The current request
@@ -77,7 +78,7 @@ class AlternativeWordInline(admin.TabularInline):
             int or None: The maximum number of forms in the formset
         """
         if obj:
-            return obj.alternative_words.count() + 1
+            return obj.alternative_words.count() + self.extra
         return super().get_max_num(request, obj, **kwargs)
 
     def get_fields(self, request: HttpRequest, obj: Word | None = None) -> _FieldGroups:

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, annotations, unicode_literals
 
 from datetime import date
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from django.contrib import admin
 from django.http import HttpRequest
@@ -58,6 +58,27 @@ class AlternativeWordInline(admin.TabularInline):
         "action_buttons",
     ]
     readonly_fields = ["action_buttons"]
+
+    def get_max_num(
+        self, request: HttpRequest, obj: Word | None = None, **kwargs: Any
+    ) -> int | None:
+        """
+        Limit the formset to the existing rows plus one empty row on the
+        change page, so Django hides its "Add another" link there. New rows
+        are added instantly via the "+" button instead, which reloads the
+        page with a fresh empty row. On the add page (no ``obj``), the
+        default is kept so multiple rows can be added before the first save.
+
+        Args:
+            request: The current request
+            obj: The word object, or None on the add page
+
+        Returns:
+            int or None: The maximum number of forms in the formset
+        """
+        if obj:
+            return obj.alternative_words.count() + 1
+        return super().get_max_num(request, obj, **kwargs)
 
     def get_fields(self, request: HttpRequest, obj: Word | None = None) -> _FieldGroups:
         """

--- a/tests/cmsv2/test_alternative_word.py
+++ b/tests/cmsv2/test_alternative_word.py
@@ -197,6 +197,36 @@ def test_word_admin_page_shows_alternative_words_section(
 
 
 @pytest.mark.django_db
+def test_word_change_page_hides_add_another_row(
+    word: Word, admin_client: Client
+) -> None:
+    """On the change page, the formset is capped at the existing rows plus one
+    empty row, so Django's "Add another" link is not rendered — new rows are
+    added instantly via the "+" button instead."""
+    response = admin_client.get(f"/en/admin/cmsv2/word/{word.pk}/change/")
+    formset = next(
+        inline.formset
+        for inline in response.context["inline_admin_formsets"]
+        if inline.formset.prefix == "alternative_words"
+    )
+    assert formset.max_num == 2
+    assert formset.total_form_count() == 2
+
+
+@pytest.mark.django_db
+def test_word_add_page_keeps_add_another_row(admin_client: Client) -> None:
+    """On the add page, the formset is not capped, so multiple alternative
+    words can be added before the word is saved for the first time."""
+    response = admin_client.get("/en/admin/cmsv2/word/add/")
+    formset = next(
+        inline.formset
+        for inline in response.context["inline_admin_formsets"]
+        if inline.formset.prefix == "alternative_words"
+    )
+    assert formset.max_num > formset.total_form_count()
+
+
+@pytest.mark.django_db
 def test_delete_alternative_word(word: Word, admin_client: Client) -> None:
     """The delete view removes the alternative word."""
     alternative_word = word.alternative_words.get()


### PR DESCRIPTION
### Short description

Follow-up to #915: removes the confusing "Add another Alternative word" link on the word change page, reported in https://github.com/digitalfabrik/lunes-cms/pull/915#issuecomment-5321446978.

### Proposed changes

- Cap the alternative words formset on the change page at the existing rows plus one empty row, so Django hides its default "Add another" link — rows added through it were only saved via the central save button, conflicting with the instant + / ✓ / × workflow
- The add page keeps the default behavior, since the instant actions are not available before the word exists
- Two new tests for the formset cap

### How to test

- Open a word (`/de/admin/cmsv2/word/<id>/change/`): no "Add another" link under „So heißt das auch", one empty row — fill it and click **+**, it saves instantly and a fresh empty row appears
- Open `/de/admin/cmsv2/word/add/`: the "Add another" link is still there and rows are saved with the central save button

### Resolved issues

Follow-up to #915 (no separate issue)

### AI usage

Created by Claude Fable 5 (Claude Code), reviewed by @qaiser42.