### PR TITLE
943: improve handling of staff status for new users

### DIFF
--- a/e2e-tests/test_add_user.py
+++ b/e2e-tests/test_add_user.py
@@ -40,12 +40,13 @@ def test_add_user(
 
     with document.step(
         "Benutzerdaten eingeben",
-        description='Geben Sie einen **Benutzernamen** und eine **E-Mail-Adresse** ein. Das **Passwort** muss mindestens 8 Zeichen enthalten und darf nicht komplett aus Ziffern bestehen. Wiederholen Sie das Passwort im Feld **„Passwort bestätigen"**.',
+        description='Geben Sie einen **Benutzernamen** und eine **E-Mail-Adresse** ein. Das **Passwort** muss mindestens 8 Zeichen enthalten und darf nicht komplett aus Ziffern bestehen. Wiederholen Sie das Passwort im Feld **„Passwort bestätigen"**.\n\nDas Häkchen bei **„Mitarbeiter-Status"** ist voreingestellt und erlaubt der Person, sich in der Lunes-Verwaltung anzumelden. Entfernen Sie es nur, wenn sich die Person bewusst nicht anmelden können soll - ohne dieses Häkchen wird die Anmeldung abgelehnt.',
     ):
         page.fill("[name=username]", USERNAME)
         page.fill("[name=email]", f"{USERNAME}@example.com")
         page.fill("[name=password1]", PASSWORD)
         page.fill("[name=password2]", PASSWORD)
+        expect(page.locator("[name=is_staff]")).to_be_checked()
 
     with document.step(
         "Benutzer speichern",

--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -8,7 +8,14 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.auth.models import User
 
-from .admins import FeedbackAdmin, JobAdmin, LunesUserAdmin, UnitAdmin, WordAdmin
+from .admins import (
+    FeedbackAdmin,
+    JobAdmin,
+    LunesAdminAuthenticationForm,
+    LunesUserAdmin,
+    UnitAdmin,
+    WordAdmin,
+)
 from .models import Feedback, Job, Unit, Word
 
 admin.site.register(Job, JobAdmin)
@@ -17,3 +24,4 @@ admin.site.register(Word, WordAdmin)
 admin.site.register(Feedback, FeedbackAdmin)
 admin.site.unregister(User)
 admin.site.register(User, LunesUserAdmin)
+admin.site.login_form = LunesAdminAuthenticationForm

--- a/lunes_cms/cmsv2/admins/__init__.py
+++ b/lunes_cms/cmsv2/admins/__init__.py
@@ -1,7 +1,14 @@
 from .feedback_admin import FeedbackAdmin
 from .job_admin import JobAdmin
 from .unit_admin import UnitAdmin
-from .user_admin import LunesUserAdmin
+from .user_admin import LunesAdminAuthenticationForm, LunesUserAdmin
 from .word_admin import WordAdmin
 
-__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "LunesUserAdmin"]
+__all__ = [
+    "JobAdmin",
+    "WordAdmin",
+    "UnitAdmin",
+    "FeedbackAdmin",
+    "LunesUserAdmin",
+    "LunesAdminAuthenticationForm",
+]

--- a/lunes_cms/cmsv2/admins/user_admin.py
+++ b/lunes_cms/cmsv2/admins/user_admin.py
@@ -16,7 +16,8 @@ from lunes_cms.cmsv2.models.review import Review
 
 class LunesUserCreationForm(AdminUserCreationForm):
     """
-    User creation form that requires an email address.
+    User creation form that requires an email address and grants staff status
+    by default.
     """
 
     class Meta(AdminUserCreationForm.Meta):
@@ -25,11 +26,12 @@ class LunesUserCreationForm(AdminUserCreationForm):
         """
 
         model = User
-        fields = ("username", "email")
+        fields = ("username", "email", "is_staff")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.fields["email"].required = True
+        self.fields["is_staff"].initial = True
 
 
 class LunesUserChangeForm(UserChangeForm):
@@ -86,6 +88,7 @@ class LunesUserAdmin(DjangoUserAdmin):
                 "fields": (
                     "username",
                     "email",
+                    "is_staff",
                     "usable_password",
                     "password1",
                     "password2",

--- a/lunes_cms/cmsv2/admins/user_admin.py
+++ b/lunes_cms/cmsv2/admins/user_admin.py
@@ -3,15 +3,45 @@ from __future__ import absolute_import, annotations, unicode_literals
 from typing import Any
 
 from django.contrib import admin
+from django.contrib.admin.forms import AdminAuthenticationForm
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
-from django.contrib.auth.forms import AdminUserCreationForm, UserChangeForm
+from django.contrib.auth.forms import (
+    AdminUserCreationForm,
+    AuthenticationForm,
+    UserChangeForm,
+)
 from django.contrib.auth.models import User
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.forms import BaseModelFormSet, ModelForm
 from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from lunes_cms.cmsv2.models.review import Review
+
+
+class LunesAdminAuthenticationForm(AdminAuthenticationForm):
+    """
+    Admin login form that reports a missing staff status with a message of its
+    own, and wrong credentials with the plain wording that makes no mention of
+    staff accounts.
+    """
+
+    error_messages = {
+        **AdminAuthenticationForm.error_messages,
+        "invalid_login": AuthenticationForm.error_messages["invalid_login"],
+        "no_staff": _(
+            "Your account is not allowed to use the Lunes administration. "
+            "Please ask an administrator to activate staff status for your account."
+        ),
+    }
+
+    def confirm_login_allowed(self, user: User) -> None:
+        """
+        Allow active accounts that hold staff status to log in.
+        """
+        AuthenticationForm.confirm_login_allowed(self, user)
+        if not user.is_staff:
+            raise ValidationError(self.error_messages["no_staff"], code="no_staff")
 
 
 class LunesUserCreationForm(AdminUserCreationForm):

--- a/lunes_cms/locale/de/LC_MESSAGES/django.po
+++ b/lunes_cms/locale/de/LC_MESSAGES/django.po
@@ -786,6 +786,15 @@ msgid "jobs"
 msgstr "Berufe"
 
 #: cmsv2/admins/user_admin.py
+msgid ""
+"Your account is not allowed to use the Lunes administration. Please ask an "
+"administrator to activate staff status for your account."
+msgstr ""
+"Ihr Konto ist nicht für die Lunes-Verwaltung freigeschaltet. Bitte wenden "
+"Sie sich an eine Administratorin oder einen Administrator, um den "
+"Mitarbeiter-Status für Ihr Konto zu aktivieren."
+
+#: cmsv2/admins/user_admin.py
 msgid "assigned word"
 msgstr "Zugewiesene Vokabel"
 

--- a/tests/cmsv2/admins/test_user_admin.py
+++ b/tests/cmsv2/admins/test_user_admin.py
@@ -1,0 +1,107 @@
+"""
+Tests for the admin login form.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User
+from django.test import Client
+from django.urls import reverse
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse
+
+PASSWORD = "supersecret123"
+
+
+@pytest.fixture
+def staff_user(db: None) -> User:
+    return get_user_model().objects.create_user(
+        username="staff_member",
+        email="staff@example.com",
+        password=PASSWORD,
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def non_staff_user(db: None) -> User:
+    return get_user_model().objects.create_user(
+        username="no_staff",
+        email="no-staff@example.com",
+        password=PASSWORD,
+        is_staff=False,
+    )
+
+
+def _login(client: Client, username: str, password: str) -> _MonkeyPatchedWSGIResponse:
+    return client.post(
+        reverse("admin:login"),
+        {"username": username, "password": password},
+    )
+
+
+def _error_codes(response: _MonkeyPatchedWSGIResponse) -> list[str]:
+    """Collect the validation codes the login form rejected the attempt with."""
+    errors = response.context["form"].errors.as_data()
+    return [error.code for field in errors.values() for error in field]
+
+
+def test_non_staff_user_is_told_about_the_missing_permission(
+    client: Client, non_staff_user: User
+) -> None:
+    """Valid credentials without staff status name the missing permission."""
+    response = _login(client, non_staff_user.username, PASSWORD)
+
+    assert response.status_code == 200
+    assert _error_codes(response) == ["no_staff"]
+    assert "not allowed to use the Lunes administration" in response.content.decode()
+    assert "_auth_user_id" not in client.session
+
+
+def test_wrong_password_does_not_mention_staff_status(
+    client: Client, staff_user: User
+) -> None:
+    """A wrong password is reported as such, without mentioning staff status."""
+    response = _login(client, staff_user.username, "wrong-password")
+
+    assert response.status_code == 200
+    assert _error_codes(response) == ["invalid_login"]
+    assert "staff" not in response.content.decode().lower()
+
+
+def test_inactive_user_is_rejected_before_the_staff_check(
+    client: Client, staff_user: User
+) -> None:
+    """
+    An inactive account is turned away by the authentication backend, so it
+    never reaches the staff check and must not be told about staff status.
+    """
+    staff_user.is_active = False
+    staff_user.save()
+
+    response = _login(client, staff_user.username, PASSWORD)
+
+    assert response.status_code == 200
+    assert _error_codes(response) == ["invalid_login"]
+    assert "_auth_user_id" not in client.session
+
+
+def test_staff_user_can_log_in(client: Client, staff_user: User) -> None:
+    """A staff account with correct credentials reaches the admin."""
+    response = _login(client, staff_user.username, PASSWORD)
+
+    assert response.status_code == 302
+    assert "_auth_user_id" in client.session
+
+
+def test_add_page_offers_staff_status(admin_client: Client) -> None:
+    """The add-user page renders the staff checkbox, pre-checked."""
+    response = admin_client.get(reverse("admin:auth_user_add"))
+
+    assert response.status_code == 200
+    assert response.context["adminform"].form.fields["is_staff"].initial is True

--- a/tests/cmsv2/admins/test_user_admin_forms.py
+++ b/tests/cmsv2/admins/test_user_admin_forms.py
@@ -1,5 +1,6 @@
 """
-Tests that the admin user forms require an email address.
+Tests that the admin user forms require an email address and grant staff
+status by default.
 """
 
 import pytest
@@ -46,3 +47,32 @@ def test_change_form_requires_email() -> None:
     )
     form = LunesUserChangeForm(instance=user)
     assert form.fields["email"].required
+
+
+def test_staff_status_is_saved() -> None:
+    """A user created with the pre-checked box may use the admin."""
+    form = LunesUserCreationForm(
+        data={
+            "username": "new.editor",
+            "email": "new.editor@lunes.app",
+            "password1": "sup3rSecret!pw",
+            "password2": "sup3rSecret!pw",
+            "is_staff": "on",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.save().is_staff
+
+
+def test_staff_status_can_be_unchecked() -> None:
+    """Unchecking the box still creates a user without admin access."""
+    form = LunesUserCreationForm(
+        data={
+            "username": "api.only",
+            "email": "api.only@lunes.app",
+            "password1": "sup3rSecret!pw",
+            "password2": "sup3rSecret!pw",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert not form.save().is_staff


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR makes it easier to create a new user by adding a check box for staff status to the user creation page, and improves the error message when a user without staff status tries to log in.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a check box during account creation for making the user a staff user
- Make that check box checked by default
- Check if the user credentials are correct and if the user is a staff user during login, and show a better error message


### How to test
<!-- Please describe how to test this PR -->

- Create a new user, see the check box
- Try to log in with a user who is not a staff user, see an improved error message.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #943 
