### PR TITLE
952: show alternative words to all users with permission to see the word itself

### DIFF
--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -4,6 +4,7 @@ from datetime import date
 from typing import TYPE_CHECKING
 
 from django.contrib import admin
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.functional import lazy
 from django.utils.html import escape, format_html
@@ -56,6 +57,23 @@ class AlternativeWordInline(admin.TabularInline):
         "action_buttons",
     ]
     readonly_fields = ["action_buttons"]
+
+    def has_view_permission(
+        self, request: HttpRequest, _obj: Word | None = None
+    ) -> bool:
+        return request.user.has_perm("cmsv2.view_word") or self.has_change_permission(
+            request
+        )
+
+    def has_add_permission(
+        self, request: HttpRequest, _obj: Word | None = None
+    ) -> bool:
+        return self.has_change_permission(request)
+
+    def has_change_permission(
+        self, request: HttpRequest, _obj: Word | None = None
+    ) -> bool:
+        return request.user.has_perm("cmsv2.change_word")
 
     def action_buttons(self, obj: AlternativeWord) -> SafeString:
         """

--- a/lunes_cms/cmsv2/admins/word_admin.py
+++ b/lunes_cms/cmsv2/admins/word_admin.py
@@ -30,7 +30,8 @@ from lunes_cms.cmsv2.utils import (
 from lunes_cms.core import settings
 
 if TYPE_CHECKING:
-    # `_StrOrPromise` only exists in django-stubs, not at runtime.
+    # These only exist in django-stubs, not at runtime.
+    from django.contrib.admin.options import _FieldGroups
     from django.utils.functional import _StrOrPromise
 
 _format_html_lazy = lazy(format_html, SafeString)
@@ -57,6 +58,16 @@ class AlternativeWordInline(admin.TabularInline):
         "action_buttons",
     ]
     readonly_fields = ["action_buttons"]
+
+    def get_fields(self, request: HttpRequest, obj: Word | None = None) -> _FieldGroups:
+        """
+        Hide the action buttons from users who may only view words, because
+        their requests to add, save or delete would be denied anyway.
+        """
+        fields = super().get_fields(request, obj)
+        if not self.has_change_permission(request, obj):
+            return [field for field in fields if field != "action_buttons"]
+        return fields
 
     def has_view_permission(
         self, request: HttpRequest, _obj: Word | None = None

--- a/lunes_cms/cmsv2/migrations/0031_remove_alternative_word_permissions.py
+++ b/lunes_cms/cmsv2/migrations/0031_remove_alternative_word_permissions.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+
+# pylint: disable=unused-argument
+def delete_alternative_word_permissions(apps, schema_editor):
+    """
+    Alternative words are edited as part of their word and no longer have
+    permissions of their own. Django only ever adds permissions, so the ones
+    created for existing databases have to be deleted explicitly, otherwise
+    they keep showing up when the permissions of a group are edited.
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    Permission = apps.get_model("auth", "Permission")
+
+    Permission.objects.filter(
+        content_type__app_label="cmsv2", content_type__model="alternativeword"
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file to drop the permissions of the alternative word model.
+    """
+
+    dependencies = [
+        ("auth", "0001_initial"),
+        ("contenttypes", "0001_initial"),
+        ("cmsv2", "0030_refactor_review"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="alternativeword",
+            options={
+                "default_permissions": (),
+                "verbose_name": "alternative word",
+                "verbose_name_plural": "alternative words",
+            },
+        ),
+        migrations.RunPython(
+            delete_alternative_word_permissions, migrations.RunPython.noop
+        ),
+    ]

--- a/lunes_cms/cmsv2/models/alternative_word.py
+++ b/lunes_cms/cmsv2/models/alternative_word.py
@@ -70,3 +70,4 @@ class AlternativeWord(models.Model):
 
         verbose_name = _("alternative word")
         verbose_name_plural = _("alternative words")
+        default_permissions = ()

--- a/lunes_cms/cmsv2/models/static.py
+++ b/lunes_cms/cmsv2/models/static.py
@@ -84,43 +84,6 @@ class Roles:
     REVIEWER_GROUP = _("Reviewer")
 
 
-class Permissions:
-    """Possible permissions"""
-
-    STAFF_PERMISSIONS = [
-        "add_job",
-        "change_job",
-        "delete_job",
-        "view_job",
-        "add_word",
-        "change_word",
-        "delete_word",
-        "view_word",
-        "add_unit",
-        "change_unit",
-        "delete_unit",
-        "view_unit",
-        "add_image",
-        "change_image",
-        "delete_image",
-        "view_image",
-        "add_feedback",
-        "change_feedback",
-        "delete_feedback",
-        "view_feedback",
-        "add_unitwordrelation",
-        "change_unitwordrelation",
-        "delete_unitwordrelation",
-        "view_unitwordrelation",
-    ]
-    REVIEW_PERMISSIONS = [
-        "add_review",
-        "change_review",
-        "delete_review",
-        "view_review",
-    ]
-
-
 def convert_image_to_webp(image_field: ImageFieldFile) -> bool:
     """
     Converts an ImageField's file to WebP format in-place.

--- a/lunes_cms/cmsv2/views/decorators.py
+++ b/lunes_cms/cmsv2/views/decorators.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from django.http import HttpRequest, JsonResponse
+
+JsonView = Callable[..., JsonResponse]
+
+
+def require_word_change_permission(view: JsonView) -> JsonView:
+    """
+    Only let users through who may change words.
+
+    The denial is a JSON response instead of Django's HTML one, because the
+    admin JavaScript reads the message of the response and shows it to the user.
+    """
+
+    @wraps(view)
+    def wrapped_view(request: HttpRequest, *args: Any, **kwargs: Any) -> JsonResponse:
+        if not request.user.has_perm("cmsv2.change_word"):
+            return JsonResponse(
+                {"status": "error", "message": "Permission denied"}, status=403
+            )
+        return view(request, *args, **kwargs)
+
+    return wrapped_view

--- a/lunes_cms/cmsv2/views/decorators.py
+++ b/lunes_cms/cmsv2/views/decorators.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any
 
 from django.http import HttpRequest, JsonResponse
+from django.utils.translation import gettext_lazy as _
 
 JsonView = Callable[..., JsonResponse]
 
@@ -21,7 +22,7 @@ def require_word_change_permission(view: JsonView) -> JsonView:
     def wrapped_view(request: HttpRequest, *args: Any, **kwargs: Any) -> JsonResponse:
         if not request.user.has_perm("cmsv2.change_word"):
             return JsonResponse(
-                {"status": "error", "message": "Permission denied"}, status=403
+                {"status": "error", "message": _("Permission denied")}, status=403
             )
         return view(request, *args, **kwargs)
 

--- a/lunes_cms/cmsv2/views/delete_alternative_word.py
+++ b/lunes_cms/cmsv2/views/delete_alternative_word.py
@@ -6,9 +6,11 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from ..models import AlternativeWord
+from .decorators import require_word_change_permission
 
 
 @staff_member_required
+@require_word_change_permission
 @csrf_exempt
 @require_POST
 def delete_alternative_word(

--- a/lunes_cms/cmsv2/views/save_alternative_word.py
+++ b/lunes_cms/cmsv2/views/save_alternative_word.py
@@ -7,9 +7,11 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from ..models import AlternativeWord, Word
+from .decorators import require_word_change_permission
 
 
 @staff_member_required
+@require_word_change_permission
 @csrf_exempt
 @require_POST
 def save_alternative_word(request: HttpRequest) -> JsonResponse:

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -1250,6 +1250,10 @@ msgstr "Beispielsatz generieren"
 msgid "Regenerate example sentence"
 msgstr "Beispielsatz neu generieren"
 
+#: cmsv2/views/decorators.py
+msgid "Permission denied"
+msgstr "Keine Berechtigung"
+
 #: cmsv2/views/import_csv_view.py
 msgid "Select CSV file"
 msgstr "CSV Datei auswählen"

--- a/tests/cmsv2/test_alternative_word.py
+++ b/tests/cmsv2/test_alternative_word.py
@@ -111,12 +111,18 @@ def test_word_admin_page_shows_alternative_words_to_editor(
 def test_word_admin_page_shows_alternative_words_to_viewer(
     word: Word, viewer_client: Client
 ) -> None:
-    """A staff user who may only view words still sees the alternative words."""
+    """
+    A staff user who may only view words sees the alternative words, but none
+    of the buttons which would add, save or delete them.
+    """
     response = viewer_client.get(f"/en/admin/cmsv2/word/{word.pk}/change/")
     assert response.status_code == 200
     content = response.content.decode()
     assert "<h2>Alternative Words</h2>" in content
     assert "Semmel" in content
+    assert "add-alternative-word-btn" not in content
+    assert "save-alternative-word-btn" not in content
+    assert "delete-alternative-word-btn" not in content
 
 
 @pytest.mark.django_db

--- a/tests/cmsv2/test_alternative_word.py
+++ b/tests/cmsv2/test_alternative_word.py
@@ -6,7 +6,7 @@ and the alternative-word inline on the word admin page.
 from __future__ import annotations
 
 import pytest
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, Permission, User
 from django.test.client import Client
 
 from lunes_cms.api.v2.serializers import UnitWordRelationSerializer, WordSerializer
@@ -53,6 +53,112 @@ def fixture_admin_client(db: None) -> Client:
     client = Client()
     client.force_login(admin_user)
     return client
+
+
+def _create_staff_client(username: str, word_permissions: list[str]) -> Client:
+    """
+    A client logged in as a staff user whose group grants the given word
+    permissions and nothing else, like the groups of the editors in production.
+    """
+    group = Group.objects.create(name=f"group-of-{username}")
+    group.permissions.set(
+        Permission.objects.filter(
+            content_type__app_label="cmsv2", codename__in=word_permissions
+        )
+    )
+    user = User.objects.create_user(username, is_staff=True)
+    user.groups.add(group)
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture(name="editor_client")
+def fixture_editor_client(db: None) -> Client:
+    """A client logged in as a staff user who may change words."""
+    return _create_staff_client("editor", ["view_word", "change_word"])
+
+
+@pytest.fixture(name="viewer_client")
+def fixture_viewer_client(db: None) -> Client:
+    """A client logged in as a staff user who may only view words."""
+    return _create_staff_client("viewer", ["view_word"])
+
+
+@pytest.mark.django_db
+def test_alternative_words_have_no_permissions_of_their_own() -> None:
+    """The alternative word model grants no permissions which a group could hold."""
+    assert not Permission.objects.filter(
+        content_type__app_label="cmsv2", content_type__model="alternativeword"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_word_admin_page_shows_alternative_words_to_editor(
+    word: Word, editor_client: Client
+) -> None:
+    """A staff user who may change words sees the editable alternative words section."""
+    response = editor_client.get(f"/en/admin/cmsv2/word/{word.pk}/change/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "<h2>Alternative Words</h2>" in content
+    assert "Semmel" in content
+    assert "save-alternative-word-btn" in content
+    assert "add-alternative-word-btn" in content
+
+
+@pytest.mark.django_db
+def test_word_admin_page_shows_alternative_words_to_viewer(
+    word: Word, viewer_client: Client
+) -> None:
+    """A staff user who may only view words still sees the alternative words."""
+    response = viewer_client.get(f"/en/admin/cmsv2/word/{word.pk}/change/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "<h2>Alternative Words</h2>" in content
+    assert "Semmel" in content
+
+
+@pytest.mark.django_db
+def test_editor_can_save_and_delete_alternative_word(
+    word: Word, editor_client: Client
+) -> None:
+    """A staff user who may change words may save and delete alternative words."""
+    save_response = editor_client.post(
+        "/en/admin/cmsv2/alternativewords/save/",
+        {"word_id": word.pk, "alt_word": "Weck"},
+    )
+    assert save_response.status_code == 200
+    alternative_word = word.alternative_words.get(alt_word="Weck")
+    delete_response = editor_client.post(
+        f"/en/admin/cmsv2/alternativewords/{alternative_word.pk}/delete/"
+    )
+    assert delete_response.status_code == 200
+    assert not word.alternative_words.filter(alt_word="Weck").exists()
+
+
+@pytest.mark.django_db
+def test_viewer_cannot_save_alternative_word(word: Word, viewer_client: Client) -> None:
+    """The save view rejects a staff user who may not change words."""
+    response = viewer_client.post(
+        "/en/admin/cmsv2/alternativewords/save/",
+        {"word_id": word.pk, "alt_word": "Weck"},
+    )
+    assert response.status_code == 403
+    assert word.alternative_words.count() == 1
+
+
+@pytest.mark.django_db
+def test_viewer_cannot_delete_alternative_word(
+    word: Word, viewer_client: Client
+) -> None:
+    """The delete view rejects a staff user who may not change words."""
+    alternative_word = word.alternative_words.get()
+    response = viewer_client.post(
+        f"/en/admin/cmsv2/alternativewords/{alternative_word.pk}/delete/"
+    )
+    assert response.status_code == 403
+    assert word.alternative_words.exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We didn't specify the permissions for the alternative words, so Django created new ones for them, which weren't assigned to anybody.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Specify permissions, analogous to the word itself.
- Remove some dead code (`Permissions`)


### How to test
<!-- Please describe how to test this PR -->
Log in with a user who is not a super user, see that you see the alternative words


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #952 
