### PR TITLE
995: Create and resolve deeplink verification files

### DIFF
--- a/example-configs/apache2-vhost.conf.example
+++ b/example-configs/apache2-vhost.conf.example
@@ -29,7 +29,11 @@
         SSLCertificateChainFile /etc/letsencrypt/live/example.com/chain.pem
         SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem
 
-        ProxyPass /.well-known/ !
+        # Only exclude the ACME challenge path from the proxy (served as a
+        # plain file by certbot's webroot plugin); everything else under
+        # /.well-known/ - e.g. apple-app-site-association and
+        # assetlinks.json for app deep linking - is served by Django.
+        ProxyPass /.well-known/acme-challenge/ !
         ProxyPass /static/ !
         ProxyPass /media/ !
         ProxyPass "/"  "http://localhost:8080/"

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -63,6 +63,16 @@ OPENAI_IMAGE_QUALITY = os.environ.get("LUNES_CMS_OPENAI_IMAGE_QUALITY", "low")
 #: OpenAI model used for text generation (e.g. example sentences)
 OPENAI_TEXT_MODEL = os.environ.get("LUNES_CMS_OPENAI_TEXT_MODEL", "gpt-4.1")
 
+####################
+# APP DEEP LINKING #
+####################
+IOS_APP_TEAM_ID = "7272KE28TJ"
+IOS_APP_BUNDLE_ID = "app.lunes"
+ANDROID_APP_PACKAGE_NAME = "app.lunes"
+ANDROID_APP_SHA256_CERT_FINGERPRINTS = [
+    "BE:DE:14:02:A3:ED:63:AE:F4:E8:57:70:35:37:1E:BD:B2:37:5C:0C:62:DB:22:F6:25:46:9B:4F:1D:DB:F1:EB"
+]
+APP_LINK_PATH_PREFIX = "/activation"
 ###################
 # MATOMO TRACKING #
 ###################

--- a/lunes_cms/core/settings.py
+++ b/lunes_cms/core/settings.py
@@ -73,6 +73,7 @@ ANDROID_APP_SHA256_CERT_FINGERPRINTS = [
     "BE:DE:14:02:A3:ED:63:AE:F4:E8:57:70:35:37:1E:BD:B2:37:5C:0C:62:DB:22:F6:25:46:9B:4F:1D:DB:F1:EB"
 ]
 APP_LINK_PATH_PREFIX = "/activation"
+
 ###################
 # MATOMO TRACKING #
 ###################

--- a/lunes_cms/core/urls.py
+++ b/lunes_cms/core/urls.py
@@ -27,8 +27,21 @@ from django.templatetags.static import static as get_static_url
 from django.urls import include, path, re_path, reverse_lazy
 from django.views.generic.base import RedirectView
 
+from .views import android_asset_links, apple_app_site_association
+
 #: The url patterns of this module (see :doc:`django:topics/http/urls`)
 urlpatterns = [
+    # Deep linking / Universal Links (iOS) and App Links (Android)
+    path(
+        ".well-known/apple-app-site-association",
+        apple_app_site_association,
+        name="apple-app-site-association",
+    ),
+    path(
+        ".well-known/assetlinks.json",
+        android_asset_links,
+        name="android-asset-links",
+    ),
     path("", RedirectView.as_view(url=reverse_lazy("admin:login"))),
     path(
         "favicon.ico",

--- a/lunes_cms/core/views.py
+++ b/lunes_cms/core/views.py
@@ -1,0 +1,66 @@
+"""
+Views that serve the well-known files required for iOS Universal Links and
+Android App Links, so links like ``https://content.lunes.app/activation/<code>``
+open directly in the Lunes app instead of the browser.
+"""
+
+from django.conf import settings
+from django.http import HttpRequest, JsonResponse
+from django.views.decorators.http import require_GET
+
+
+@require_GET
+def apple_app_site_association(
+    request: HttpRequest,  # pylint: disable=unused-argument
+) -> JsonResponse:
+    """
+    Serve the ``apple-app-site-association`` file at
+    ``/.well-known/apple-app-site-association``, required for iOS
+    Universal Links.
+
+    :param request: The current HTTP request
+    :return: The association file as JSON
+    """
+    app_id = f"{settings.IOS_APP_TEAM_ID}.{settings.IOS_APP_BUNDLE_ID}"
+    prefix = settings.APP_LINK_PATH_PREFIX
+    data = {
+        "applinks": {
+            "apps": [],
+            "details": [
+                {
+                    "appID": app_id,
+                    "components": [
+                        {
+                            "/": f"{prefix}/*",
+                            "comment": f"Matches any URL with a path that starts with {prefix}/.",
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+    return JsonResponse(data, content_type="application/json")
+
+
+@require_GET
+def android_asset_links(
+    request: HttpRequest,  # pylint: disable=unused-argument
+) -> JsonResponse:
+    """
+    Serve the ``assetlinks.json`` file at ``/.well-known/assetlinks.json``,
+    required for Android App Links.
+
+    :param request: The current HTTP request
+    :return: The asset links file as JSON
+    """
+    data = [
+        {
+            "relation": ["delegate_permission/common.handle_all_urls"],
+            "target": {
+                "namespace": "android_app",
+                "package_name": settings.ANDROID_APP_PACKAGE_NAME,
+                "sha256_cert_fingerprints": settings.ANDROID_APP_SHA256_CERT_FINGERPRINTS,
+            },
+        }
+    ]
+    return JsonResponse(data, content_type="application/json", safe=False)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Serve the required deeplink files for https scheme verification

### Proposed changes
<!-- Describe this PR in more detail. -->

- add deeplink settings
- create assetlinks.json and app site association
- add urls to serve files
- exclude acme-challenge path

### How to test
<!-- Please describe how to test this PR -->

- start backend
- go to: `http://localhost:8080/.well-known/apple-app-site-association`
- go to: `http://localhost:8080/.well-known/assetlinks.json`
- Check that the files exist and contain valid content


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #995
