### PR TITLE
Make Review per UnitWordRelation

### DIFF
--- a/lunes_cms/cmsv2/admin.py
+++ b/lunes_cms/cmsv2/admin.py
@@ -8,11 +8,19 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.auth.models import User
 
-from .admins import FeedbackAdmin, JobAdmin, LunesUserAdmin, UnitAdmin, WordAdmin
-from .models import Feedback, Job, Unit, Word
+from .admins import (
+    FeedbackAdmin,
+    JobAdmin,
+    LunesUserAdmin,
+    UnitAdmin,
+    UnitWordRelationAdmin,
+    WordAdmin,
+)
+from .models import Feedback, Job, Unit, UnitWordRelation, Word
 
 admin.site.register(Job, JobAdmin)
 admin.site.register(Unit, UnitAdmin)
+admin.site.register(UnitWordRelation, UnitWordRelationAdmin)
 admin.site.register(Word, WordAdmin)
 admin.site.register(Feedback, FeedbackAdmin)
 admin.site.unregister(User)

--- a/lunes_cms/cmsv2/admins/__init__.py
+++ b/lunes_cms/cmsv2/admins/__init__.py
@@ -1,7 +1,14 @@
 from .feedback_admin import FeedbackAdmin
 from .job_admin import JobAdmin
-from .unit_admin import UnitAdmin
+from .unit_admin import UnitAdmin, UnitWordRelationAdmin
 from .user_admin import LunesUserAdmin
 from .word_admin import WordAdmin
 
-__all__ = ["JobAdmin", "WordAdmin", "UnitAdmin", "FeedbackAdmin", "LunesUserAdmin"]
+__all__ = [
+    "JobAdmin",
+    "WordAdmin",
+    "UnitAdmin",
+    "UnitWordRelationAdmin",
+    "FeedbackAdmin",
+    "LunesUserAdmin",
+]

--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import Group, User
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils.safestring import mark_safe, SafeString
 from django.utils.translation import gettext_lazy as _
@@ -15,7 +16,6 @@ from django.utils.translation import gettext_lazy as _
 from lunes_cms.cmsv2.admins.base import BaseAdmin
 from lunes_cms.cmsv2.models.review import Review
 from lunes_cms.cmsv2.models.unit import Unit, UnitWordRelation
-from lunes_cms.cmsv2.models.word import Word
 
 if TYPE_CHECKING:
     from django.utils.functional import _StrOrPromise
@@ -45,6 +45,37 @@ class WordInline(admin.TabularInline):
         "example_sentence_generate",
         "example_sentence_audio_player",
     ]
+
+
+class UnitWordRelationAdmin(admin.ModelAdmin):
+    """
+    Admin for the UnitWordRelation model.
+
+    It only exists to power the autocomplete widget of the review inline on
+    the user admin page, so it is hidden from the admin index.
+    """
+
+    model = UnitWordRelation
+    search_fields = ["word__word", "unit__title"]
+    ordering = ["word__word", "unit__title"]
+    list_select_related = ["word", "unit"]
+
+    def has_module_permission(self, request: HttpRequest) -> bool:
+        """Determines whether this admin should be shown in the sidebar"""
+        return False
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
+
+    def has_change_permission(
+        self, request: HttpRequest, obj: UnitWordRelation | None = None
+    ) -> bool:
+        return False
+
+    def has_delete_permission(
+        self, request: HttpRequest, obj: UnitWordRelation | None = None
+    ) -> bool:
+        return False
 
 
 class MigratedFilter(admin.SimpleListFilter):
@@ -175,9 +206,10 @@ class UnitAdmin(BaseAdmin):
         self, request: HttpRequest, queryset: QuerySet[Unit]
     ) -> HttpResponse | None:
         """
-        Bulk-create Reviews linking every word of each selected unit to a
-        chosen user. Superusers only. Words already assigned to the target
-        user are silently skipped via the (word, reviewer) unique constraint.
+        Bulk-create Reviews linking every unit-word relation of each selected
+        unit to a chosen user. Superusers only. Relations already assigned to
+        the target user are silently skipped via the (unit_word, reviewer)
+        unique constraint.
         """
         if not request.user.is_authenticated or not request.user.is_superuser:
             raise PermissionDenied
@@ -196,17 +228,17 @@ class UnitAdmin(BaseAdmin):
                 },
             )
 
-        user = User.objects.get(pk=request.POST["user"])
-        words = Word.objects.filter(units__in=queryset).distinct()
-        word_ids_assigned_to_user = set(
-            Review.objects.filter(reviewer=user, word__in=words).values_list(
-                "word_id", flat=True
+        user = get_object_or_404(User, pk=request.POST["user"])
+        unit_words = UnitWordRelation.objects.filter(unit__in=queryset)
+        unit_word_ids_assigned_to_user = set(
+            Review.objects.filter(reviewer=user, unit_word__in=unit_words).values_list(
+                "unit_word_id", flat=True
             )
         )
         to_create = [
-            Review(word=word, reviewer=user, assigned_by=request.user)
-            for word in words
-            if word.pk not in word_ids_assigned_to_user
+            Review(unit_word=unit_word, reviewer=user, assigned_by=request.user)
+            for unit_word in unit_words
+            if unit_word.pk not in unit_word_ids_assigned_to_user
         ]
         Review.objects.bulk_create(to_create, ignore_conflicts=True)
         self.message_user(
@@ -214,7 +246,7 @@ class UnitAdmin(BaseAdmin):
             _("Assigned %(new)d word(s) to %(user)s (%(skipped)d already assigned).")
             % {
                 "new": len(to_create),
-                "skipped": len(word_ids_assigned_to_user),
+                "skipped": len(unit_word_ids_assigned_to_user),
                 "user": user,
             },
         )

--- a/lunes_cms/cmsv2/admins/user_admin.py
+++ b/lunes_cms/cmsv2/admins/user_admin.py
@@ -50,9 +50,9 @@ class UserReviewInline(admin.TabularInline):
     model = Review
     fk_name = "reviewer"
     extra = 0
-    fields = ["word", "assigned_by", "assigned_at"]
+    fields = ["unit_word", "assigned_by", "assigned_at"]
     readonly_fields = ["assigned_by", "assigned_at"]
-    autocomplete_fields = ["word"]
+    autocomplete_fields = ["unit_word"]
     verbose_name = _("assigned word")
     verbose_name_plural = _("assigned words")
 

--- a/lunes_cms/cmsv2/migrations/0032_review_unit_word.py
+++ b/lunes_cms/cmsv2/migrations/0032_review_unit_word.py
@@ -1,0 +1,52 @@
+import django.db.models.deletion
+from django.apps.registry import Apps
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+# pylint: disable=unused-argument
+def delete_reviews(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """
+    Delete all reviews so the new column can be added as non-null.
+
+    A word can belong to several units, so there is no unambiguous relation to
+    migrate an existing review to. Reviews are not in use yet, so the existing
+    ones can simply be discarded.
+    """
+    apps.get_model("cmsv2", "Review").objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    """Make reviews reference a unit-word relation instead of a word"""
+
+    dependencies = [
+        ("cmsv2", "0031_remove_alternative_word_permissions"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_reviews, migrations.RunPython.noop),
+        migrations.RemoveConstraint(
+            model_name="review",
+            name="unique_review_assignment",
+        ),
+        migrations.RemoveField(
+            model_name="review",
+            name="word",
+        ),
+        migrations.AddField(
+            model_name="review",
+            name="unit_word",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="review_assignments",
+                to="cmsv2.unitwordrelation",
+                verbose_name="word",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="review",
+            constraint=models.UniqueConstraint(
+                fields=("unit_word", "reviewer"), name="unique_review_assignment"
+            ),
+        ),
+    ]

--- a/lunes_cms/cmsv2/models/review.py
+++ b/lunes_cms/cmsv2/models/review.py
@@ -1,24 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from django.conf import settings
 from django.db import models
-from django.db.models.fields.files import FieldFile, ImageFieldFile
 from django.utils.translation import gettext_lazy as _
 
 from ..utils import create_resource_path
-from .job import Job
 from .static import (
     ProgressStatus,
     ReviewStatus,
 )
-
-if TYPE_CHECKING:
-    from django.db.models import QuerySet
-
-    from .unit import Unit
-    from .word import Word
 
 
 def upload_review_suggestions(_: models.Model, filename: str) -> str:
@@ -33,8 +23,8 @@ class Review(models.Model):
     Model for a single review
     """
 
-    word = models.ForeignKey(
-        "Word",
+    unit_word = models.ForeignKey(
+        "UnitWordRelation",
         on_delete=models.CASCADE,
         related_name="review_assignments",
         verbose_name=_("word"),
@@ -66,36 +56,6 @@ class Review(models.Model):
     )
 
     @property
-    def word_article(self) -> int:
-        """Returns the article of the word being reviewed."""
-        return self.word.singular_article
-
-    @property
-    def word_type(self) -> str:
-        """Returns the word_type of the word being reviewed."""
-        return self.word.word_type
-
-    @property
-    def units(self) -> "QuerySet[Unit]":
-        """Returns the units the word being reviewed belongs to."""
-        return self.word.units.all()
-
-    @property
-    def jobs(self) -> "QuerySet[Job]":
-        """Returns the jobs of the units the word being reviewed belongs to."""
-        return Job.objects.filter(units__in=self.units).distinct()
-
-    @property
-    def image(self) -> ImageFieldFile:
-        """Returns the image of the word being reviewed"""
-        return self.word.image
-
-    @property
-    def audio(self) -> FieldFile:
-        """Returns the audio of the word being reviewed"""
-        return self.word.audio
-
-    @property
     def progress_status(self) -> ProgressStatus:
         """Returns the status of a review"""
         return (
@@ -111,11 +71,11 @@ class Review(models.Model):
 
         constraints = [
             models.UniqueConstraint(
-                fields=["word", "reviewer"], name="unique_review_assignment"
+                fields=["unit_word", "reviewer"], name="unique_review_assignment"
             )
         ]
         verbose_name = _("Review")
         verbose_name_plural = _("Review")
 
     def __str__(self) -> str:
-        return f"{self.word} – {self.reviewer}"
+        return f"{self.unit_word} – {self.reviewer}"

--- a/lunes_cms/cmsv2/models/unit.py
+++ b/lunes_cms/cmsv2/models/unit.py
@@ -84,6 +84,15 @@ class UnitWordRelation(models.Model):
         ),
     )
 
+    def __str__(self) -> str:
+        """
+        Returns a string representation of the relation, e.g. "Hammer (Tools)".
+
+        Returns:
+            str: The word followed by the unit it belongs to.
+        """
+        return f"{self.word} ({self.unit})"
+
     def image_tag(self) -> SafeString:
         """
         Generate an HTML image tag for the relation's image.

--- a/tests/cmsv2/admins/test_unit_admin.py
+++ b/tests/cmsv2/admins/test_unit_admin.py
@@ -2,9 +2,9 @@
 Tests for the ``assign_to_user`` bulk action on UnitAdmin (#644).
 
 Covers the refactor that moved review assignment from the Unit level to the
-Word level: a word shared by several selected units must only be reviewed
-once, already-assigned words must be skipped, and the action stays
-superuser-only.
+unit-word level: a word shared by several selected units is reviewed once per
+unit it belongs to, already-assigned unit-word relations must be skipped, and
+the action stays superuser-only.
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ from django.http import HttpRequest
 from django.test import RequestFactory
 
 from lunes_cms.cmsv2.admins.unit_admin import UnitAdmin
-from lunes_cms.cmsv2.models import Review, Unit, Word
+from lunes_cms.cmsv2.models import Review, Unit, UnitWordRelation, Word
 
 
 @pytest.fixture
@@ -40,11 +40,11 @@ def _post_request(request_factory: RequestFactory, data: dict) -> HttpRequest:
     return request
 
 
-def test_assign_to_user_creates_one_review_per_word_across_units(
+def test_assign_to_user_creates_one_review_per_unit_word_relation(
     db: None, unit_admin: UnitAdmin, request_factory: RequestFactory
 ) -> None:
-    """A word shared by several selected units must only get one Review
-    (word-level), not one per unit (old unit-level behaviour)."""
+    """A word shared by several selected units gets one Review per unit, because
+    reviews are assigned per unit-word relation."""
     shared_word = Word.objects.create(word="Hammer", singular_article=1)
     unit_a = Unit.objects.create(title="Unit A")
     unit_b = Unit.objects.create(title="Unit B")
@@ -62,27 +62,30 @@ def test_assign_to_user_creates_one_review_per_word_across_units(
         request, Unit.objects.filter(pk__in=[unit_a.pk, unit_b.pk])
     )
 
-    assert Review.objects.filter(word=shared_word, reviewer=target_user).count() == 1
+    assert (
+        Review.objects.filter(unit_word__word=shared_word, reviewer=target_user).count()
+        == 2
+    )
 
 
-def test_assign_to_user_skips_already_assigned_words(
+def test_assign_to_user_skips_already_assigned_unit_words(
     db: None, unit_admin: UnitAdmin, request_factory: RequestFactory
 ) -> None:
     word = Word.objects.create(word="Hammer", singular_article=1)
     unit = Unit.objects.create(title="Unit A")
-    unit.words.add(word)
+    unit_word = UnitWordRelation.objects.create(unit=unit, word=word)
     target_user = get_user_model().objects.create_user(username="reviewer")
     admin_user = get_user_model().objects.create_superuser(
         username="admin", password="password"
     )
-    Review.objects.create(word=word, reviewer=target_user)
+    Review.objects.create(unit_word=unit_word, reviewer=target_user)
 
     request = _post_request(request_factory, {"apply": "1", "user": target_user.pk})
     request.user = admin_user
 
     unit_admin.assign_to_user(request, Unit.objects.filter(pk=unit.pk))
 
-    assert Review.objects.filter(word=word, reviewer=target_user).count() == 1
+    assert Review.objects.filter(unit_word=unit_word, reviewer=target_user).count() == 1
 
 
 def test_assign_to_user_sets_assigned_by_to_acting_admin(
@@ -101,7 +104,7 @@ def test_assign_to_user_sets_assigned_by_to_acting_admin(
 
     unit_admin.assign_to_user(request, Unit.objects.filter(pk=unit.pk))
 
-    review = Review.objects.get(word=word, reviewer=target_user)
+    review = Review.objects.get(unit_word__word=word, reviewer=target_user)
     assert review.assigned_by == admin_user
 
 

--- a/tests/cmsv2/models/test_review.py
+++ b/tests/cmsv2/models/test_review.py
@@ -1,5 +1,5 @@
 """
-Tests for the Review model (word-level review assignments, #644).
+Tests for the Review model (unit-word-level review assignments, #644).
 """
 
 from __future__ import annotations
@@ -9,27 +9,36 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.utils import timezone
 
-from lunes_cms.cmsv2.models import Review, Word
+from lunes_cms.cmsv2.models import Review, Unit, UnitWordRelation, Word
+
+
+def _create_unit_word() -> UnitWordRelation:
+    """Create a word inside a unit and return their relation."""
+    word = Word.objects.create(word="Hammer", singular_article=1)
+    unit = Unit.objects.create(title="Unit A")
+    return UnitWordRelation.objects.create(unit=unit, word=word)
 
 
 @pytest.mark.django_db
-def test_same_word_and_reviewer_violates_unique_constraint() -> None:
-    """A word must not be assigned twice to the same reviewer."""
-    word = Word.objects.create(word="Hammer", singular_article=1)
+def test_same_unit_word_and_reviewer_violates_unique_constraint() -> None:
+    """A unit-word relation must not be assigned twice to the same reviewer."""
+    unit_word = _create_unit_word()
     reviewer = get_user_model().objects.create_user(username="reviewer")
-    Review.objects.create(word=word, reviewer=reviewer)
+    Review.objects.create(unit_word=unit_word, reviewer=reviewer)
 
     with pytest.raises(IntegrityError):
-        Review.objects.create(word=word, reviewer=reviewer)
+        Review.objects.create(unit_word=unit_word, reviewer=reviewer)
 
 
 @pytest.mark.django_db
 def test_deleting_assigning_user_keeps_review_but_clears_assigned_by() -> None:
     """assigned_by uses SET_NULL, so the Review must survive the assigner's deletion."""
-    word = Word.objects.create(word="Hammer", singular_article=1)
+    unit_word = _create_unit_word()
     reviewer = get_user_model().objects.create_user(username="reviewer")
     admin_user = get_user_model().objects.create_user(username="admin")
-    review = Review.objects.create(word=word, reviewer=reviewer, assigned_by=admin_user)
+    review = Review.objects.create(
+        unit_word=unit_word, reviewer=reviewer, assigned_by=admin_user
+    )
 
     admin_user.delete()
     review.refresh_from_db()
@@ -40,9 +49,9 @@ def test_deleting_assigning_user_keeps_review_but_clears_assigned_by() -> None:
 @pytest.mark.django_db
 def test_deleting_reviewer_deletes_review() -> None:
     """reviewer uses CASCADE, so the Review must be removed with the reviewer."""
-    word = Word.objects.create(word="Hammer", singular_article=1)
+    unit_word = _create_unit_word()
     reviewer = get_user_model().objects.create_user(username="reviewer")
-    review = Review.objects.create(word=word, reviewer=reviewer)
+    review = Review.objects.create(unit_word=unit_word, reviewer=reviewer)
 
     reviewer.delete()
 
@@ -51,9 +60,9 @@ def test_deleting_reviewer_deletes_review() -> None:
 
 @pytest.mark.django_db
 def test_progress_status_reflects_completed_at() -> None:
-    word = Word.objects.create(word="Hammer", singular_article=1)
+    unit_word = _create_unit_word()
     reviewer = get_user_model().objects.create_user(username="reviewer")
-    review = Review.objects.create(word=word, reviewer=reviewer)
+    review = Review.objects.create(unit_word=unit_word, reviewer=reviewer)
 
     assert review.progress_status == "IN_REVIEW"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This will allow implementing the reviewer view as planned, where one review is shown per unit-word-relation.
This will delete all previous reviews, which should be fine, because we don't have any reviews yet on the production server.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Update the ReviewModel accordingly
- Add a new Admin for UnitWordRelation (hidden from the sidebar, view-only)
- Adjust tests


### How to test
<!-- Please describe how to test this PR -->

- Make sure that it is still possible to assign units to users
- Make sure that the user admin shows all reviews that belong to the user


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /
