### PR TITLE
948: import words into existing units

### DIFF
--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -252,7 +252,9 @@ def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
             )
 
         unknown_keys = {
-            k.strip() for k in raw_row.keys() if k and not column_mapping.get(k.strip())
+            key.strip()
+            for key in raw_row.keys()
+            if key and not column_mapping.get(key.strip().lower())
         }
         if unknown_keys:
             logger.info(

--- a/lunes_cms/cmsv2/admins/word_import_resource.py
+++ b/lunes_cms/cmsv2/admins/word_import_resource.py
@@ -1,12 +1,20 @@
 import logging
-from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Dict, Optional, TYPE_CHECKING
 
 from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
-from ..models import Job, PluralArticle, SingularArticle, Unit, Word, WordType
+from ..models import (
+    Job,
+    PluralArticle,
+    SingularArticle,
+    Unit,
+    UnitWordRelation,
+    Word,
+    WordType,
+)
 
 if TYPE_CHECKING:
     from django.utils.functional import _StrOrPromise
@@ -63,6 +71,10 @@ def _lowered_column_mapping() -> dict[str, str]:
 #: has a usable default and doesn't need to be filled in.
 REQUIRED_FIELDS = ("unit", "word")
 
+#: The row the column headers occupy. The dataset's rows start below it, and
+#: error messages count from the file so they name the row the editor sees.
+HEADER_ROW = 1
+
 
 def validate_header_structure(
     headers: Optional[list[str]],
@@ -116,10 +128,23 @@ class RowResult:
     Return object of a single row.
     """
 
-    units_created: int = 0
     word_created: bool = False
     error: Optional[str] = None
     word_id: Optional[int] = None
+
+
+@dataclass
+class ImportSummary:
+    """
+    Outcome of importing one CSV file: how much content it added, which
+    units it extended rather than created, and the rows it had to skip.
+    """
+
+    words_created: int = 0
+    units_created: int = 0
+    units_reused: int = 0
+    errors: list[str] = field(default_factory=list)
+    imported_word_ids: list[int] = field(default_factory=list)
 
 
 def map_article_to_int(article: str) -> int:
@@ -157,15 +182,6 @@ def map_word_type(word_type: str) -> str:
     return WORD_TYPE_MAP.get(word_type.lower().strip(), "")
 
 
-def create_unit(unit_title: str, job: Job, creator_fields: dict) -> Unit:
-    """
-    Create a new unit - even if one already exists with the same title.
-    """
-    unit = Unit.objects.create(title=unit_title, **creator_fields)
-    unit.jobs.add(job)
-    return unit
-
-
 @dataclass(frozen=True)
 class WordAttributes:
     """The (already converted/validated) word fields a CSV row contributes."""
@@ -175,6 +191,7 @@ class WordAttributes:
     plural: str = ""
     pronunciation: str = ""
     word_type: str = ""
+    example_sentence: str = ""
 
 
 def create_word(
@@ -190,6 +207,7 @@ def create_word(
         plural=attributes.plural,
         pronunciation=attributes.pronunciation,
         word_type=attributes.word_type,
+        example_sentence=attributes.example_sentence,
         **creator_fields,
     )
 
@@ -211,15 +229,6 @@ def _creator_fields_for_user(user: User) -> dict:
         "created_by_user": user,
         "creator_is_admin": user.is_superuser,
     }
-
-
-def update_or_add_example_sentence(word_obj: Word, word_defaults: dict) -> None:
-    """
-    Adds or edits example sentence to word object.
-    """
-    if word_obj.example_sentence != word_defaults["example_sentence"]:
-        word_obj.example_sentence = word_defaults["example_sentence"]
-        word_obj.save(update_fields=["example_sentence"])
 
 
 def parse_row(raw_row: dict, row_number: int) -> ParsedRow | RowResult:
@@ -313,50 +322,51 @@ def _split_unit_titles(unit_column: str) -> list[str]:
     return [title for title in titles if title]
 
 
-def _resolve_unit(
-    unit_title: str,
-    job: Job,
-    created_units: Dict[str, Unit],
-    creator_fields: dict,
-) -> Tuple[Unit, bool]:
+class UnitResolver:
     """
-    Looks up ``unit_title`` in the ``created_units`` cache, creating it (even
-    if a unit with the same title already exists elsewhere) if this is the
-    first time this import encounters it. Returns the unit and whether it
-    was newly created.
+    Maps the unit titles of an import onto unit objects: a title that the job
+    already has a unit for extends that unit, any other title gets a new one.
+    Keeps track of which titles went which way so the import can report both.
     """
-    unit = created_units.get(unit_title)
-    if unit is None:
-        unit = create_unit(unit_title, job, creator_fields)
-        created_units[unit_title] = unit
-        return unit, True
 
-    if not unit.jobs.filter(pk=job.pk).exists():
-        unit.jobs.add(job)
-    return unit, False
+    def __init__(self, job: Job, creator_fields: dict) -> None:
+        self.job = job
+        self.creator_fields = creator_fields
+        self.units_by_title: Dict[str, Unit] = {
+            unit.title: unit for unit in job.units.order_by("-pk")
+        }
+        self.created_titles: set[str] = set()
+        self.reused_titles: set[str] = set()
+
+    def resolve(self, unit_title: str) -> Unit:
+        """
+        Returns the unit the words of this title belong in, creating it if
+        the job has none.
+        """
+        unit = self.units_by_title.get(unit_title)
+        if unit is None:
+            unit = Unit.objects.create(title=unit_title, **self.creator_fields)
+            unit.jobs.add(self.job)
+            self.units_by_title[unit_title] = unit
+            self.created_titles.add(unit_title)
+        elif unit_title not in self.created_titles:
+            self.reused_titles.add(unit_title)
+        return unit
 
 
 def process_row(
     parsed: ParsedRow,
-    job: Job,
-    created_units: Dict[str, Unit],
+    units: UnitResolver,
     creator_fields: dict,
 ) -> RowResult:
     """
     Processes a single parsed row.
 
     The "unit" column may name more than one unit (see
-    ``_split_unit_titles``); each one is resolved/created and linked to the
-    word individually. Update example sentence. Add word to newly created
-    unit(s).
+    ``_split_unit_titles``); each one is resolved and linked to the word
+    individually.
     """
-    units_created = 0
-    units = []
-    for unit_title in _split_unit_titles(parsed.unit):
-        unit, created = _resolve_unit(unit_title, job, created_units, creator_fields)
-        units.append(unit)
-        if created:
-            units_created += 1
+    row_units = [units.resolve(title) for title in _split_unit_titles(parsed.unit)]
 
     attributes = WordAttributes(
         singular_article=map_article_to_int(parsed.article),
@@ -364,59 +374,49 @@ def process_row(
         plural=parsed.plural,
         pronunciation=parsed.pronunciation,
         word_type=map_word_type(parsed.word_type),
+        example_sentence=parsed.example,
     )
     word = create_word(parsed.word, attributes, creator_fields)
 
-    update_or_add_example_sentence(word, {"example_sentence": parsed.example})
+    # Bypasses ``unit.words.add``, which would first query for links that a
+    # word created a line ago cannot have.
+    UnitWordRelation.objects.bulk_create(
+        UnitWordRelation(unit=unit, word=word) for unit in dict.fromkeys(row_units)
+    )
 
-    for unit in units:
-        unit.words.add(word)
-
-    return RowResult(units_created=units_created, word_created=True, word_id=word.pk)
+    return RowResult(word_created=True, word_id=word.pk)
 
 
-def import_words_from_csv(
-    dataset: Dataset, job: Job, user: User
-) -> Tuple[int, int, list[str], list[int]]:
+def import_words_from_csv(dataset: Dataset, job: Job, user: User) -> ImportSummary:
     """
-    Imports the entire csv dataset to a job.
-    Returns a tuple of words_created_count, units_created_count, error_messages,
-    imported_word_ids
-
-    Important: During the import there is a local cache ``created_units`` because of the following scenario:
-    In the CSV file there are ten words for the unit "tools"
-    There is already a unit called "tools" in the system
-    What we want to happen is: a second unit "tools" is created, distinct from the one that already exists. All words
-    in the CSV file gets imported into that second instance of "tools".
+    Imports the csv dataset into the job. A row that cannot be imported is
+    collected in the summary's errors rather than aborting the rest.
     """
-    total_words_created = 0
-    total_units_created = 0
-    error_messages: list[str] = []
-    imported_word_ids: list[int] = []
-
+    summary = ImportSummary()
     creator_fields = _creator_fields_for_user(user)
-    created_units: Dict[str, Unit] = {}
+    units = UnitResolver(job, creator_fields)
 
-    for row_number, raw_row in enumerate(dataset.dict, start=1):
+    for row_number, raw_row in enumerate(dataset.dict, start=HEADER_ROW + 1):
         parsed_or_error = parse_row(raw_row, row_number)
 
         if isinstance(parsed_or_error, RowResult):
             if parsed_or_error.error:
-                error_messages.append(parsed_or_error.error)
+                summary.errors.append(parsed_or_error.error)
             continue
 
-        result = process_row(parsed_or_error, job, created_units, creator_fields)
+        result = process_row(parsed_or_error, units, creator_fields)
 
         if result.error:
-            error_messages.append(
+            summary.errors.append(
                 _("Row %(n)s: %(msg)s") % {"n": row_number, "msg": result.error}
             )
             continue
 
         if result.word_created:
-            total_words_created += 1
-        total_units_created += result.units_created
+            summary.words_created += 1
         if result.word_id is not None:
-            imported_word_ids.append(result.word_id)
+            summary.imported_word_ids.append(result.word_id)
 
-    return total_words_created, total_units_created, error_messages, imported_word_ids
+    summary.units_created = len(units.created_titles)
+    summary.units_reused = len(units.reused_titles)
+    return summary

--- a/lunes_cms/cmsv2/views/import_csv_view.py
+++ b/lunes_cms/cmsv2/views/import_csv_view.py
@@ -13,6 +13,7 @@ from tablib.exceptions import InvalidDimensions
 
 from ..admins.word_import_resource import (
     import_words_from_csv,
+    ImportSummary,
     validate_header_structure,
 )
 from ..models import Job
@@ -41,21 +42,56 @@ class ImportCSVForm(forms.Form):
     )
 
 
-def _build_success_message(words_created: int, units_created: int) -> str:
+def _build_success_message(summary: ImportSummary) -> str:
     """
     Builds the pluralized success message shown after a completed CSV import.
+    Each sentence is translated whole, so that leaving the reuse one out
+    still reads correctly in every language.
     """
     words_phrase = ngettext(
-        "%(count)s new word", "%(count)s new words", words_created
-    ) % {"count": words_created}
+        "%(count)s new word", "%(count)s new words", summary.words_created
+    ) % {"count": summary.words_created}
     units_phrase = ngettext(
-        "%(count)s new unit", "%(count)s new units", units_created
-    ) % {"count": units_created}
-    return _(
-        "Import successful! %(words)s, %(units)s created. Example "
-        "sentences, audio and images are being generated in the "
-        "background. This may take a few minutes..."
-    ) % {"words": words_phrase, "units": units_phrase}
+        "%(count)s new unit", "%(count)s new units", summary.units_created
+    ) % {"count": summary.units_created}
+    sentences = [
+        _("Import successful! %(words)s, %(units)s created.")
+        % {"words": words_phrase, "units": units_phrase}
+    ]
+
+    if summary.units_reused:
+        sentences.append(
+            ngettext(
+                "%(count)s existing unit was extended.",
+                "%(count)s existing units were extended.",
+                summary.units_reused,
+            )
+            % {"count": summary.units_reused}
+        )
+
+    sentences.append(
+        str(
+            _(
+                "Example sentences, audio and images are being generated in the "
+                "background. This may take a few minutes..."
+            )
+        )
+    )
+    return " ".join(sentences)
+
+
+def _generate_word_assets(word_ids: list[int], job_title: str) -> None:
+    """
+    Generates the missing assets for the imported words, in a thread.
+
+    The order matters — audio can only be made once the sentence exists —
+    and the drains must not run in parallel: each does a full ``Word.save()``,
+    so concurrent ones would write back stale in-memory copies and clobber
+    each other's file fields, re-triggering generation.
+    """
+    drain_pending_sentences(word_ids, job_title=job_title)
+    drain_pending_audio(word_ids)
+    drain_pending_images(word_ids, job_title=job_title)
 
 
 def _report_dataset_issue(request: HttpRequest, data: Dataset) -> bool:
@@ -137,37 +173,24 @@ def import_from_csv(request: HttpRequest, job_id: int | None = None) -> HttpResp
 
         # request.user is `User | AnonymousUser`, but this view is only
         # reachable by authenticated staff users.
-        words_created, units_created, errors, imported_word_ids = import_words_from_csv(
+        summary = import_words_from_csv(
             data, selected_job, request.user  # type: ignore[arg-type]
         )
 
-        if errors:
-            error_summary = " | ".join(errors[:5])
+        if summary.errors:
+            error_summary = " | ".join(summary.errors[:5])
             messages.warning(
                 request,
                 _("Import completed with warnings: %(summary)s")
                 % {"summary": error_summary},
             )
         else:
-            messages.success(
-                request, _build_success_message(words_created, units_created)
-            )
+            messages.success(request, _build_success_message(summary))
 
-        if imported_word_ids:
-            # Run the three drains sequentially in one thread:
-            #   1. sentences  — audio can only be made once the sentence exists
-            #   2. audio
-            #   3. images
-            # They must not run in parallel: each does a full ``Word.save()``,
-            # so concurrent drains would write back stale in-memory copies and
-            # clobber each other's file fields (re-triggering generation).
-            def _generate_word_assets() -> None:
-                drain_pending_sentences(imported_word_ids, job_title=selected_job.name)
-                drain_pending_audio(imported_word_ids)
-                drain_pending_images(imported_word_ids, job_title=selected_job.name)
-
+        if summary.imported_word_ids:
             threading.Thread(
                 target=_generate_word_assets,
+                args=(summary.imported_word_ids, selected_job.name),
                 daemon=True,
             ).start()
         return redirect(reverse("admin:cmsv2_job_change", args=[selected_job.pk]))

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -1266,13 +1266,23 @@ msgstr[1] "%(count)s neue Einheiten"
 
 #: cmsv2/views/import_csv_view.py
 #, python-format
+msgid "Import successful! %(words)s, %(units)s created."
+msgstr "Import erfolgreich! %(words)s, %(units)s erstellt."
+
+#: cmsv2/views/import_csv_view.py
+#, python-format
+msgid "%(count)s existing unit was extended."
+msgid_plural "%(count)s existing units were extended."
+msgstr[0] "%(count)s bestehende Einheit wurde erweitert."
+msgstr[1] "%(count)s bestehende Einheiten wurden erweitert."
+
+#: cmsv2/views/import_csv_view.py
 msgid ""
-"Import successful! %(words)s, %(units)s created. Example sentences, audio "
-"and images are being generated in the background. This may take a few "
-"minutes..."
+"Example sentences, audio and images are being generated in the background. "
+"This may take a few minutes..."
 msgstr ""
-"Import erfolgreich! %(words)s, %(units)s erstellt. Beispielsätze, Audio und "
-"Bilder werden im Hintergrund generiert. Dies kann einige Minuten dauern..."
+"Beispielsätze, Audio und Bilder werden im Hintergrund generiert. Dies kann "
+"einige Minuten dauern..."
 
 #: cmsv2/views/import_csv_view.py
 msgid "The file contains no entries. Nothing was imported."

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -23,7 +23,7 @@ from lunes_cms.cmsv2.admins.word_import_resource import (
     RowResult,
     validate_header_structure,
 )
-from lunes_cms.cmsv2.models import Word
+from lunes_cms.cmsv2.models import Unit, Word
 from lunes_cms.cmsv2.models.job import Job
 
 # ---------------------------------------------------------------------------
@@ -268,7 +268,7 @@ def test_import_with_german_headers(job: Job, user: User) -> None:
         ["Einheit", "Vokabel", "Artikel"],
         [["Werkzeug", "Hammer", "der"], ["Werkzeug", "Säge", "die"]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     assert _job_words(job).count() == 2
 
@@ -280,7 +280,7 @@ def test_reimport_with_english_headers(job: Job, user: User) -> None:
         ["Units", "Word", "Singular Article", "Plural Article", "Example sentence"],
         [["Werkzeug", "Hammer", "der", "die (Plural)", "Der Hammer ist schwer."]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     word = _job_words(job).get(word="Hammer")
     assert word.plural_article == 1
@@ -298,7 +298,7 @@ def test_imported_word_with_example_sentence_is_not_checked(
         ["Units", "Word", "Singular Article", "Example sentence"],
         [["Werkzeug", "Hammer", "der", "Der Hammer ist schwer."]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     word = _job_words(job).get(word="Hammer")
     assert word.example_sentence == "Der Hammer ist schwer."
@@ -314,7 +314,7 @@ def test_reimport_with_german_headers(job: Job, user: User) -> None:
         ["Einheit", "Vokabel", "Singularartikel", "Pluralartikel", "Beispielsatz"],
         [["Werkzeug", "Hammer", "der", "die (Plural)", "Der Hammer ist schwer."]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     assert _job_words(job).get(word="Hammer").plural_article == 1
 
@@ -326,7 +326,7 @@ def test_import_plural_word(job: Job, user: User) -> None:
         ["Units", "Word", "Singular Article", "Plural", "Plural Article"],
         [["Werkzeug", "Hammer", "der", "Hämmer", "die"]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     word = _job_words(job).get(word="Hammer")
     assert word.plural == "Hämmer"
@@ -363,7 +363,7 @@ def test_extra_export_columns_are_ignored(job: Job, user: User) -> None:
         ["Units", "Word", "Singular Article", "Has audio?", "Creation date"],
         [["Werkzeug", "Hammer", "der", "No", "01.01.2026 10:00"]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     assert _job_words(job).count() == 1
 
@@ -375,7 +375,7 @@ def test_word_type_column_is_imported(job: Job, user: User) -> None:
         ["Units", "Word", "Singular Article", "Word type"],
         [["Werkzeug", "Hammer", "der", "Nomen"]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     assert _job_words(job).get(word="Hammer").word_type == "Nomen"
 
@@ -388,7 +388,7 @@ def test_unrecognised_word_type_defaults_to_empty(job: Job, user: User) -> None:
         ["Units", "Word", "Singular Article", "Word type"],
         [["Werkzeug", "Hammer", "der", "not-a-real-type"]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert errors == []
     assert _job_words(job).get(word="Hammer").word_type == ""
 
@@ -399,9 +399,24 @@ def test_empty_rows_produce_errors(job: Job, user: User) -> None:
         ["Einheit", "Vokabel", "Artikel"],
         [["", "Hammer", "der"], ["Werkzeug", "", "der"]],
     )
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
     assert len(errors) == 2
     assert _job_words(job).count() == 0
+
+
+@pytest.mark.django_db
+def test_error_messages_name_the_row_the_file_shows(job: Job, user: User) -> None:
+    """The headers occupy row 1, so the second data row is row 3 — the number
+    the editor sees next to it in their spreadsheet."""
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["Werkzeug", "Hammer", "der"], ["Werkzeug", "", "die"]],
+    )
+
+    errors = import_words_from_csv(ds, job, user).errors
+
+    assert len(errors) == 1
+    assert "Row 3" in str(errors[0])
 
 
 @pytest.mark.django_db
@@ -495,7 +510,7 @@ def test_import_stores_pronunciation_on_the_word(job: Job, user: User) -> None:
         [["Backwaren", "Baiser", "das", "Bessee"], ["Werkzeug", "Hammer", "der", ""]],
     )
 
-    _, _, errors, _ = import_words_from_csv(ds, job, user)
+    errors = import_words_from_csv(ds, job, user).errors
 
     assert errors == []
     assert _job_words(job).get(word="Baiser").pronunciation == "Bessee"
@@ -516,14 +531,14 @@ def test_pipe_separated_units_are_split_and_both_linked(job: Job, user: User) ->
         ["Einheit", "Vokabel", "Artikel"],
         [["Werkzeuge | Baustelle", "Hammer", "der"]],
     )
-    _, units_created, errors, _ = import_words_from_csv(ds, job, user)
-    assert errors == []
+    summary = import_words_from_csv(ds, job, user)
+    assert summary.errors == []
     word = _job_words(job).get(word="Hammer")
     assert set(word.units.values_list("title", flat=True)) == {
         "Werkzeuge",
         "Baustelle",
     }
-    assert units_created == 2
+    assert summary.units_created == 2
 
 
 @pytest.mark.django_db
@@ -543,9 +558,22 @@ def test_pipe_separated_units_tolerate_missing_spaces(job: Job, user: User) -> N
 
 
 @pytest.mark.django_db
+def test_a_unit_named_twice_in_one_row_is_linked_once(job: Job, user: User) -> None:
+    """The word's units are written directly, so a row repeating a title must
+    not produce two identical (unit, word) rows."""
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["Werkzeuge | Werkzeuge", "Hammer", "der"]],
+    )
+    summary = import_words_from_csv(ds, job, user)
+    assert summary.errors == []
+    assert _job_words(job).get(word="Hammer").units.count() == 1
+
+
+@pytest.mark.django_db
 def test_pipe_separated_units_reuse_the_row_cache(job: Job, user: User) -> None:
     """Two rows naming the same multi-unit combination reuse the same two
-    units (via the ``created_units`` cache) instead of creating duplicates."""
+    units instead of creating duplicates."""
     ds = _make_dataset(
         ["Einheit", "Vokabel", "Artikel"],
         [
@@ -553,11 +581,106 @@ def test_pipe_separated_units_reuse_the_row_cache(job: Job, user: User) -> None:
             ["Werkzeuge | Baustelle", "Säge", "die"],
         ],
     )
-    _, units_created, errors, _ = import_words_from_csv(ds, job, user)
-    assert errors == []
-    assert units_created == 2
+    summary = import_words_from_csv(ds, job, user)
+    assert summary.errors == []
+    assert summary.units_created == 2
     hammer = _job_words(job).get(word="Hammer")
     saege = _job_words(job).get(word="Säge")
     assert set(hammer.units.values_list("pk", flat=True)) == set(
         saege.units.values_list("pk", flat=True)
     )
+
+
+# ---------------------------------------------------------------------------
+# Extending units the job already has
+# ---------------------------------------------------------------------------
+
+
+def _tool_dataset(word: str, article: str, unit: str = "Werkzeug") -> Dataset:
+    return _make_dataset(["Einheit", "Vokabel", "Artikel"], [[unit, word, article]])
+
+
+def _job_units(job: Job, title: str) -> QuerySet[Unit]:
+    return Unit.objects.filter(jobs=job, title=title)
+
+
+@pytest.mark.django_db
+def test_second_import_extends_the_existing_unit(job: Job, user: User) -> None:
+    """A follow-up CSV naming a unit the job already has adds its words to
+    that unit instead of creating a second one with the same title."""
+    import_words_from_csv(_tool_dataset("Hammer", "der"), job, user)
+
+    summary = import_words_from_csv(_tool_dataset("Säge", "die"), job, user)
+
+    assert summary.errors == []
+    assert summary.units_created == 0
+    assert summary.units_reused == 1
+    unit = _job_units(job, "Werkzeug").get()
+    assert set(unit.words.values_list("word", flat=True)) == {"Hammer", "Säge"}
+
+
+@pytest.mark.django_db
+def test_a_same_titled_unit_of_another_job_is_not_reused(job: Job, user: User) -> None:
+    """A unit of the same title belonging to another job is left alone."""
+    other_job = Job.objects.create(name="Other Job")
+    import_words_from_csv(_tool_dataset("Hammer", "der"), other_job, user)
+
+    summary = import_words_from_csv(_tool_dataset("Säge", "die"), job, user)
+
+    assert summary.units_created == 1
+    assert summary.units_reused == 0
+    assert _job_units(other_job, "Werkzeug").get().words.get().word == "Hammer"
+
+
+@pytest.mark.django_db
+def test_pipe_separated_units_mix_existing_and_new(job: Job, user: User) -> None:
+    """One row may name both a unit the job already has and one it doesn't."""
+    import_words_from_csv(_tool_dataset("Hammer", "der"), job, user)
+
+    ds = _make_dataset(
+        ["Einheit", "Vokabel", "Artikel"],
+        [["Werkzeug | Baustelle", "Säge", "die"]],
+    )
+    summary = import_words_from_csv(ds, job, user)
+
+    assert summary.units_created == 1
+    assert summary.units_reused == 1
+    saege = _job_words(job).get(word="Säge")
+    assert set(saege.units.values_list("title", flat=True)) == {
+        "Werkzeug",
+        "Baustelle",
+    }
+    assert _job_units(job, "Werkzeug").count() == 1
+
+
+@pytest.mark.django_db
+def test_the_oldest_of_several_same_titled_units_is_extended(
+    job: Job, user: User
+) -> None:
+    """Imports made before this behaviour existed can leave a job with
+    several same-titled units; every later import converges on the first."""
+    oldest = Unit.objects.create(title="Werkzeug")
+    oldest.jobs.add(job)
+    duplicate = Unit.objects.create(title="Werkzeug")
+    duplicate.jobs.add(job)
+
+    import_words_from_csv(_tool_dataset("Hammer", "der"), job, user)
+
+    assert oldest.words.get().word == "Hammer"
+    assert not duplicate.words.exists()
+
+
+@pytest.mark.django_db
+def test_extending_a_unit_leaves_its_own_attributes_alone(job: Job, user: User) -> None:
+    """Adding words to an existing unit must not re-attribute it to the
+    importing user or link it to its job a second time."""
+    owner = get_user_model().objects.create_superuser(
+        username="owner", email="owner@example.com", password="password"
+    )
+    import_words_from_csv(_tool_dataset("Hammer", "der"), job, owner)
+
+    import_words_from_csv(_tool_dataset("Säge", "die"), job, user)
+
+    unit = _job_units(job, "Werkzeug").get()
+    assert unit.created_by_user == owner
+    assert unit.jobs.count() == 1

--- a/tests/cmsv2/admins/test_word_import_resource.py
+++ b/tests/cmsv2/admins/test_word_import_resource.py
@@ -5,6 +5,7 @@ Covers the re-import workflow described in issue #775.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -227,6 +228,17 @@ def test_parse_row_strips_whitespace_from_column_names() -> None:
     row = {" Einheit ": "Werkzeug", " Vokabel ": "Hammer", " Artikel ": "der"}
     result = parse_row(row, 1)
     assert isinstance(result, ParsedRow)
+
+
+def test_parse_row_does_not_report_recognised_columns_as_unexpected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Recognised headers are matched case-insensitively, so no row logs them
+    as unexpected columns."""
+    row = {"einheit": "Werkzeug", "VOKABEL": "Hammer", "Artikel": "der"}
+    with caplog.at_level(logging.INFO):
+        parse_row(row, 1)
+    assert "unexpected columns" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cmsv2/views/test_import_csv_view.py
+++ b/tests/cmsv2/views/test_import_csv_view.py
@@ -7,6 +7,8 @@ processing happens.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
@@ -99,3 +101,30 @@ def test_valid_file_still_imports_successfully(admin_client: Client, job: Job) -
     messages = [str(m) for m in response.context["messages"]]
     assert any("import successful" in m.lower() for m in messages)
     assert Word.objects.filter(units__jobs=job, word="Hammer").exists()
+
+
+def _import_tool(admin_client: Client, job: Job, word: str, article: str) -> Any:
+    return admin_client.post(
+        reverse("cmsv2:import_csv"),
+        {
+            "job": job.pk,
+            "csv_file": _upload(
+                f"Einheit,Vokabel,Artikel\nWerkzeug,{word},{article}\n"
+            ),
+        },
+        follow=True,
+    )
+
+
+@pytest.mark.django_db()
+def test_second_import_reports_the_extended_unit(
+    admin_client: Client, job: Job
+) -> None:
+    """The message tells the user that the second CSV extended the unit that
+    was already there rather than adding another one."""
+    _import_tool(admin_client, job, "Hammer", "der")
+
+    response = _import_tool(admin_client, job, "Säge", "die")
+
+    messages = [str(m) for m in response.context["messages"]]
+    assert any("existing unit was extended" in m for m in messages)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR checks during a CSV import if a unit already exists, and if it does, add the word there instead of adding a new unit.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Check during a CSV import if a unit with the same name in the same job already exists
- If yes, add the word to that unit

- Fix a new kind of off-by-one error (error messages in CSV imports saying line 1 when it is actually line 2, because we start after the header)
- Reduced the queries during the import: the example sentence is written immediately during word creation, and the unit-word links are bulk_created without checking if there already is one for this newly created word

### How to test
<!-- Please describe how to test this PR -->

- Import a CSV with an existing unit name into a job, see that no second unit with the same name is created.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #948 