### PR TITLE
971: backfill alternative words from v1

### DIFF
--- a/lunes_cms/cmsv2/migrations/0032_backfill_alternative_words_from_v1.py
+++ b/lunes_cms/cmsv2/migrations/0032_backfill_alternative_words_from_v1.py
@@ -1,0 +1,84 @@
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+#: The fields an alternative word carries over unchanged from v1
+ALTERNATIVE_WORD_FIELDS = (
+    "alt_word",
+    "grammatical_gender",
+    "singular_article",
+    "plural",
+    "plural_article",
+)
+
+
+# pylint: disable=unused-argument
+def backfill_alternative_words(apps, schema_editor):
+    """
+    Migration 0027 reintroduced alternative words as a cmsv2 model, but only
+    created the table - the alternative words that editors had entered in v1
+    stayed behind in the cms app and disappeared from the CMS. Copy them over
+    so they show up as "So heißt das auch" again.
+
+    Words that already have alternative words are skipped, so anything entered
+    by hand since 0027 is neither duplicated nor shadowed.
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    Word = apps.get_model("cmsv2", "Word")
+    AlternativeWord = apps.get_model("cmsv2", "AlternativeWord")
+    V1AlternativeWord = apps.get_model("cms", "AlternativeWord")
+
+    words_by_v1_id = dict(
+        Word.objects.filter(v1_id__isnull=False)
+        .exclude(alternative_words__isnull=False)
+        .values_list("v1_id", "id")
+    )
+    if not words_by_v1_id:
+        logger.info("No words migrated from v1 need their alternative words back.")
+        return
+
+    # Reading the v1 table in one pass and matching in memory keeps the query
+    # free of an ``IN`` list holding every migrated word.
+    restored = []
+    for row in V1AlternativeWord.objects.values(
+        "document_id", *ALTERNATIVE_WORD_FIELDS
+    ).iterator():
+        word_id = words_by_v1_id.get(row.pop("document_id"))
+        if word_id is not None:
+            restored.append(AlternativeWord(word_id=word_id, **row))
+
+    AlternativeWord.objects.bulk_create(restored, batch_size=500)
+    # This runs unattended on deploy, so without a count a restore that found
+    # nothing would look exactly like a successful one.
+    logger.info(
+        "Restored %s alternative words from v1 across %s words.",
+        len(restored),
+        len({alternative.word_id for alternative in restored}),
+    )
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file to restore the alternative words entered in v1.
+    """
+
+    dependencies = [
+        ("cms", "0015_add_grammatical_gender_fields"),
+        ("cmsv2", "0031_remove_alternative_word_permissions"),
+    ]
+
+    operations = [
+        # Not reversible: once restored, a v1 alternative word cannot be told
+        # apart from one an editor typed by hand, so undoing would risk
+        # deleting the synonyms this migration exists to bring back.
+        migrations.RunPython(
+            backfill_alternative_words, migrations.RunPython.noop, elidable=True
+        ),
+    ]

--- a/tests/cmsv2/test_backfill_alternative_words.py
+++ b/tests/cmsv2/test_backfill_alternative_words.py
@@ -1,0 +1,143 @@
+"""
+Tests for the ``backfill_alternative_words_from_v1`` migration, which restores
+the alternative words entered in v1.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+from django.apps import apps
+
+from lunes_cms.cms.models import AlternativeWord as V1AlternativeWord, Document
+from lunes_cms.cmsv2 import migrations as cmsv2_migrations
+from lunes_cms.cmsv2.models import AlternativeWord, Word
+
+(MIGRATION_PATH,) = Path(cmsv2_migrations.__file__).parent.glob(
+    "*_backfill_alternative_words_from_v1.py"
+)
+migration = import_module(f"{cmsv2_migrations.__name__}.{MIGRATION_PATH.stem}")
+
+pytestmark = pytest.mark.django_db
+
+
+def backfill() -> None:
+    """Run the migration's backfill against the current models."""
+    migration.backfill_alternative_words(apps, None)
+
+
+def v1_document(word: str = "Brötchen") -> Document:
+    """A v1 document to hang alternative words off."""
+    return Document.objects.create(word=word, singular_article=3)
+
+
+def v1_alternative_word(
+    document: Document, alt_word: str = "Semmel", **fields: int | str
+) -> V1AlternativeWord:
+    """An alternative word entered in v1, waiting to be restored."""
+    return V1AlternativeWord.objects.create(
+        document=document, alt_word=alt_word, singular_article=2, **fields
+    )
+
+
+def v2_word(document: Document | None = None) -> Word:
+    """A word in the current CMS, migrated from ``document`` if one is given."""
+    return Word.objects.create(
+        word="Brötchen",
+        singular_article=3,
+        v1_id=document.id if document is not None else None,
+    )
+
+
+def test_alternative_words_of_a_migrated_word_are_restored() -> None:
+    """The alternative words of a v1 document reappear on its v2 word."""
+    document = v1_document()
+    v1_alternative_word(
+        document, grammatical_gender=2, plural="Semmeln", plural_article=1
+    )
+    word = v2_word(document)
+
+    backfill()
+
+    restored = word.alternative_words.get()
+    assert restored.alt_word == "Semmel"
+    assert restored.singular_article == 2
+    assert restored.grammatical_gender == 2
+    assert restored.plural == "Semmeln"
+    assert restored.plural_article == 1
+
+
+def test_all_alternative_words_of_a_word_are_restored() -> None:
+    """A word with several synonyms in v1 gets all of them back."""
+    document = v1_document()
+    for alt_word in ("Semmel", "Weck", "Schrippe"):
+        v1_alternative_word(document, alt_word)
+    word = v2_word(document)
+
+    backfill()
+
+    assert sorted(word.alternative_words.values_list("alt_word", flat=True)) == [
+        "Schrippe",
+        "Semmel",
+        "Weck",
+    ]
+
+
+def test_words_created_in_v2_are_left_alone() -> None:
+    """A word without a v1_id has nothing to restore."""
+    v1_alternative_word(v1_document())
+    word = v2_word()
+
+    backfill()
+
+    assert not word.alternative_words.exists()
+
+
+def test_words_with_existing_alternative_words_are_skipped() -> None:
+    """
+    Alternative words entered by hand since the v2 rollout are neither
+    duplicated nor shadowed by the ones coming from v1.
+    """
+    document = v1_document()
+    v1_alternative_word(document)
+    word = v2_word(document)
+    AlternativeWord.objects.create(word=word, alt_word="Weck", singular_article=2)
+
+    backfill()
+
+    assert list(word.alternative_words.values_list("alt_word", flat=True)) == ["Weck"]
+
+
+def test_running_the_backfill_twice_restores_each_word_once() -> None:
+    """The backfill is idempotent, so a re-run creates no duplicates."""
+    document = v1_document()
+    v1_alternative_word(document)
+    word = v2_word(document)
+
+    backfill()
+    backfill()
+
+    assert word.alternative_words.count() == 1
+
+
+def test_alternative_words_of_other_documents_are_not_mixed_in() -> None:
+    """Each word only gets the alternative words of its own v1 document."""
+    brötchen = v1_document()
+    v1_alternative_word(brötchen)
+    v1_alternative_word(v1_document(word="Hammer"), alt_word="Fäustel")
+    word = v2_word(brötchen)
+
+    backfill()
+
+    assert list(word.alternative_words.values_list("alt_word", flat=True)) == ["Semmel"]
+
+
+def test_a_v1_document_without_a_v2_word_is_ignored() -> None:
+    """Orphaned v1 documents do not blow the backfill up."""
+    v1_alternative_word(v1_document(), alt_word="Nur-in-v1")
+
+    backfill()
+
+    assert not AlternativeWord.objects.filter(alt_word="Nur-in-v1").exists()


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds alternative words that had been added in CMS v1 to the new fields for v2.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a migration that fills in the alternative word fields in v2 from v1.

### How to test
<!-- Please describe how to test this PR -->

- Run the tests


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #971 
