### PR TITLE
Fix deleting words

### DIFF
--- a/lunes_cms/cmsv2/admins/unit_admin.py
+++ b/lunes_cms/cmsv2/admins/unit_admin.py
@@ -64,19 +64,6 @@ class UnitWordRelationAdmin(admin.ModelAdmin):
         """Determines whether this admin should be shown in the sidebar"""
         return False
 
-    def has_add_permission(self, request: HttpRequest) -> bool:
-        return False
-
-    def has_change_permission(
-        self, request: HttpRequest, obj: UnitWordRelation | None = None
-    ) -> bool:
-        return False
-
-    def has_delete_permission(
-        self, request: HttpRequest, obj: UnitWordRelation | None = None
-    ) -> bool:
-        return False
-
 
 class MigratedFilter(admin.SimpleListFilter):
     """


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Makes the new admin deletable and editable, to prevent django from disallowing deletes.
Apparently, django checks permissions for cascading deletes by consulting the corresponding admin and in #981 I introduced a new admin that didn't allow deleting objects...
