### PR TITLE
[Dev] Script db reset

### DIFF
--- a/.idea/runConfigurations/Reset_database.xml
+++ b/.idea/runConfigurations/Reset_database.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Reset database" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tools/reset_db.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs>
+      <env name="LUNES_CMS_DB_BACKEND" value="sqlite" />
+      <env name="LUNES_CMS_DEBUG" value="1" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/docs/src/dev-tools.rst
+++ b/docs/src/dev-tools.rst
@@ -53,6 +53,14 @@ Import test data into the database :github-source:`tools/load_test_data.sh`::
 
     ./tools/load_test_data.sh
 
+Reset the local SQLite database (deleting it, re-running migrations and re-importing
+the test data) with :github-source:`tools/reset_db.sh`::
+
+    ./tools/reset_db.sh
+
+Use this if your local database ends up in an inconsistent state, e.g. after switching
+between branches whose migrations diverge (``OperationalError: no such column: ...``).
+
 Debug Toolbar
 =============
 

--- a/tools/reset_db.sh
+++ b/tools/reset_db.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script resets the local development database: it deletes the existing
+# SQLite database file, runs migrations from scratch and re-imports the test
+# data fixtures (including an admin user and basic vocabulary).
+
+# Import utility functions
+# shellcheck source=./tools/_functions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
+
+require_installed
+
+echo "Removing existing SQLite database..." | print_info
+rm -f "${PACKAGE_DIR}/db.sqlite3"
+echo "✔ Removed existing SQLite database" | print_success
+
+# Migrate the fresh database and re-import the test data fixtures
+bash "${DEV_TOOL_DIR}/load_test_data.sh"
+
+echo -e "\n✔ Database was successfully reset 😻" | print_success


### PR DESCRIPTION
### Short description
Sometimes we get migration conflicts if we review and test multiple branches that have a different migration state


### Proposed changes
<!-- Describe this PR in more detail. -->

- add a script and runConfig that removes the database, runs migrations from scratch and import test data

### How to test
<!-- Please describe how to test this PR -->

- run the script


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
